### PR TITLE
[API-5] Initial Drizzle schema for sites, zones, grass types, soil types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Detailed React Native testing patterns (libraries, render helpers) live in `shar
 
 Postgres (container `irrigo_db`) is the data store; **Drizzle ORM** wraps it, **drizzle-kit** manages schema and migrations.
 
-- Schema lives in `api/db/schema.ts` (definitions land in API-5).
+- Schema lives in `api/db/schema/` — one file per table plus a barrel `index.ts`.
 - Migrations are written to `api/drizzle/` by `bun run db:generate` after schema changes — commit these.
 - The runtime client is the typed `db` exported from `api/db/index.ts`. It reads `DATABASE_URL` from the environment; `api/docker-compose.yml` plumbs a default into the api container.
 - A fresh environment runs `bun run db:migrate` (schema-only) and then `bun run seed` (API-6, JSON-driven).

--- a/api/db/.test.ts
+++ b/api/db/.test.ts
@@ -12,7 +12,7 @@ test('drizzle config exposes the postgres dialect, schema path, and out folder',
     const config = buildDrizzleConfig('postgresql://user:pass@host:5432/db');
 
     expect(config.dialect).toBe('postgresql');
-    expect(config.schema).toBe('./db/schema');
+    expect(config.schema).toBe('./db/schema/index.ts');
     expect(config.out).toBe('./drizzle');
 });
 

--- a/api/db/.test.ts
+++ b/api/db/.test.ts
@@ -12,7 +12,7 @@ test('drizzle config exposes the postgres dialect, schema path, and out folder',
     const config = buildDrizzleConfig('postgresql://user:pass@host:5432/db');
 
     expect(config.dialect).toBe('postgresql');
-    expect(config.schema).toBe('./db/schema.ts');
+    expect(config.schema).toBe('./db/schema');
     expect(config.out).toBe('./drizzle');
 });
 

--- a/api/db/schema.ts
+++ b/api/db/schema.ts
@@ -1,2 +1,0 @@
-// Schema definitions land in API-5.
-export {};

--- a/api/db/schema/.test.ts
+++ b/api/db/schema/.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from 'bun:test';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { grassTypes, sites, soilTypes, zones } from '.';
+
+function columnsByName(table: Parameters<typeof getTableConfig>[0]) {
+    const config = getTableConfig(table);
+    return Object.fromEntries(config.columns.map(column => [column.name, column]));
+}
+
+test('grass_types table has the expected columns and constraints', () => {
+    const config = getTableConfig(grassTypes);
+    const columns = columnsByName(grassTypes);
+
+    expect(config.name).toBe('grass_types');
+    expect(columns['id']?.primary).toBe(true);
+    expect(columns['id']?.hasDefault).toBe(true);
+    expect(columns['slug']?.notNull).toBe(true);
+    expect(columns['slug']?.isUnique).toBe(true);
+    expect(columns['name']?.notNull).toBe(true);
+    expect(columns['crop_coefficient']?.notNull).toBe(true);
+    expect(columns['crop_coefficient']?.columnType).toBe('PgReal');
+    expect(columns['created_at']?.notNull).toBe(true);
+    expect(columns['updated_at']?.notNull).toBe(true);
+});
+
+test('soil_types table has the expected columns and constraints', () => {
+    const config = getTableConfig(soilTypes);
+    const columns = columnsByName(soilTypes);
+
+    expect(config.name).toBe('soil_types');
+    expect(columns['id']?.primary).toBe(true);
+    expect(columns['slug']?.isUnique).toBe(true);
+    expect(columns['slug']?.notNull).toBe(true);
+    expect(columns['name']?.notNull).toBe(true);
+    expect(columns['available_water_holding_capacity_mm_per_m']?.notNull).toBe(true);
+    expect(columns['infiltration_rate_mm_per_hr']?.notNull).toBe(true);
+    expect(columns['created_at']?.notNull).toBe(true);
+    expect(columns['updated_at']?.notNull).toBe(true);
+});
+
+test('sites table has the expected columns and constraints', () => {
+    const config = getTableConfig(sites);
+    const columns = columnsByName(sites);
+
+    expect(config.name).toBe('sites');
+    expect(columns['id']?.primary).toBe(true);
+    expect(columns['slug']?.isUnique).toBe(true);
+    expect(columns['slug']?.notNull).toBe(true);
+    expect(columns['name']?.notNull).toBe(true);
+    expect(columns['timezone']?.notNull).toBe(true);
+    expect(columns['latitude']?.notNull).toBe(true);
+    expect(columns['latitude']?.columnType).toBe('PgDoublePrecision');
+    expect(columns['longitude']?.notNull).toBe(true);
+    expect(columns['longitude']?.columnType).toBe('PgDoublePrecision');
+    expect(columns['address']?.notNull).toBe(false);
+    expect(columns['created_at']?.notNull).toBe(true);
+    expect(columns['updated_at']?.notNull).toBe(true);
+});
+
+test('zones table has the expected columns and constraints', () => {
+    const config = getTableConfig(zones);
+    const columns = columnsByName(zones);
+
+    expect(config.name).toBe('zones');
+    expect(columns['id']?.primary).toBe(true);
+    expect(columns['slug']?.isUnique).toBe(true);
+    expect(columns['slug']?.notNull).toBe(true);
+    expect(columns['site_id']?.notNull).toBe(true);
+    expect(columns['grass_type_id']?.notNull).toBe(true);
+    expect(columns['soil_type_id']?.notNull).toBe(true);
+    expect(columns['name']?.notNull).toBe(true);
+    expect(columns['root_depth_m']?.notNull).toBe(true);
+    expect(columns['allowable_depletion_fraction']?.notNull).toBe(true);
+    expect(columns['irrigation_efficiency']?.notNull).toBe(true);
+    expect(columns['flow_rate_l_per_min']?.notNull).toBe(true);
+    expect(columns['area_m2']?.notNull).toBe(true);
+    expect(columns['precipitation_rate_mm_per_hr']?.notNull).toBe(false);
+    expect(columns['current_depletion_mm']?.notNull).toBe(true);
+    expect(columns['current_depletion_mm']?.hasDefault).toBe(true);
+    expect(columns['is_enabled']?.notNull).toBe(true);
+    expect(columns['is_enabled']?.hasDefault).toBe(true);
+    expect(columns['latitude']?.notNull).toBe(false);
+    expect(columns['longitude']?.notNull).toBe(false);
+    expect(columns['home_assistant_entity_id']?.notNull).toBe(false);
+    expect(columns['created_at']?.notNull).toBe(true);
+    expect(columns['updated_at']?.notNull).toBe(true);
+});
+
+test('zones foreign keys reference the right parent tables', () => {
+    const config = getTableConfig(zones);
+    const fkTargets = config.foreignKeys
+        .map(fk => {
+            const reference = fk.reference();
+            return {
+                from: reference.columns.map(c => c.name),
+                to: reference.foreignTable,
+            };
+        });
+
+    const siteFk = fkTargets.find(fk => fk.from.includes('site_id'));
+    const grassFk = fkTargets.find(fk => fk.from.includes('grass_type_id'));
+    const soilFk = fkTargets.find(fk => fk.from.includes('soil_type_id'));
+
+    expect(siteFk?.to).toBe(sites);
+    expect(grassFk?.to).toBe(grassTypes);
+    expect(soilFk?.to).toBe(soilTypes);
+});

--- a/api/db/schema/audit-columns.ts
+++ b/api/db/schema/audit-columns.ts
@@ -1,0 +1,13 @@
+import { timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Project-standard audit columns. Every table includes these — created_at stamps
+ * on insert, updated_at stamps on insert and bumps on each update.
+ */
+export const auditColumns = {
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+        .notNull()
+        .defaultNow()
+        .$onUpdate(() => new Date()),
+};

--- a/api/db/schema/grass-types.ts
+++ b/api/db/schema/grass-types.ts
@@ -1,0 +1,10 @@
+import { pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+
+export const grassTypes = pgTable('grass_types', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    slug: text('slug').notNull().unique(),
+    name: text('name').notNull(),
+    cropCoefficient: real('crop_coefficient').notNull(),
+    ...auditColumns,
+});

--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -1,0 +1,4 @@
+export { grassTypes } from './grass-types';
+export { sites } from './sites';
+export { soilTypes } from './soil-types';
+export { zones } from './zones';

--- a/api/db/schema/sites.ts
+++ b/api/db/schema/sites.ts
@@ -1,0 +1,13 @@
+import { doublePrecision, pgTable, text, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+
+export const sites = pgTable('sites', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    slug: text('slug').notNull().unique(),
+    name: text('name').notNull(),
+    timezone: text('timezone').notNull(),
+    latitude: doublePrecision('latitude').notNull(),
+    longitude: doublePrecision('longitude').notNull(),
+    address: text('address'),
+    ...auditColumns,
+});

--- a/api/db/schema/soil-types.ts
+++ b/api/db/schema/soil-types.ts
@@ -1,0 +1,11 @@
+import { pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+
+export const soilTypes = pgTable('soil_types', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    slug: text('slug').notNull().unique(),
+    name: text('name').notNull(),
+    availableWaterHoldingCapacityMmPerM: real('available_water_holding_capacity_mm_per_m').notNull(),
+    infiltrationRateMmPerHr: real('infiltration_rate_mm_per_hr').notNull(),
+    ...auditColumns,
+});

--- a/api/db/schema/zones.ts
+++ b/api/db/schema/zones.ts
@@ -1,0 +1,26 @@
+import { boolean, doublePrecision, pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+import { grassTypes } from './grass-types';
+import { sites } from './sites';
+import { soilTypes } from './soil-types';
+
+export const zones = pgTable('zones', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    slug: text('slug').notNull().unique(),
+    siteId: uuid('site_id').notNull().references(() => sites.id),
+    name: text('name').notNull(),
+    grassTypeId: uuid('grass_type_id').notNull().references(() => grassTypes.id),
+    soilTypeId: uuid('soil_type_id').notNull().references(() => soilTypes.id),
+    rootDepthM: real('root_depth_m').notNull(),
+    allowableDepletionFraction: real('allowable_depletion_fraction').notNull(),
+    irrigationEfficiency: real('irrigation_efficiency').notNull(),
+    flowRateLPerMin: real('flow_rate_l_per_min').notNull(),
+    areaM2: real('area_m2').notNull(),
+    precipitationRateMmPerHr: real('precipitation_rate_mm_per_hr'),
+    currentDepletionMm: real('current_depletion_mm').notNull().default(0),
+    isEnabled: boolean('is_enabled').notNull().default(true),
+    latitude: doublePrecision('latitude'),
+    longitude: doublePrecision('longitude'),
+    homeAssistantEntityId: text('home_assistant_entity_id'),
+    ...auditColumns,
+});

--- a/api/drizzle.config.ts
+++ b/api/drizzle.config.ts
@@ -10,7 +10,7 @@ export function buildDrizzleConfig(databaseUrl: string | undefined) {
 
     return defineConfig({
         dialect: 'postgresql',
-        schema: './db/schema.ts',
+        schema: './db/schema',
         out: './drizzle',
         dbCredentials: {
             url: databaseUrl,

--- a/api/drizzle.config.ts
+++ b/api/drizzle.config.ts
@@ -10,7 +10,7 @@ export function buildDrizzleConfig(databaseUrl: string | undefined) {
 
     return defineConfig({
         dialect: 'postgresql',
-        schema: './db/schema',
+        schema: './db/schema/index.ts',
         out: './drizzle',
         dbCredentials: {
             url: databaseUrl,

--- a/api/drizzle/0000_ambiguous_supernaut.sql
+++ b/api/drizzle/0000_ambiguous_supernaut.sql
@@ -1,0 +1,60 @@
+CREATE TABLE "grass_types" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"crop_coefficient" real NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "grass_types_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "sites" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"timezone" text NOT NULL,
+	"latitude" double precision NOT NULL,
+	"longitude" double precision NOT NULL,
+	"address" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "sites_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "soil_types" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"available_water_holding_capacity_mm_per_m" real NOT NULL,
+	"infiltration_rate_mm_per_hr" real NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "soil_types_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "zones" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"site_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"grass_type_id" uuid NOT NULL,
+	"soil_type_id" uuid NOT NULL,
+	"root_depth_m" real NOT NULL,
+	"allowable_depletion_fraction" real NOT NULL,
+	"irrigation_efficiency" real NOT NULL,
+	"flow_rate_l_per_min" real NOT NULL,
+	"area_m2" real NOT NULL,
+	"precipitation_rate_mm_per_hr" real,
+	"current_depletion_mm" real DEFAULT 0 NOT NULL,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"latitude" double precision,
+	"longitude" double precision,
+	"home_assistant_entity_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "zones_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "zones" ADD CONSTRAINT "zones_site_id_sites_id_fk" FOREIGN KEY ("site_id") REFERENCES "public"."sites"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "zones" ADD CONSTRAINT "zones_grass_type_id_grass_types_id_fk" FOREIGN KEY ("grass_type_id") REFERENCES "public"."grass_types"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "zones" ADD CONSTRAINT "zones_soil_type_id_soil_types_id_fk" FOREIGN KEY ("soil_type_id") REFERENCES "public"."soil_types"("id") ON DELETE no action ON UPDATE no action;

--- a/api/drizzle/meta/0000_snapshot.json
+++ b/api/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,403 @@
+{
+  "id": "fac6799f-d3d6-44cc-8a22-ff3f803dd556",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1777901011548,
+      "tag": "0000_ambiguous_supernaut",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
## Ticket

[API-5](http://192.168.2.100:7123/irrigo/browse/API-5/) — Initial Drizzle schema for sites, zones, grass types, soil types

## Summary

- Defined `grass_types`, `soil_types`, `sites`, `zones` tables in `api/db/schema/`, one file per table plus a shared `audit-columns.ts` helper for the project-standard `created_at` / `updated_at` columns.
- Generated the initial migration `0000_ambiguous_supernaut.sql` (4 `CREATE TABLE` statements + 3 FKs on `zones` referencing `sites`, `grass_types`, `soil_types`).
- Pointed `drizzle.config.ts` at `./db/schema/index.ts` so drizzle-kit doesn't crawl the test file.
- Schema-introspection tests in `api/db/schema/.test.ts` lock down columns, NOT NULL flags, uniqueness, defaults, and FK targets — runs without a live DB.
- Updated `CLAUDE.md` to reflect the new `db/schema/` layout.

Schedule/cycle tables, seed data, and swapping `models.ts` to use Drizzle's inferred types remain out of scope (deferred to API-3 and API-6).