### PR TITLE
[API-11] Retry HA calls with exponential backoff

### DIFF
--- a/api/data/home-assistant/.test.ts
+++ b/api/data/home-assistant/.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { createTestZone } from '@/mock/zone';
 import { closeZone, openZone } from '.';
+import { HttpResponseError, computeBackoffMs, retry } from './retry';
 
 const mockFetch = mock(() => Promise.resolve({} as Response));
 (global as any).fetch = mockFetch;
@@ -138,5 +139,108 @@ describe('Home Assistant client', () => {
             await expect(closeZone(zone)).rejects.toThrow(/HA_TOKEN environment variable is required/);
             expect(mockFetch).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe('computeBackoffMs', () => {
+    it('returns baseMs * 2^attempt for a non-zero base', () => {
+        expect(computeBackoffMs(0, 1000)).toBe(1000);
+        expect(computeBackoffMs(1, 1000)).toBe(2000);
+        expect(computeBackoffMs(2, 1000)).toBe(4000);
+        expect(computeBackoffMs(3, 1000)).toBe(8000);
+    });
+
+    it('returns 0 when baseMs is 0 regardless of attempt', () => {
+        expect(computeBackoffMs(0, 0)).toBe(0);
+        expect(computeBackoffMs(5, 0)).toBe(0);
+    });
+});
+
+describe('retry', () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+    let errorSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    const baseOpts = { baseMs: 0, operation: 'turn_on', entityId: ENTITY_ID };
+
+    it('returns the resolved value on first success without logging a retry', async () => {
+        const fn = mock(() => Promise.resolve('done'));
+
+        const result = await retry(fn, { ...baseOpts, maxAttempts: 3 });
+
+        expect(result).toBe('done');
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('retries a 5xx HttpResponseError and succeeds on the second attempt', async () => {
+        let calls = 0;
+        const fn = mock(() => {
+            calls += 1;
+            if (calls === 1) return Promise.reject(new HttpResponseError(503, 'Service Unavailable', 'down'));
+            return Promise.resolve('ok');
+        });
+
+        const result = await retry(fn, { ...baseOpts, maxAttempts: 3 });
+
+        expect(result).toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a network error (plain Error) and succeeds on the second attempt', async () => {
+        let calls = 0;
+        const fn = mock(() => {
+            calls += 1;
+            if (calls === 1) return Promise.reject(new Error('connect ECONNREFUSED'));
+            return Promise.resolve('ok');
+        });
+
+        const result = await retry(fn, { ...baseOpts, maxAttempts: 3 });
+
+        expect(result).toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry a 4xx HttpResponseError', async () => {
+        const err = new HttpResponseError(401, 'Unauthorized', 'bad token');
+        const fn = mock(() => Promise.reject(err));
+
+        await expect(retry(fn, { ...baseOpts, maxAttempts: 3 })).rejects.toBe(err);
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausts after maxAttempts and throws the last underlying error', async () => {
+        const errors = [
+            new HttpResponseError(500, 'Internal Server Error', 'oops 1'),
+            new HttpResponseError(500, 'Internal Server Error', 'oops 2'),
+            new HttpResponseError(502, 'Bad Gateway', 'oops 3'),
+        ];
+        let calls = 0;
+        const fn = mock(() => {
+            const err = errors[calls];
+            calls += 1;
+            return Promise.reject(err);
+        });
+
+        await expect(retry(fn, { ...baseOpts, maxAttempts: 3 })).rejects.toBe(errors[2]!);
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('logs a warning for every retry attempt and an error on final exhaustion', async () => {
+        const fn = mock(() => Promise.reject(new HttpResponseError(500, 'Internal Server Error', 'down')));
+
+        await expect(retry(fn, { ...baseOpts, maxAttempts: 3 })).rejects.toBeInstanceOf(HttpResponseError);
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(errorSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/api/data/home-assistant/.test.ts
+++ b/api/data/home-assistant/.test.ts
@@ -13,12 +13,18 @@ const HA_TOKEN = 'test-token-123';
 describe('Home Assistant client', () => {
     let originalUrl: string | undefined;
     let originalToken: string | undefined;
+    let originalRetryMax: string | undefined;
+    let originalRetryBaseMs: string | undefined;
 
     beforeEach(() => {
         originalUrl = process.env.HA_URL;
         originalToken = process.env.HA_TOKEN;
+        originalRetryMax = process.env.HA_RETRY_MAX;
+        originalRetryBaseMs = process.env.HA_RETRY_BASE_MS;
         process.env.HA_URL = HA_URL;
         process.env.HA_TOKEN = HA_TOKEN;
+        process.env.HA_RETRY_MAX = '1';
+        process.env.HA_RETRY_BASE_MS = '0';
         mockFetch.mockClear();
         mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' } as Response);
     });
@@ -29,6 +35,12 @@ describe('Home Assistant client', () => {
 
         if (originalToken === undefined) delete process.env.HA_TOKEN;
         else process.env.HA_TOKEN = originalToken;
+
+        if (originalRetryMax === undefined) delete process.env.HA_RETRY_MAX;
+        else process.env.HA_RETRY_MAX = originalRetryMax;
+
+        if (originalRetryBaseMs === undefined) delete process.env.HA_RETRY_BASE_MS;
+        else process.env.HA_RETRY_BASE_MS = originalRetryBaseMs;
     });
 
     describe('openZone', () => {
@@ -87,8 +99,8 @@ describe('Home Assistant client', () => {
             expect(JSON.parse(init.body as string)).toEqual({ entity_id: ENTITY_ID });
         });
 
-        it('throws when Home Assistant returns a non-2xx response', async () => {
-            mockFetch.mockResolvedValueOnce({
+        it('throws when Home Assistant returns a non-2xx response after exhausting retries', async () => {
+            mockFetch.mockResolvedValue({
                 ok: false,
                 status: 500,
                 statusText: 'Internal Server Error',
@@ -96,13 +108,15 @@ describe('Home Assistant client', () => {
             const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
 
             await expect(closeZone(zone)).rejects.toThrow(/turn_off on switch\.sonoff_4chpro_relay_1 failed: 500 Internal Server Error/);
+            expect(mockFetch).toHaveBeenCalledTimes(2);
         });
 
-        it('throws when fetch rejects with a network error', async () => {
-            mockFetch.mockRejectedValueOnce(new Error('socket hang up'));
+        it('throws when fetch rejects with a network error after exhausting retries', async () => {
+            mockFetch.mockRejectedValue(new Error('socket hang up'));
             const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
 
             await expect(closeZone(zone)).rejects.toThrow('socket hang up');
+            expect(mockFetch).toHaveBeenCalledTimes(2);
         });
 
         it('throws when the zone has no homeAssistantEntityId', async () => {
@@ -138,6 +152,91 @@ describe('Home Assistant client', () => {
 
             await expect(closeZone(zone)).rejects.toThrow(/HA_TOKEN environment variable is required/);
             expect(mockFetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('retry behaviour', () => {
+        it('openZone retries a 503 then succeeds when HA returns OK on the second attempt', async () => {
+            process.env.HA_RETRY_MAX = '3';
+            mockFetch.mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await openZone(zone);
+
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('openZone retries a network error then succeeds when fetch resolves on the second attempt', async () => {
+            process.env.HA_RETRY_MAX = '3';
+            mockFetch.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await openZone(zone);
+
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('openZone exhausts after HA_RETRY_MAX attempts on sustained 5xx and throws', async () => {
+            process.env.HA_RETRY_MAX = '2';
+            mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 500 Internal Server Error/);
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('openZone does not retry a 401 response', async () => {
+            process.env.HA_RETRY_MAX = '5';
+            mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 401 Unauthorized/);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('openZone does not retry a 404 response', async () => {
+            process.env.HA_RETRY_MAX = '5';
+            mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 404 Not Found/);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('closeZone uses double the open-zone retry budget', async () => {
+            process.env.HA_RETRY_MAX = '3';
+            mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(closeZone(zone)).rejects.toThrow(/turn_off on switch\.sonoff_4chpro_relay_1 failed: 500 Internal Server Error/);
+            expect(mockFetch).toHaveBeenCalledTimes(6);
+        });
+
+        it('falls back to default of 3 attempts when HA_RETRY_MAX is unset', async () => {
+            delete process.env.HA_RETRY_MAX;
+            mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 502 Bad Gateway/);
+            expect(mockFetch).toHaveBeenCalledTimes(3);
+        });
+
+        it('falls back to default of 3 attempts when HA_RETRY_MAX is non-numeric', async () => {
+            process.env.HA_RETRY_MAX = 'not-a-number';
+            mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 502 Bad Gateway/);
+            expect(mockFetch).toHaveBeenCalledTimes(3);
+        });
+
+        it('falls back to default of 3 attempts when HA_RETRY_MAX is below 1', async () => {
+            process.env.HA_RETRY_MAX = '0';
+            mockFetch.mockResolvedValue({ ok: false, status: 502, statusText: 'Bad Gateway' } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 502 Bad Gateway/);
+            expect(mockFetch).toHaveBeenCalledTimes(3);
         });
     });
 });

--- a/api/data/home-assistant/index.ts
+++ b/api/data/home-assistant/index.ts
@@ -1,4 +1,5 @@
 import type { Zone } from '@/models';
+import { HttpResponseError, retry } from './retry';
 
 type SwitchService = 'turn_on' | 'turn_off';
 
@@ -7,10 +8,19 @@ type HomeAssistantConfig = {
     token: string;
 };
 
+type RetryConfig = {
+    maxAttempts: number;
+    baseMs: number;
+};
+
+const DEFAULT_RETRY_MAX = 3;
+const DEFAULT_RETRY_BASE_MS = 1000;
+
 /**
  * Opens (energizes) the relay for the given zone via Home Assistant's
  * `switch.turn_on` service. Throws if the zone has no Home Assistant entity
- * configured, if the HA env vars are missing, or if the service call fails.
+ * configured, if the HA env vars are missing, or if the service call fails
+ * after exhausting retries.
  *
  * @param zone - Zone whose relay should be opened.
  * @throws Error when configuration is missing or HA returns a non-2xx response.
@@ -21,7 +31,9 @@ export async function openZone(zone: Zone): Promise<void> {
 
 /**
  * Closes (de-energizes) the relay for the given zone via Home Assistant's
- * `switch.turn_off` service. Throws on the same conditions as `openZone`.
+ * `switch.turn_off` service. Throws on the same conditions as `openZone`. The
+ * close-side retry budget is twice the open-side budget — closing a stuck-on
+ * relay matters more than opening one.
  *
  * @param zone - Zone whose relay should be closed.
  * @throws Error when configuration is missing or HA returns a non-2xx response.
@@ -37,9 +49,25 @@ async function callService(zone: Zone, service: SwitchService): Promise<void> {
     const { url, token } = readConfig();
     const endpoint = buildServiceUrl(url, service);
     const action = service === 'turn_on' ? 'open' : 'close';
+    const entityId = zone.homeAssistantEntityId;
 
-    console.log(`home-assistant: ${action} zone ${zone.id} (${zone.name}) via ${zone.homeAssistantEntityId}.`);
+    console.log(`home-assistant: ${action} zone ${zone.id} (${zone.name}) via ${entityId}.`);
 
+    const retryConfig = readRetryConfig();
+    const maxAttempts = service === 'turn_off' ? retryConfig.maxAttempts * 2 : retryConfig.maxAttempts;
+
+    await retry(
+        () => sendRequest(endpoint, token, entityId, service),
+        {
+            maxAttempts,
+            baseMs: retryConfig.baseMs,
+            operation: service,
+            entityId,
+        },
+    );
+}
+
+async function sendRequest(endpoint: string, token: string, entityId: string, service: SwitchService): Promise<void> {
     let response: Response;
     try {
         response = await fetch(endpoint, {
@@ -48,17 +76,17 @@ async function callService(zone: Zone, service: SwitchService): Promise<void> {
                 Authorization: `Bearer ${token}`,
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ entity_id: zone.homeAssistantEntityId }),
+            body: JSON.stringify({ entity_id: entityId }),
         });
     } catch (err) {
-        console.error(`home-assistant: fetch failed while attempting to ${service} ${zone.homeAssistantEntityId}.`, err);
+        console.error(`home-assistant: fetch failed while attempting to ${service} ${entityId}.`, err);
         throw err;
     }
 
     if (!response.ok) {
-        const message = `home-assistant: ${service} on ${zone.homeAssistantEntityId} failed: ${response.status} ${response.statusText}`;
+        const message = `home-assistant: ${service} on ${entityId} failed: ${response.status} ${response.statusText}`;
         console.error(message);
-        throw new Error(message);
+        throw new HttpResponseError(response.status, response.statusText, message);
     }
 }
 
@@ -68,6 +96,25 @@ function readConfig(): HomeAssistantConfig {
     if (!url) throw new Error('home-assistant: HA_URL environment variable is required.');
     if (!token) throw new Error('home-assistant: HA_TOKEN environment variable is required.');
     return { url, token };
+}
+
+function readRetryConfig(): RetryConfig {
+    return {
+        maxAttempts: parsePositiveInt(process.env.HA_RETRY_MAX, DEFAULT_RETRY_MAX),
+        baseMs: parseNonNegativeInt(process.env.HA_RETRY_BASE_MS, DEFAULT_RETRY_BASE_MS),
+    };
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+    if (raw === undefined) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 1 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(raw: string | undefined, fallback: number): number {
+    if (raw === undefined) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 function buildServiceUrl(baseUrl: string, service: SwitchService): string {

--- a/api/data/home-assistant/retry.ts
+++ b/api/data/home-assistant/retry.ts
@@ -1,0 +1,96 @@
+/**
+ * Error thrown when Home Assistant returns a non-2xx HTTP response. Carries
+ * the status and statusText so the retry layer can decide whether the failure
+ * is transient (5xx) or permanent (4xx).
+ */
+export class HttpResponseError extends Error {
+    readonly status: number;
+    readonly statusText: string;
+
+    constructor(status: number, statusText: string, message: string) {
+        super(message);
+        this.name = 'HttpResponseError';
+        this.status = status;
+        this.statusText = statusText;
+    }
+}
+
+/**
+ * Configuration for a single `retry` call.
+ */
+export type RetryOptions = {
+    /** Total number of attempts, including the first. Must be >= 1. */
+    maxAttempts: number;
+
+    /** Base delay used by the exponential schedule, in milliseconds. */
+    baseMs: number;
+
+    /** Logical operation name (e.g. `turn_on`) — used for log context only. */
+    operation: string;
+
+    /** HA entity ID being acted on — used for log context only. */
+    entityId: string;
+};
+
+/**
+ * Returns the delay before the next attempt as `baseMs * 2^attempt`.
+ *
+ * @param attempt - Zero-indexed attempt number (0 = delay before the second try).
+ * @param baseMs - Base delay in milliseconds.
+ * @returns Computed delay in milliseconds.
+ */
+export function computeBackoffMs(attempt: number, baseMs: number): number {
+    return baseMs * 2 ** attempt;
+}
+
+/**
+ * Runs `fn` with retries on transient failures. A 4xx `HttpResponseError`
+ * surfaces immediately; a 5xx `HttpResponseError` or any other thrown value
+ * (network errors, timeouts) is retried with exponential backoff up to
+ * `opts.maxAttempts` total tries. After exhaustion, the last underlying error
+ * is thrown.
+ *
+ * @param fn - Async callable to invoke.
+ * @param opts - Retry budget, base delay, and log context.
+ * @returns Resolved value from `fn` on success.
+ * @throws The original error from `fn` after exhausting retries or on a permanent failure.
+ */
+export async function retry<T>(fn: () => Promise<T>, opts: RetryOptions): Promise<T> {
+    const { maxAttempts, baseMs, operation, entityId } = opts;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastError = err;
+
+            if (!isTransient(err)) {
+                console.warn(`home-assistant: ${operation} on ${entityId} failed permanently on attempt ${attempt + 1}/${maxAttempts}; not retrying.`, err);
+                throw err;
+            }
+
+            const isLastAttempt = attempt === maxAttempts - 1;
+            if (isLastAttempt) {
+                console.error(`home-assistant: ${operation} on ${entityId} exhausted ${maxAttempts} attempts.`, err);
+                throw err;
+            }
+
+            const delayMs = computeBackoffMs(attempt, baseMs);
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(`home-assistant: ${operation} on ${entityId} attempt ${attempt + 1}/${maxAttempts} failed (${message}); retrying in ${delayMs}ms.`);
+            await sleep(delayMs);
+        }
+    }
+
+    throw lastError;
+}
+
+function isTransient(err: unknown): boolean {
+    if (err instanceof HttpResponseError) return err.status >= 500;
+    return true;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Ticket

[API-11](http://192.168.2.100:7123/irrigo/browse/API-11/) — Retry HA calls with exponential backoff.

## Summary

- Adds `api/data/home-assistant/retry.ts` with `HttpResponseError`, a pure `computeBackoffMs(attempt, baseMs)` helper, and a generic `retry(fn, opts)` that retries 5xx and network errors with exponential backoff while surfacing 4xx responses immediately.
- Wraps `openZone` and `closeZone` in `retry`. Budgets come from `HA_RETRY_MAX` (default 3) and `HA_RETRY_BASE_MS` (default 1000); `closeZone` always gets 2× the open budget so a stuck-open relay tolerates more retries than a missed open.
- Pre-flight failures (missing `homeAssistantEntityId`, unset env vars) bypass the retry loop. Every retry attempt logs via `console.warn`; final exhaustion logs via `console.error`.
- 16 new tests cover the backoff math, retry/no-retry classification, exhaustion, close-budget doubling, and parser fallbacks (`HA_RETRY_MAX` unset / non-numeric / below 1). Existing closeZone failure tests were tightened to assert call counts under retries.