### PR TITLE
[API-21] Author seed data for grass types, soil types, sites, and zones

### DIFF
--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -147,3 +147,16 @@ describe('grass-types.json fixture', () => {
         expect(slugs.has('bermudagrass')).toBe(true);
     });
 });
+
+describe('soil-types.json fixture', () => {
+    it('parses against the schema and includes the standard USDA texture classes', async () => {
+        const rows = parseSoilTypes(await readSeedJson('soil-types.json'));
+
+        expect(rows.length).toBeGreaterThanOrEqual(5);
+
+        const slugs = new Set(rows.map(row => row.slug));
+        expect(slugs.has('sand')).toBe(true);
+        expect(slugs.has('loam')).toBe(true);
+        expect(slugs.has('clay')).toBe(true);
+    });
+});

--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, it, expect } from 'bun:test';
 import {
     parseGrassTypes,
@@ -5,6 +6,12 @@ import {
     parseSites,
     parseZones,
 } from '.';
+
+const SEEDS_DIR = import.meta.dir;
+
+async function readSeedJson(file: string): Promise<unknown> {
+    return Bun.file(path.join(SEEDS_DIR, file)).json();
+}
 
 describe('parseGrassTypes', () => {
     it('parses a valid grass type entry', () => {
@@ -126,5 +133,17 @@ describe('parseZones', () => {
 
     it('rejects entries where a numeric field has the wrong type', () => {
         expect(() => parseZones([{ ...validZone, areaM2: 'big' }])).toThrow(/areaM2/);
+    });
+});
+
+describe('grass-types.json fixture', () => {
+    it('parses against the schema and includes the standard cool/warm-season set', async () => {
+        const rows = parseGrassTypes(await readSeedJson('grass-types.json'));
+
+        expect(rows.length).toBeGreaterThanOrEqual(8);
+
+        const slugs = new Set(rows.map(row => row.slug));
+        expect(slugs.has('kentucky-bluegrass')).toBe(true);
+        expect(slugs.has('bermudagrass')).toBe(true);
     });
 });

--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -160,3 +160,15 @@ describe('soil-types.json fixture', () => {
         expect(slugs.has('clay')).toBe(true);
     });
 });
+
+describe('sites.json fixture', () => {
+    it('parses against the schema and includes the home site', async () => {
+        const rows = parseSites(await readSeedJson('sites.json'));
+
+        expect(rows.length).toBeGreaterThanOrEqual(1);
+
+        const home = rows.find(row => row.slug === 'home');
+        expect(home).toBeDefined();
+        expect(home?.timezone).toMatch(/\//);
+    });
+});

--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -172,3 +172,29 @@ describe('sites.json fixture', () => {
         expect(home?.timezone).toMatch(/\//);
     });
 });
+
+describe('zones.json fixture', () => {
+    it('parses against the schema and resolves all cross-file slug references', async () => {
+        const [zoneRows, grassRows, soilRows, siteRows] = await Promise.all([
+            readSeedJson('zones.json').then(parseZones),
+            readSeedJson('grass-types.json').then(parseGrassTypes),
+            readSeedJson('soil-types.json').then(parseSoilTypes),
+            readSeedJson('sites.json').then(parseSites),
+        ]);
+
+        expect(zoneRows).toHaveLength(3);
+
+        const grassSlugs = new Set(grassRows.map(row => row.slug));
+        const soilSlugs = new Set(soilRows.map(row => row.slug));
+        const siteSlugs = new Set(siteRows.map(row => row.slug));
+
+        for (const zone of zoneRows) {
+            expect(siteSlugs.has(zone.site)).toBe(true);
+            expect(grassSlugs.has(zone.grassType)).toBe(true);
+            expect(soilSlugs.has(zone.soilType)).toBe(true);
+        }
+
+        const zoneSlugs = zoneRows.map(row => row.slug);
+        expect(zoneSlugs).toEqual(['front-lawn', 'back-lawn', 'side-yard']);
+    });
+});

--- a/api/data/seeds/grass-types.json
+++ b/api/data/seeds/grass-types.json
@@ -1,1 +1,42 @@
-[]
+[
+    {
+        "slug": "kentucky-bluegrass",
+        "name": "Kentucky Bluegrass",
+        "cropCoefficient": 0.95
+    },
+    {
+        "slug": "perennial-ryegrass",
+        "name": "Perennial Ryegrass",
+        "cropCoefficient": 0.95
+    },
+    {
+        "slug": "tall-fescue",
+        "name": "Tall Fescue",
+        "cropCoefficient": 0.9
+    },
+    {
+        "slug": "bermudagrass",
+        "name": "Bermudagrass",
+        "cropCoefficient": 1.0
+    },
+    {
+        "slug": "st-augustine",
+        "name": "St. Augustine",
+        "cropCoefficient": 0.9
+    },
+    {
+        "slug": "zoysiagrass",
+        "name": "Zoysiagrass",
+        "cropCoefficient": 0.85
+    },
+    {
+        "slug": "buffalo-grass",
+        "name": "Buffalo Grass",
+        "cropCoefficient": 0.75
+    },
+    {
+        "slug": "fine-fescue-mix",
+        "name": "Fine Fescue Mix",
+        "cropCoefficient": 0.9
+    }
+]

--- a/api/data/seeds/sites.json
+++ b/api/data/seeds/sites.json
@@ -3,7 +3,7 @@
         "slug": "home",
         "name": "Home",
         "timezone": "America/Edmonton",
-        "latitude": 51.05,
-        "longitude": -114.07
+        "latitude": 51.17472962357743,
+        "longitude": -114.1290803717915
     }
 ]

--- a/api/data/seeds/sites.json
+++ b/api/data/seeds/sites.json
@@ -1,1 +1,9 @@
-[]
+[
+    {
+        "slug": "home",
+        "name": "Home",
+        "timezone": "America/Edmonton",
+        "latitude": 51.05,
+        "longitude": -114.07
+    }
+]

--- a/api/data/seeds/soil-types.json
+++ b/api/data/seeds/soil-types.json
@@ -1,1 +1,74 @@
-[]
+[
+    {
+        "slug": "sand",
+        "name": "Sand",
+        "availableWaterHoldingCapacityMmPerM": 80,
+        "infiltrationRateMmPerHr": 50
+    },
+    {
+        "slug": "loamy-sand",
+        "name": "Loamy Sand",
+        "availableWaterHoldingCapacityMmPerM": 100,
+        "infiltrationRateMmPerHr": 40
+    },
+    {
+        "slug": "sandy-loam",
+        "name": "Sandy Loam",
+        "availableWaterHoldingCapacityMmPerM": 125,
+        "infiltrationRateMmPerHr": 30
+    },
+    {
+        "slug": "loam",
+        "name": "Loam",
+        "availableWaterHoldingCapacityMmPerM": 150,
+        "infiltrationRateMmPerHr": 25
+    },
+    {
+        "slug": "silt-loam",
+        "name": "Silt Loam",
+        "availableWaterHoldingCapacityMmPerM": 175,
+        "infiltrationRateMmPerHr": 20
+    },
+    {
+        "slug": "silt",
+        "name": "Silt",
+        "availableWaterHoldingCapacityMmPerM": 165,
+        "infiltrationRateMmPerHr": 15
+    },
+    {
+        "slug": "sandy-clay-loam",
+        "name": "Sandy Clay Loam",
+        "availableWaterHoldingCapacityMmPerM": 140,
+        "infiltrationRateMmPerHr": 18
+    },
+    {
+        "slug": "clay-loam",
+        "name": "Clay Loam",
+        "availableWaterHoldingCapacityMmPerM": 165,
+        "infiltrationRateMmPerHr": 13
+    },
+    {
+        "slug": "silty-clay-loam",
+        "name": "Silty Clay Loam",
+        "availableWaterHoldingCapacityMmPerM": 180,
+        "infiltrationRateMmPerHr": 10
+    },
+    {
+        "slug": "sandy-clay",
+        "name": "Sandy Clay",
+        "availableWaterHoldingCapacityMmPerM": 135,
+        "infiltrationRateMmPerHr": 8
+    },
+    {
+        "slug": "silty-clay",
+        "name": "Silty Clay",
+        "availableWaterHoldingCapacityMmPerM": 175,
+        "infiltrationRateMmPerHr": 6
+    },
+    {
+        "slug": "clay",
+        "name": "Clay",
+        "availableWaterHoldingCapacityMmPerM": 170,
+        "infiltrationRateMmPerHr": 4
+    }
+]

--- a/api/data/seeds/zones.json
+++ b/api/data/seeds/zones.json
@@ -1,1 +1,41 @@
-[]
+[
+    {
+        "slug": "front-lawn",
+        "name": "Front Lawn",
+        "site": "home",
+        "grassType": "kentucky-bluegrass",
+        "soilType": "clay-loam",
+        "rootDepthM": 0.3,
+        "allowableDepletionFraction": 0.5,
+        "irrigationEfficiency": 0.8,
+        "flowRateLPerMin": 15,
+        "areaM2": 80,
+        "homeAssistantEntityId": "switch.sonoff_4chpro_relay_1"
+    },
+    {
+        "slug": "back-lawn",
+        "name": "Back Lawn",
+        "site": "home",
+        "grassType": "kentucky-bluegrass",
+        "soilType": "clay-loam",
+        "rootDepthM": 0.3,
+        "allowableDepletionFraction": 0.5,
+        "irrigationEfficiency": 0.8,
+        "flowRateLPerMin": 15,
+        "areaM2": 120,
+        "homeAssistantEntityId": "switch.sonoff_4chpro_relay_2"
+    },
+    {
+        "slug": "side-yard",
+        "name": "Side Yard",
+        "site": "home",
+        "grassType": "kentucky-bluegrass",
+        "soilType": "clay-loam",
+        "rootDepthM": 0.3,
+        "allowableDepletionFraction": 0.5,
+        "irrigationEfficiency": 0.8,
+        "flowRateLPerMin": 15,
+        "areaM2": 60,
+        "homeAssistantEntityId": "switch.sonoff_4chpro_relay_3"
+    }
+]

--- a/api/scripts/.test.ts
+++ b/api/scripts/.test.ts
@@ -277,3 +277,26 @@ describe('seed orchestrator', () => {
         await expect(seed({ db, dataDir })).rejects.toThrow(/missing seed file .+zones\.json/);
     });
 });
+
+describe('seed orchestrator against real api/data/seeds fixtures', () => {
+    const realDataDir = path.resolve(import.meta.dir, '../data/seeds');
+
+    it('runs end-to-end without parse or unknown-slug errors and inserts the expected zones', async () => {
+        const { db, calls } = createStubDb();
+
+        const summary = await seed({ db, dataDir: realDataDir });
+
+        expect(summary.grassTypes).toBeGreaterThanOrEqual(8);
+        expect(summary.soilTypes).toBeGreaterThanOrEqual(5);
+        expect(summary.sites).toBeGreaterThanOrEqual(1);
+        expect(summary.zones).toBe(3);
+
+        const zoneCall = calls.find(c => c.table === zones);
+        expect(zoneCall).toBeDefined();
+        for (const row of zoneCall!.rows) {
+            expect(row['siteId']).toMatch(/^id-/);
+            expect(row['grassTypeId']).toMatch(/^id-/);
+            expect(row['soilTypeId']).toMatch(/^id-/);
+        }
+    });
+});


### PR DESCRIPTION
## Ticket

[API-21](http://192.168.2.100:7123/irrigo/browse/API-21/) — Author seed data for grass types, soil types, sites, and zones.

## Summary

- Populate `api/data/seeds/grass-types.json` with 8 entries transcribed from `grassData` (active-growth Kc).
- Populate `api/data/seeds/soil-types.json` with 12 USDA texture classes from `api/data/soil/lookup.json`.
- Populate `api/data/seeds/sites.json` with one `home` site (Calgary-area, `America/Edmonton`).
- Populate `api/data/seeds/zones.json` with three Sonoff-4CHPRO-backed zones (front-lawn, back-lawn, side-yard), defaulting to kentucky-bluegrass on clay-loam.
- Add per-file fixture-validation tests in `api/data/seeds/.test.ts` plus an end-to-end seed-orchestrator test in `api/scripts/.test.ts` that runs against the real `api/data/seeds` directory and asserts cross-file slug references resolve.

## Test plan

- [x] `bun --cwd api run type-check`
- [x] `bun --cwd api test` — 134 passed, 0 failed
- [ ] Manual sanity check: `docker compose run --rm api bun run seed` against a freshly-migrated db container