### PR TITLE
[API-2] Home Assistant client and zone entity wiring

### DIFF
--- a/api/data/home-assistant/.test.ts
+++ b/api/data/home-assistant/.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { createTestZone } from '@/mock/zone';
+import { closeZone, openZone } from '.';
+
+const mockFetch = mock(() => Promise.resolve({} as Response));
+(global as any).fetch = mockFetch;
+
+const ENTITY_ID = 'switch.sonoff_4chpro_relay_1';
+const HA_URL = 'http://ha.local:8123';
+const HA_TOKEN = 'test-token-123';
+
+describe('Home Assistant client', () => {
+    let originalUrl: string | undefined;
+    let originalToken: string | undefined;
+
+    beforeEach(() => {
+        originalUrl = process.env.HA_URL;
+        originalToken = process.env.HA_TOKEN;
+        process.env.HA_URL = HA_URL;
+        process.env.HA_TOKEN = HA_TOKEN;
+        mockFetch.mockClear();
+        mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' } as Response);
+    });
+
+    afterEach(() => {
+        if (originalUrl === undefined) delete process.env.HA_URL;
+        else process.env.HA_URL = originalUrl;
+
+        if (originalToken === undefined) delete process.env.HA_TOKEN;
+        else process.env.HA_TOKEN = originalToken;
+    });
+
+    describe('openZone', () => {
+        it('POSTs to /api/services/switch/turn_on with bearer auth and JSON entity_id body', async () => {
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await openZone(zone);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            const [calledUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+            expect(calledUrl).toBe(`${HA_URL}/api/services/switch/turn_on`);
+            expect(init.method).toBe('POST');
+            expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${HA_TOKEN}`);
+            expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+            expect(JSON.parse(init.body as string)).toEqual({ entity_id: ENTITY_ID });
+        });
+
+        it('throws when Home Assistant returns a non-2xx response', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                statusText: 'Unauthorized',
+            } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 401 Unauthorized/);
+        });
+
+        it('throws when fetch rejects with a network error', async () => {
+            mockFetch.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow('connect ECONNREFUSED');
+        });
+
+        it('throws when the zone has no homeAssistantEntityId', async () => {
+            const zone = createTestZone({ homeAssistantEntityId: undefined });
+
+            await expect(openZone(zone)).rejects.toThrow(/has no homeAssistantEntityId/);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('closeZone', () => {
+        it('POSTs to /api/services/switch/turn_off with bearer auth and JSON entity_id body', async () => {
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await closeZone(zone);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            const [calledUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+            expect(calledUrl).toBe(`${HA_URL}/api/services/switch/turn_off`);
+            expect(init.method).toBe('POST');
+            expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${HA_TOKEN}`);
+            expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+            expect(JSON.parse(init.body as string)).toEqual({ entity_id: ENTITY_ID });
+        });
+
+        it('throws when Home Assistant returns a non-2xx response', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                statusText: 'Internal Server Error',
+            } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(closeZone(zone)).rejects.toThrow(/turn_off on switch\.sonoff_4chpro_relay_1 failed: 500 Internal Server Error/);
+        });
+
+        it('throws when fetch rejects with a network error', async () => {
+            mockFetch.mockRejectedValueOnce(new Error('socket hang up'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(closeZone(zone)).rejects.toThrow('socket hang up');
+        });
+
+        it('throws when the zone has no homeAssistantEntityId', async () => {
+            const zone = createTestZone({ homeAssistantEntityId: undefined });
+
+            await expect(closeZone(zone)).rejects.toThrow(/has no homeAssistantEntityId/);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('configuration', () => {
+        it('strips a trailing slash on HA_URL when building the service endpoint', async () => {
+            process.env.HA_URL = `${HA_URL}/`;
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await openZone(zone);
+
+            const [calledUrl] = mockFetch.mock.calls[0] as [string];
+            expect(calledUrl).toBe(`${HA_URL}/api/services/switch/turn_on`);
+        });
+
+        it('throws when HA_URL is unset', async () => {
+            delete process.env.HA_URL;
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/HA_URL environment variable is required/);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('throws when HA_TOKEN is unset', async () => {
+            delete process.env.HA_TOKEN;
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(closeZone(zone)).rejects.toThrow(/HA_TOKEN environment variable is required/);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/api/data/home-assistant/index.ts
+++ b/api/data/home-assistant/index.ts
@@ -1,0 +1,76 @@
+import type { Zone } from '@/models';
+
+type SwitchService = 'turn_on' | 'turn_off';
+
+type HomeAssistantConfig = {
+    url: string;
+    token: string;
+};
+
+/**
+ * Opens (energizes) the relay for the given zone via Home Assistant's
+ * `switch.turn_on` service. Throws if the zone has no Home Assistant entity
+ * configured, if the HA env vars are missing, or if the service call fails.
+ *
+ * @param zone - Zone whose relay should be opened.
+ * @throws Error when configuration is missing or HA returns a non-2xx response.
+ */
+export async function openZone(zone: Zone): Promise<void> {
+    return callService(zone, 'turn_on');
+}
+
+/**
+ * Closes (de-energizes) the relay for the given zone via Home Assistant's
+ * `switch.turn_off` service. Throws on the same conditions as `openZone`.
+ *
+ * @param zone - Zone whose relay should be closed.
+ * @throws Error when configuration is missing or HA returns a non-2xx response.
+ */
+export async function closeZone(zone: Zone): Promise<void> {
+    return callService(zone, 'turn_off');
+}
+
+async function callService(zone: Zone, service: SwitchService): Promise<void> {
+    if (!zone.homeAssistantEntityId)
+        throw new Error(`home-assistant: zone ${zone.id} (${zone.name}) has no homeAssistantEntityId; cannot ${service}.`);
+
+    const { url, token } = readConfig();
+    const endpoint = buildServiceUrl(url, service);
+    const action = service === 'turn_on' ? 'open' : 'close';
+
+    console.log(`home-assistant: ${action} zone ${zone.id} (${zone.name}) via ${zone.homeAssistantEntityId}.`);
+
+    let response: Response;
+    try {
+        response = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ entity_id: zone.homeAssistantEntityId }),
+        });
+    } catch (err) {
+        console.error(`home-assistant: fetch failed while attempting to ${service} ${zone.homeAssistantEntityId}.`, err);
+        throw err;
+    }
+
+    if (!response.ok) {
+        const message = `home-assistant: ${service} on ${zone.homeAssistantEntityId} failed: ${response.status} ${response.statusText}`;
+        console.error(message);
+        throw new Error(message);
+    }
+}
+
+function readConfig(): HomeAssistantConfig {
+    const url = process.env.HA_URL;
+    const token = process.env.HA_TOKEN;
+    if (!url) throw new Error('home-assistant: HA_URL environment variable is required.');
+    if (!token) throw new Error('home-assistant: HA_TOKEN environment variable is required.');
+    return { url, token };
+}
+
+function buildServiceUrl(baseUrl: string, service: SwitchService): string {
+    const trimmed = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    return `${trimmed}/api/services/switch/${service}`;
+}

--- a/api/models.ts
+++ b/api/models.ts
@@ -92,6 +92,9 @@ export type Zone = {
 
     /** Optional. Geographic location of the zone. */
     location?: { lat: number; lon: number };
+
+    /** Optional. The Home Assistant entity ID controlling the zone's relay (e.g. `switch.sonoff_4chpro_relay_1`). */
+    homeAssistantEntityId?: string;
 }
 
 export type IrrigationCycle = {


### PR DESCRIPTION
## Ticket

[API-2](http://192.168.2.100:7123/irrigo/browse/API-2/) — Home Assistant client and zone entity wiring

## Summary

- Add `api/data/home-assistant/` client exposing `openZone(zone)` / `closeZone(zone)` primitives. They POST to `${HA_URL}/api/services/switch/turn_{on,off}` with bearer auth and an `{ entity_id }` body, and throw on missing config, missing entity ID, non-2xx responses, or fetch failures so the daemon's safety story has something to react to.
- Surface `homeAssistantEntityId` on the in-memory `Zone` model — the column already exists in the API-5 schema and seed pipeline.
- 11 tests covering happy path, 4xx/5xx, network failure, missing entity ID, trailing-slash URL handling, and missing env vars. Mocks `global.fetch` only (external boundary).

## Out of scope

When/how the primitives get called (API-3), retry policy (API-11), env-var plumbing through docker-compose (API-8).