### PR TITLE
[API-3] Daemon for daily re-planning and schedule execution

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'bun:test';
+import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
+import {
+    loadEnabledZones,
+    mapJoinedRowsToZones,
+    type ZoneJoinedRow,
+    type ZoneLoaderDb,
+} from './zones';
+
+const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+function buildJoinedRow(overrides?: Partial<{
+    zone: Partial<ZoneJoinedRow['zone']>;
+    grassType: Partial<ZoneJoinedRow['grassType']>;
+    soilType: Partial<ZoneJoinedRow['soilType']>;
+    site: Partial<ZoneJoinedRow['site']>;
+}>): ZoneJoinedRow {
+    return {
+        zone: {
+            id: 'zone-001',
+            slug: 'front-lawn',
+            siteId: 'site-001',
+            name: 'Front Lawn',
+            grassTypeId: 'grass-001',
+            soilTypeId: 'soil-001',
+            rootDepthM: 0.3,
+            allowableDepletionFraction: 0.5,
+            irrigationEfficiency: 0.8,
+            flowRateLPerMin: 15,
+            areaM2: 100,
+            precipitationRateMmPerHr: 9,
+            currentDepletionMm: 0,
+            isEnabled: true,
+            latitude: 51.0447,
+            longitude: -114.0719,
+            homeAssistantEntityId: 'switch.zone_1',
+            createdAt: NOW,
+            updatedAt: NOW,
+            ...overrides?.zone,
+        },
+        grassType: {
+            id: 'grass-001',
+            slug: 'kentucky-bluegrass',
+            name: 'Kentucky Bluegrass',
+            cropCoefficient: 0.85,
+            createdAt: NOW,
+            updatedAt: NOW,
+            ...overrides?.grassType,
+        },
+        soilType: {
+            id: 'soil-001',
+            slug: 'loam',
+            name: 'Loam',
+            availableWaterHoldingCapacityMmPerM: 150,
+            infiltrationRateMmPerHr: 25,
+            createdAt: NOW,
+            updatedAt: NOW,
+            ...overrides?.soilType,
+        },
+        site: {
+            id: 'site-001',
+            slug: 'home',
+            name: 'Home',
+            timezone: 'America/Edmonton',
+            latitude: 51.05,
+            longitude: -114.07,
+            address: null,
+            createdAt: NOW,
+            updatedAt: NOW,
+            ...overrides?.site,
+        },
+    };
+}
+
+type WhereCall = { conditions: unknown };
+
+function createZoneLoaderStub(rows: ZoneJoinedRow[]) {
+    const whereCalls: WhereCall[] = [];
+    let selectColumns: unknown;
+
+    const db: ZoneLoaderDb = {
+        select(columns) {
+            selectColumns = columns;
+            return {
+                from() {
+                    return {
+                        innerJoin() {
+                            return {
+                                innerJoin() {
+                                    return {
+                                        innerJoin() {
+                                            return {
+                                                where(conditions) {
+                                                    whereCalls.push({ conditions });
+                                                    return Promise.resolve(rows);
+                                                },
+                                            };
+                                        },
+                                    };
+                                },
+                            };
+                        },
+                    };
+                },
+            };
+        },
+    };
+
+    return {
+        db,
+        whereCalls,
+        getSelectColumns: () => selectColumns,
+    };
+}
+
+describe('mapJoinedRowsToZones', () => {
+    it('drops zones whose is_enabled flag is false', () => {
+        const enabled = buildJoinedRow({ zone: { id: 'enabled-zone', isEnabled: true } });
+        const disabled = buildJoinedRow({ zone: { id: 'disabled-zone', isEnabled: false } });
+
+        const result = mapJoinedRowsToZones([enabled, disabled]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.id).toBe('enabled-zone');
+    });
+
+    it('uses the zone-level latitude and longitude when both are set', () => {
+        const row = buildJoinedRow({
+            zone: { latitude: 49.5, longitude: -100.0 },
+            site: { latitude: 51.05, longitude: -114.07 },
+        });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.location).toEqual({ lat: 49.5, lon: -100.0 });
+    });
+
+    it('falls back to the site latitude and longitude when the zone has none', () => {
+        const row = buildJoinedRow({
+            zone: { latitude: null, longitude: null },
+            site: { latitude: 51.05, longitude: -114.07 },
+        });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.location).toEqual({ lat: 51.05, lon: -114.07 });
+    });
+
+    it('falls back per-axis when only one of the zone coordinates is null', () => {
+        const row = buildJoinedRow({
+            zone: { latitude: 49.5, longitude: null },
+            site: { latitude: 51.05, longitude: -114.07 },
+        });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.location).toEqual({ lat: 49.5, lon: -114.07 });
+    });
+
+    it('maps the grass type and soil type into the nested model shape', () => {
+        const row = buildJoinedRow({
+            grassType: { name: 'Bermudagrass', cropCoefficient: 0.65 },
+            soilType: { name: 'Sandy Loam', availableWaterHoldingCapacityMmPerM: 125, infiltrationRateMmPerHr: 30 },
+        });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.grassType).toEqual({ name: 'Bermudagrass', cropCoefficient: 0.65 });
+        expect(result[0]?.soil).toEqual({ name: 'Sandy Loam', availableWaterHoldingCapacityMmPerM: 125, infiltrationRateMmPerHr: 30 });
+    });
+
+    it('converts null precipitationRateMmPerHr and homeAssistantEntityId to undefined', () => {
+        const row = buildJoinedRow({
+            zone: { precipitationRateMmPerHr: null, homeAssistantEntityId: null },
+        });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.precipitationRateMmPerHr).toBeUndefined();
+        expect(result[0]?.homeAssistantEntityId).toBeUndefined();
+    });
+
+    it('preserves non-null precipitationRateMmPerHr and homeAssistantEntityId', () => {
+        const row = buildJoinedRow({
+            zone: { precipitationRateMmPerHr: 12.5, homeAssistantEntityId: 'switch.front_yard' },
+        });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.precipitationRateMmPerHr).toBe(12.5);
+        expect(result[0]?.homeAssistantEntityId).toBe('switch.front_yard');
+    });
+});
+
+describe('loadEnabledZones', () => {
+    it('returns mapped Zone models from the joined-row query', async () => {
+        const row = buildJoinedRow({ zone: { id: 'returned-zone', name: 'Back Yard' } });
+        const { db } = createZoneLoaderStub([row]);
+
+        const result = await loadEnabledZones(db);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.id).toBe('returned-zone');
+        expect(result[0]?.name).toBe('Back Yard');
+    });
+
+    it('passes the standard set of joined columns to db.select', async () => {
+        const { db, getSelectColumns } = createZoneLoaderStub([]);
+
+        await loadEnabledZones(db);
+
+        const cols = getSelectColumns() as Record<string, unknown>;
+        expect(cols['zone']).toBe(zones);
+        expect(cols['grassType']).toBe(grassTypes);
+        expect(cols['soilType']).toBe(soilTypes);
+        expect(cols['site']).toBe(sites);
+    });
+
+    it('issues exactly one .where(...) call per invocation', async () => {
+        const { db, whereCalls } = createZoneLoaderStub([buildJoinedRow()]);
+
+        await loadEnabledZones(db);
+
+        expect(whereCalls).toHaveLength(1);
+    });
+
+    it('returns an empty array when no zones match', async () => {
+        const { db } = createZoneLoaderStub([]);
+
+        const result = await loadEnabledZones(db);
+
+        expect(result).toEqual([]);
+    });
+});

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -8,10 +8,12 @@ import {
     soilTypes,
     zones,
 } from '@/db/schema';
-import type { IrrigationScheduleEntry } from '@/models';
+import type { IrrigationScheduleEntry, Zone } from '@/models';
+import { computeNextRePlanAt, start, type DaemonDb } from '.';
 import {
     loadEnabledZones,
     mapJoinedRowsToZones,
+    type SelectJoinChain,
     type ZoneJoinedRow,
     type ZoneLoaderDb,
 } from './zones';
@@ -20,8 +22,17 @@ import {
     replaceZoneSchedule,
     type FutureCycleJoinedRow,
     type FutureCyclesDb,
+    type PersistedCycle,
     type ScheduleWriterDb,
 } from './schedules';
+import {
+    armCycle,
+    closeAllInFlight,
+    TimerRegistry,
+    type Clock,
+    type RuntimeDb,
+    type TimerHandle,
+} from './runtime';
 
 const NOW = new Date('2026-05-04T12:00:00.000Z');
 
@@ -90,6 +101,17 @@ function buildJoinedRow(overrides?: Partial<{
 
 type WhereCall = { conditions: unknown };
 
+function buildJoinChainStub<TRow>(whereCalls: WhereCall[], rows: TRow[]): SelectJoinChain<TRow> {
+    const chain: SelectJoinChain<TRow> = {
+        innerJoin: () => chain,
+        where: (conditions) => {
+            whereCalls.push({ conditions });
+            return Promise.resolve(rows);
+        },
+    };
+    return chain;
+}
+
 function createZoneLoaderStub(rows: ZoneJoinedRow[]) {
     const whereCalls: WhereCall[] = [];
     let selectColumns: unknown;
@@ -97,28 +119,7 @@ function createZoneLoaderStub(rows: ZoneJoinedRow[]) {
     const db: ZoneLoaderDb = {
         select(columns) {
             selectColumns = columns;
-            return {
-                from() {
-                    return {
-                        innerJoin() {
-                            return {
-                                innerJoin() {
-                                    return {
-                                        innerJoin() {
-                                            return {
-                                                where(conditions) {
-                                                    whereCalls.push({ conditions });
-                                                    return Promise.resolve(rows);
-                                                },
-                                            };
-                                        },
-                                    };
-                                },
-                            };
-                        },
-                    };
-                },
-            };
+            return { from: () => buildJoinChainStub(whereCalls, rows) };
         },
     };
 
@@ -446,36 +447,7 @@ function createFutureCyclesStub(rows: FutureCycleJoinedRow[]) {
     const db: FutureCyclesDb = {
         select(columns) {
             selectColumns = columns;
-            return {
-                from() {
-                    return {
-                        innerJoin() {
-                            return {
-                                innerJoin() {
-                                    return {
-                                        innerJoin() {
-                                            return {
-                                                innerJoin() {
-                                                    return {
-                                                        innerJoin() {
-                                                            return {
-                                                                where(conditions) {
-                                                                    whereCalls.push({ conditions });
-                                                                    return Promise.resolve(rows);
-                                                                },
-                                                            };
-                                                        },
-                                                    };
-                                                },
-                                            };
-                                        },
-                                    };
-                                },
-                            };
-                        },
-                    };
-                },
-            };
+            return { from: () => buildJoinChainStub(whereCalls, rows) };
         },
     };
 
@@ -540,5 +512,608 @@ describe('loadFutureCycles', () => {
         const result = await loadFutureCycles(db, NOW_DAEMON);
 
         expect(result).toEqual([]);
+    });
+});
+
+describe('computeNextRePlanAt', () => {
+    it('returns todays hour when the current time is before that hour', () => {
+        const now = new Date('2026-05-04T01:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4);
+
+        expect(dayjs(next).format('YYYY-MM-DDTHH:mm')).toBe(dayjs(now).hour(4).minute(0).format('YYYY-MM-DDTHH:mm'));
+    });
+
+    it('returns tomorrows hour when the current time is past todays hour', () => {
+        const now = new Date('2026-05-04T18:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4);
+
+        const expected = dayjs(now).add(1, 'day').hour(4).minute(0).second(0).millisecond(0);
+        expect(dayjs(next).format('YYYY-MM-DDTHH:mm:ss')).toBe(expected.format('YYYY-MM-DDTHH:mm:ss'));
+    });
+
+    it('returns tomorrows hour when the current time exactly matches todays hour', () => {
+        const now = dayjs(NOW_DAEMON).hour(4).minute(0).second(0).millisecond(0).toDate();
+        const next = computeNextRePlanAt(now, 4);
+
+        expect(dayjs(next).diff(dayjs(now), 'hour')).toBe(24);
+    });
+});
+
+type ScheduledTimer = { handle: number; fireAt: number; cb: () => void };
+
+function createFakeClock(initial: Date) {
+    let currentMs = initial.getTime();
+    let nextHandle = 1;
+    const timers = new Map<number, ScheduledTimer>();
+
+    const clock: Clock = {
+        now: () => new Date(currentMs),
+        setTimeout(cb, ms) {
+            const handle = nextHandle++;
+            const fireAt = currentMs + ms;
+            timers.set(handle, { handle, fireAt, cb });
+            return handle as TimerHandle;
+        },
+        clearTimeout(h) {
+            timers.delete(h as number);
+        },
+    };
+
+    async function flushMicrotasks(): Promise<void> {
+        for (let i = 0; i < 50; i += 1) await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    async function advanceTo(target: Date): Promise<void> {
+        const targetMs = target.getTime();
+        // Repeatedly fire whichever timer is earliest among those due, until none remain.
+        while (true) {
+            let earliest: ScheduledTimer | undefined;
+            for (const t of timers.values()) {
+                if (t.fireAt > targetMs) continue;
+                if (!earliest || t.fireAt < earliest.fireAt) earliest = t;
+            }
+            if (!earliest) break;
+            timers.delete(earliest.handle);
+            currentMs = earliest.fireAt;
+            earliest.cb();
+            await flushMicrotasks();
+        }
+        currentMs = targetMs;
+    }
+
+    return {
+        clock,
+        advanceTo,
+        flushMicrotasks,
+        getPendingCount: () => timers.size,
+        getPendingDelays: () => [...timers.values()].map(t => t.fireAt - initial.getTime()),
+    };
+}
+
+type CycleUpdate = { cycleId: string; firedAt?: Date; closedAt?: Date };
+
+function createRuntimeDbStub() {
+    const updates: CycleUpdate[] = [];
+    const db: RuntimeDb = {
+        update(table) {
+            expect(table).toBe(irrigationCycles);
+            return {
+                set(values) {
+                    return {
+                        async where(cond) {
+                            // Inspect the cond to extract cycle id — for the fake we just
+                            // record the values + a free-form id placeholder. Real Drizzle
+                            // would compile this to a parameterized statement.
+                            const update: CycleUpdate = { cycleId: extractCycleId(cond) };
+                            if (values['firedAt'] instanceof Date) update.firedAt = values['firedAt'];
+                            if (values['closedAt'] instanceof Date) update.closedAt = values['closedAt'];
+                            updates.push(update);
+                            return Promise.resolve(undefined);
+                        },
+                    };
+                },
+            };
+        },
+    };
+    return { db, updates };
+}
+
+// Extracts the comparison value from an `eq(irrigationCycles.id, X)` condition. Drizzle's
+// SQL object can contain cyclic references, so we walk it manually with a WeakSet rather
+// than reaching for JSON.stringify.
+function extractCycleId(cond: unknown): string {
+    const seen = new WeakSet<object>();
+    function walk(node: unknown): string | undefined {
+        if (typeof node === 'string') return /^cycle-/.test(node) ? node : undefined;
+        if (typeof node !== 'object' || node === null) return undefined;
+        if (seen.has(node)) return undefined;
+        seen.add(node);
+        if (Array.isArray(node)) {
+            for (const item of node) {
+                const found = walk(item);
+                if (found) return found;
+            }
+            return undefined;
+        }
+        for (const value of Object.values(node)) {
+            const found = walk(value);
+            if (found) return found;
+        }
+        return undefined;
+    }
+    return walk(cond) ?? '';
+}
+
+function buildPersistedCycle(overrides?: Partial<PersistedCycle>): PersistedCycle {
+    return {
+        id: 'cycle-001',
+        startTime: new Date('2026-05-04T13:00:00.000Z'),
+        durationMin: 20,
+        ...overrides,
+    };
+}
+
+function buildZoneModel(overrides?: Partial<Zone>): Zone {
+    return {
+        id: 'zone-001',
+        name: 'Front Lawn',
+        grassType: { name: 'Kentucky Bluegrass', cropCoefficient: 0.85 },
+        soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        flowRateLPerMin: 15,
+        areaM2: 100,
+        precipitationRateMmPerHr: 9,
+        currentDepletionMm: 0,
+        isEnabled: true,
+        location: { lat: 51.0447, lon: -114.0719 },
+        homeAssistantEntityId: 'switch.zone_1',
+        ...overrides,
+    };
+}
+
+describe('armCycle', () => {
+    const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+    it('opens the zone at start_time, records firedAt, then closes after durationMin and records closedAt', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001' });
+        const cycle = buildPersistedCycle({
+            id: 'cycle-A',
+            startTime: new Date('2026-05-04T13:00:00.000Z'),
+            durationMin: 30,
+        });
+        const opens: Zone[] = [];
+        const closes: Zone[] = [];
+        const openZone = async (z: Zone) => { opens.push(z); };
+        const closeZone = async (z: Zone) => { closes.push(z); };
+
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+
+        await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
+
+        expect(opens).toHaveLength(1);
+        expect(opens[0]?.id).toBe('zone-001');
+        expect(closes).toHaveLength(1);
+        expect(updates.map(u => ({ id: u.cycleId, fired: !!u.firedAt, closed: !!u.closedAt }))).toEqual([
+            { id: 'cycle-A', fired: true, closed: false },
+            { id: 'cycle-A', fired: false, closed: true },
+        ]);
+    });
+
+    it('skips chaining the close when openZone fails and leaves firedAt unset', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel();
+        const cycle = buildPersistedCycle({
+            id: 'cycle-B',
+            startTime: new Date('2026-05-04T13:00:00.000Z'),
+            durationMin: 20,
+        });
+        const closes: Zone[] = [];
+        const openZone = async () => { throw new Error('HA down'); };
+        const closeZone = async (z: Zone) => { closes.push(z); };
+
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
+
+        expect(closes).toEqual([]);
+        expect(updates).toEqual([]);
+        expect(registry.snapshotInFlight()).toEqual([]);
+    });
+
+    it('records firedAt but not closedAt when closeZone fails after a successful open', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel();
+        const cycle = buildPersistedCycle({
+            id: 'cycle-C',
+            startTime: new Date('2026-05-04T13:00:00.000Z'),
+            durationMin: 15,
+        });
+        const openZone = async () => { /* success */ };
+        const closeZone = async () => { throw new Error('close failed'); };
+
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
+
+        expect(updates).toHaveLength(1);
+        expect(updates[0]?.firedAt).toBeInstanceOf(Date);
+        expect(updates[0]?.closedAt).toBeUndefined();
+        expect(registry.snapshotInFlight()).toEqual([]);
+    });
+
+    it('fires immediately if start_time is in the past relative to now', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel();
+        const cycle = buildPersistedCycle({
+            id: 'cycle-D',
+            startTime: new Date('2026-05-04T11:00:00.000Z'),
+            durationMin: 5,
+        });
+        const opens: Zone[] = [];
+        const openZone = async (z: Zone) => { opens.push(z); };
+        const closeZone = async () => { /* success */ };
+
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        await advanceTo(new Date('2026-05-04T12:05:01.000Z'));
+
+        expect(opens).toHaveLength(1);
+        expect(updates.length).toBeGreaterThanOrEqual(1);
+    });
+});
+
+describe('closeAllInFlight', () => {
+    const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+    it('closes every in-flight relay and records closedAt for each', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zoneA = buildZoneModel({ id: 'zone-A' });
+        const zoneB = buildZoneModel({ id: 'zone-B' });
+        registry.addInFlight('cycle-X', zoneA, 999);
+        registry.addInFlight('cycle-Y', zoneB, 998);
+        const closes: Zone[] = [];
+        const closeZone = async (z: Zone) => { closes.push(z); };
+
+        await closeAllInFlight({ db, clock, registry, closeZone });
+
+        expect(closes.map(z => z.id)).toEqual(['zone-A', 'zone-B']);
+        expect(updates.filter(u => u.closedAt instanceof Date)).toHaveLength(2);
+        expect(registry.snapshotInFlight()).toEqual([]);
+    });
+
+    it('tolerates a closeZone failure on shutdown and continues with the remaining relays', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        registry.addInFlight('cycle-X', buildZoneModel({ id: 'zone-A' }), 999);
+        registry.addInFlight('cycle-Y', buildZoneModel({ id: 'zone-B' }), 998);
+        let calls = 0;
+        const closeZone = async () => {
+            calls += 1;
+            if (calls === 1) throw new Error('HA flaky');
+        };
+
+        await closeAllInFlight({ db, clock, registry, closeZone });
+
+        expect(calls).toBe(2);
+        expect(updates).toHaveLength(1); // only the second one updated closedAt
+        expect(registry.snapshotInFlight()).toEqual([]);
+    });
+
+    it('returns immediately when there is nothing in-flight', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const closes: Zone[] = [];
+
+        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); } });
+
+        expect(closes).toEqual([]);
+        expect(updates).toEqual([]);
+    });
+});
+
+type DaemonStubInputs = {
+    futureCycles?: FutureCycleJoinedRow[];
+    enabledZones?: ZoneJoinedRow[];
+};
+
+function createDaemonDbStub(inputs?: DaemonStubInputs) {
+    const updates: CycleUpdate[] = [];
+    const inserts: InsertCall[] = [];
+    const deletes: DeleteCall[] = [];
+    const whereCallsZone: WhereCall[] = [];
+    const whereCallsCycles: WhereCall[] = [];
+
+    const db: DaemonDb = {
+        select(columns) {
+            const cols = columns as Record<string, unknown>;
+            const isFutureCyclesQuery = 'cycle' in cols;
+            const rows = (isFutureCyclesQuery ? inputs?.futureCycles : inputs?.enabledZones) ?? [];
+            const whereSink = isFutureCyclesQuery ? whereCallsCycles : whereCallsZone;
+            return { from: () => buildJoinChainStub(whereSink, rows) };
+        },
+        delete(table) {
+            return {
+                where(conditions) {
+                    deletes.push({ table, conditions });
+                    return Promise.resolve(undefined);
+                },
+            };
+        },
+        insert(table) {
+            return {
+                values(rows) {
+                    return {
+                        returning() {
+                            inserts.push({ table, rows });
+                            if (table === scheduleEntries) {
+                                return Promise.resolve(rows.map((_, i) => ({ id: `entry-${inserts.length}-${i}` })));
+                            }
+                            if (table === irrigationCycles) {
+                                return Promise.resolve(rows.map((row, i) => ({
+                                    id: `cycle-${inserts.length}-${i}`,
+                                    startTime: row['startTime'],
+                                    durationMin: row['durationMin'],
+                                })));
+                            }
+                            return Promise.resolve([]);
+                        },
+                    };
+                },
+            };
+        },
+        update(table) {
+            expect(table).toBe(irrigationCycles);
+            return {
+                set(values) {
+                    return {
+                        async where(cond) {
+                            const update: CycleUpdate = { cycleId: extractCycleId(cond) };
+                            if (values['firedAt'] instanceof Date) update.firedAt = values['firedAt'];
+                            if (values['closedAt'] instanceof Date) update.closedAt = values['closedAt'];
+                            updates.push(update);
+                            return Promise.resolve(undefined);
+                        },
+                    };
+                },
+            };
+        },
+    };
+
+    return { db, updates, inserts, deletes };
+}
+
+describe('start', () => {
+    const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+    it('arms each future cycle returned by the DB so it fires at its start_time', async () => {
+        const futureRow = buildFutureCycleRow({
+            cycle: {
+                id: 'cycle-existing',
+                startTime: new Date('2026-05-04T13:00:00.000Z'),
+                durationMin: 10,
+            },
+        });
+        const { db } = createDaemonDbStub({ futureCycles: [futureRow] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const opens: string[] = [];
+        const closes: string[] = [];
+
+        await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => [],
+            openZone: async (z) => { opens.push(z.id); },
+            closeZone: async (z) => { closes.push(z.id); },
+        });
+
+        await advanceTo(new Date('2026-05-04T13:10:01.000Z'));
+
+        expect(opens).toEqual([futureRow.zone.id]);
+        expect(closes).toEqual([futureRow.zone.id]);
+    });
+
+    it('schedules the next re-plan timer for the configured local hour', async () => {
+        const { db } = createDaemonDbStub();
+        // Set initial time to 12:00, hour=4 -> next re-plan should be 04:00 next day = +16h
+        const { clock, getPendingDelays } = createFakeClock(NOW);
+
+        await start(db, { clock, rePlanHourLocal: 4 });
+
+        const sixteenHoursMs = 16 * 60 * 60 * 1000;
+        expect(getPendingDelays()).toContain(sixteenHoursMs);
+    });
+
+    it('returned rePlan() runs the planner for every enabled zone and inserts the planner output', async () => {
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded', name: 'Loaded Zone' } });
+        const { db, inserts, deletes } = createDaemonDbStub({ enabledZones: [enabledRow] });
+        const { clock } = createFakeClock(NOW);
+        const planned: IrrigationScheduleEntry[] = [
+            buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 20 }]),
+        ];
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => planned,
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await control.rePlan();
+
+        expect(deletes.length).toBeGreaterThanOrEqual(1);
+        expect(inserts.filter(c => c.table === scheduleEntries)).toHaveLength(1);
+        expect(inserts.filter(c => c.table === irrigationCycles)).toHaveLength(1);
+    });
+
+    it('rePlan() cancels pending open timers from the previous plan', async () => {
+        const futureRow = buildFutureCycleRow({
+            cycle: {
+                id: 'cycle-old',
+                startTime: new Date('2026-05-04T15:00:00.000Z'),
+                durationMin: 20,
+            },
+        });
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded' } });
+        const { db } = createDaemonDbStub({ futureCycles: [futureRow], enabledZones: [enabledRow] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const opens: string[] = [];
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => [],
+            openZone: async (z) => { opens.push(z.id); },
+            closeZone: async () => {},
+        });
+
+        await control.rePlan();
+        await advanceTo(new Date('2026-05-04T15:30:00.000Z'));
+
+        expect(opens).toEqual([]);
+    });
+
+    it('rePlan() logs and continues when the planner throws for a single zone', async () => {
+        const enabledRows = [
+            buildJoinedRow({ zone: { id: 'zone-bad' } }),
+            buildJoinedRow({ zone: { id: 'zone-good' } }),
+        ];
+        const { db, inserts } = createDaemonDbStub({ enabledZones: enabledRows });
+        const { clock } = createFakeClock(NOW);
+        const planned = buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 20 }]);
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async (z) => {
+                if (z.id === 'zone-bad') throw new Error('plan failed');
+                return [planned];
+            },
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await control.rePlan();
+
+        // Only zone-good should have produced inserts.
+        expect(inserts.filter(c => c.table === scheduleEntries)).toHaveLength(1);
+    });
+
+    it('shutdown() cancels pending timers and closes any in-flight relay', async () => {
+        const futureRow = buildFutureCycleRow({
+            cycle: {
+                id: 'cycle-inflight',
+                startTime: new Date('2026-05-04T13:00:00.000Z'),
+                durationMin: 60,
+            },
+        });
+        const { db } = createDaemonDbStub({ futureCycles: [futureRow] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const opens: string[] = [];
+        const closes: string[] = [];
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => [],
+            openZone: async (z) => { opens.push(z.id); },
+            closeZone: async (z) => { closes.push(z.id); },
+        });
+
+        // Advance past the open but before the natural close; the relay is now in-flight.
+        await advanceTo(new Date('2026-05-04T13:05:00.000Z'));
+        expect(opens).toHaveLength(1);
+        expect(closes).toEqual([]);
+
+        await control.shutdown();
+
+        expect(closes).toEqual([futureRow.zone.id]);
+    });
+
+    it('shutdown() with no in-flight cycles only cancels timers and resolves quickly', async () => {
+        const { db } = createDaemonDbStub();
+        const { clock } = createFakeClock(NOW);
+        const closes: string[] = [];
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => [],
+            openZone: async () => {},
+            closeZone: async (z) => { closes.push(z.id); },
+        });
+
+        await control.shutdown();
+
+        expect(closes).toEqual([]);
+    });
+
+    it('the scheduled re-plan timer fires runPlan automatically when its time elapses', async () => {
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded' } });
+        const { db } = createDaemonDbStub({ enabledZones: [enabledRow] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const planCalls: string[] = [];
+
+        await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async (z) => {
+                planCalls.push(z.id);
+                return [];
+            },
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        // Advance to just past the next 04:00 — the scheduled timer should fire and
+        // call rePlan, which iterates enabled zones.
+        await advanceTo(new Date('2026-05-05T04:00:01.000Z'));
+
+        expect(planCalls).toContain('zone-loaded');
+    });
+
+    it('rePlan() does not cancel the close timer of an already-fired cycle', async () => {
+        const futureRow = buildFutureCycleRow({
+            cycle: {
+                id: 'cycle-running',
+                startTime: new Date('2026-05-04T13:00:00.000Z'),
+                durationMin: 30,
+            },
+        });
+        const { db } = createDaemonDbStub({ futureCycles: [futureRow], enabledZones: [] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const opens: string[] = [];
+        const closes: string[] = [];
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => [],
+            openZone: async (z) => { opens.push(z.id); },
+            closeZone: async (z) => { closes.push(z.id); },
+        });
+
+        // Open fires; cycle is now in-flight.
+        await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
+        expect(opens).toHaveLength(1);
+        expect(closes).toEqual([]);
+
+        // rePlan happens mid-cycle. The in-flight close timer should NOT be cancelled.
+        await control.rePlan();
+        await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
+
+        expect(closes).toEqual([futureRow.zone.id]);
     });
 });

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1,11 +1,27 @@
 import { describe, it, expect } from 'bun:test';
-import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
+import dayjs from 'dayjs';
+import {
+    grassTypes,
+    irrigationCycles,
+    scheduleEntries,
+    sites,
+    soilTypes,
+    zones,
+} from '@/db/schema';
+import type { IrrigationScheduleEntry } from '@/models';
 import {
     loadEnabledZones,
     mapJoinedRowsToZones,
     type ZoneJoinedRow,
     type ZoneLoaderDb,
 } from './zones';
+import {
+    loadFutureCycles,
+    replaceZoneSchedule,
+    type FutureCycleJoinedRow,
+    type FutureCyclesDb,
+    type ScheduleWriterDb,
+} from './schedules';
 
 const NOW = new Date('2026-05-04T12:00:00.000Z');
 
@@ -228,6 +244,300 @@ describe('loadEnabledZones', () => {
         const { db } = createZoneLoaderStub([]);
 
         const result = await loadEnabledZones(db);
+
+        expect(result).toEqual([]);
+    });
+});
+
+type DeleteCall = { table: unknown; conditions: unknown };
+type InsertCall = { table: unknown; rows: ReadonlyArray<Record<string, unknown>> };
+
+function createScheduleWriterStub(idPlan?: { entries?: string[]; cycles?: string[][] }) {
+    const deleteCalls: DeleteCall[] = [];
+    const insertCalls: InsertCall[] = [];
+    let entryIdx = 0;
+    let cycleBatchIdx = 0;
+
+    const db: ScheduleWriterDb = {
+        delete(table) {
+            return {
+                where(conditions) {
+                    deleteCalls.push({ table, conditions });
+                    return Promise.resolve(undefined);
+                },
+            };
+        },
+        insert(table) {
+            return {
+                values(rows) {
+                    return {
+                        returning() {
+                            insertCalls.push({ table, rows });
+                            if (table === scheduleEntries) {
+                                const id = idPlan?.entries?.[entryIdx] ?? `entry-${entryIdx}`;
+                                entryIdx += 1;
+                                return Promise.resolve([{ id }]);
+                            }
+                            if (table === irrigationCycles) {
+                                const ids = idPlan?.cycles?.[cycleBatchIdx] ?? rows.map((_, i) => `cycle-${cycleBatchIdx}-${i}`);
+                                cycleBatchIdx += 1;
+                                const out = rows.map((row, i) => ({
+                                    id: ids[i],
+                                    startTime: row['startTime'],
+                                    durationMin: row['durationMin'],
+                                }));
+                                return Promise.resolve(out);
+                            }
+                            return Promise.resolve([]);
+                        },
+                    };
+                },
+            };
+        },
+    };
+
+    return { db, deleteCalls, insertCalls };
+}
+
+function buildEntry(date: string, cycles: Array<{ startTime: string; durationMin: number }>): IrrigationScheduleEntry {
+    return {
+        date: dayjs(date),
+        zoneId: 'zone-001',
+        cycles: cycles.map(c => ({ startTime: dayjs(c.startTime), durationMin: c.durationMin })),
+        appliedDepthMm: 12.0,
+        depletionBeforeMm: 18.5,
+        depletionAfterMm: 0,
+    };
+}
+
+describe('replaceZoneSchedule', () => {
+    it('issues a delete on schedule_entries for the zone before any inserts', async () => {
+        const { db, deleteCalls, insertCalls } = createScheduleWriterStub();
+        const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
+
+        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04');
+
+        expect(deleteCalls).toHaveLength(1);
+        expect(deleteCalls[0]?.table).toBe(scheduleEntries);
+        expect(insertCalls.length).toBeGreaterThan(0);
+    });
+
+    it('inserts one schedule_entries row per planner entry with the right zoneId, date, and depletion fields', async () => {
+        const { db, insertCalls } = createScheduleWriterStub({ entries: ['entry-A', 'entry-B'] });
+        const entries = [
+            buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]),
+            buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
+        ];
+
+        await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04');
+
+        const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
+        expect(entryInserts).toHaveLength(2);
+        expect(entryInserts[0]?.rows[0]).toMatchObject({
+            zoneId: 'zone-001',
+            date: '2026-05-04',
+            appliedDepthMm: 12.0,
+            depletionBeforeMm: 18.5,
+            depletionAfterMm: 0,
+        });
+        expect(entryInserts[1]?.rows[0]).toMatchObject({ date: '2026-05-06' });
+    });
+
+    it('inserts the cycles for each entry referencing the inserted entry id', async () => {
+        const { db, insertCalls } = createScheduleWriterStub({ entries: ['entry-A'] });
+        const entry = buildEntry('2026-05-04', [
+            { startTime: '2026-05-04T05:00:00Z', durationMin: 20 },
+            { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
+        ]);
+
+        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04');
+
+        const cycleInserts = insertCalls.filter(c => c.table === irrigationCycles);
+        expect(cycleInserts).toHaveLength(1);
+        expect(cycleInserts[0]?.rows).toHaveLength(2);
+        expect(cycleInserts[0]?.rows[0]).toMatchObject({
+            scheduleEntryId: 'entry-A',
+            durationMin: 20,
+        });
+        expect(cycleInserts[0]?.rows[0]?.['startTime']).toBeInstanceOf(Date);
+    });
+
+    it('returns each inserted cycle with its generated id, start time, and duration', async () => {
+        const { db } = createScheduleWriterStub({
+            entries: ['entry-A'],
+            cycles: [['cycle-A1', 'cycle-A2']],
+        });
+        const entry = buildEntry('2026-05-04', [
+            { startTime: '2026-05-04T05:00:00Z', durationMin: 20 },
+            { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
+        ]);
+
+        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04');
+
+        expect(result.cycles).toHaveLength(2);
+        expect(result.cycles[0]?.id).toBe('cycle-A1');
+        expect(result.cycles[0]?.durationMin).toBe(20);
+        expect(result.cycles[1]?.id).toBe('cycle-A2');
+        expect(result.cycles[1]?.durationMin).toBe(15);
+    });
+
+    it('still issues the delete and inserts no rows when given an empty entries array', async () => {
+        const { db, deleteCalls, insertCalls } = createScheduleWriterStub();
+
+        const result = await replaceZoneSchedule(db, 'zone-001', [], '2026-05-04');
+
+        expect(deleteCalls).toHaveLength(1);
+        expect(insertCalls).toHaveLength(0);
+        expect(result.cycles).toEqual([]);
+    });
+
+    it('skips cycle inserts when the planner entry has no cycles for the day', async () => {
+        const { db, insertCalls } = createScheduleWriterStub({ entries: ['entry-A'] });
+        const entry = buildEntry('2026-05-04', []);
+
+        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04');
+
+        expect(insertCalls.filter(c => c.table === scheduleEntries)).toHaveLength(1);
+        expect(insertCalls.filter(c => c.table === irrigationCycles)).toHaveLength(0);
+        expect(result.cycles).toEqual([]);
+    });
+});
+
+const NOW_DAEMON = new Date('2026-05-04T12:00:00.000Z');
+
+function buildFutureCycleRow(overrides?: Partial<{
+    cycle: Partial<FutureCycleJoinedRow['cycle']>;
+    scheduleEntry: Partial<FutureCycleJoinedRow['scheduleEntry']>;
+    zone: Partial<FutureCycleJoinedRow['zone']>;
+    site: Partial<FutureCycleJoinedRow['site']>;
+}>): FutureCycleJoinedRow {
+    const base = buildJoinedRow({ zone: overrides?.zone, site: overrides?.site });
+    return {
+        ...base,
+        cycle: {
+            id: 'cycle-001',
+            scheduleEntryId: 'entry-001',
+            startTime: new Date('2026-05-05T05:00:00.000Z'),
+            durationMin: 25,
+            firedAt: null,
+            closedAt: null,
+            createdAt: NOW_DAEMON,
+            updatedAt: NOW_DAEMON,
+            ...overrides?.cycle,
+        },
+        scheduleEntry: {
+            id: 'entry-001',
+            zoneId: base.zone.id,
+            date: '2026-05-05',
+            appliedDepthMm: 12,
+            depletionBeforeMm: 18.5,
+            depletionAfterMm: 0,
+            createdAt: NOW_DAEMON,
+            updatedAt: NOW_DAEMON,
+            ...overrides?.scheduleEntry,
+        },
+    };
+}
+
+function createFutureCyclesStub(rows: FutureCycleJoinedRow[]) {
+    const whereCalls: WhereCall[] = [];
+    let selectColumns: unknown;
+
+    const db: FutureCyclesDb = {
+        select(columns) {
+            selectColumns = columns;
+            return {
+                from() {
+                    return {
+                        innerJoin() {
+                            return {
+                                innerJoin() {
+                                    return {
+                                        innerJoin() {
+                                            return {
+                                                innerJoin() {
+                                                    return {
+                                                        innerJoin() {
+                                                            return {
+                                                                where(conditions) {
+                                                                    whereCalls.push({ conditions });
+                                                                    return Promise.resolve(rows);
+                                                                },
+                                                            };
+                                                        },
+                                                    };
+                                                },
+                                            };
+                                        },
+                                    };
+                                },
+                            };
+                        },
+                    };
+                },
+            };
+        },
+    };
+
+    return { db, whereCalls, getSelectColumns: () => selectColumns };
+}
+
+describe('loadFutureCycles', () => {
+    it('returns mapped (cycle, zone) pairs with the runtime fields the caller needs', async () => {
+        const row = buildFutureCycleRow({
+            cycle: { id: 'cycle-future', durationMin: 30 },
+            zone: { id: 'zone-future', name: 'Future Zone' },
+        });
+        const { db } = createFutureCyclesStub([row]);
+
+        const pairs = await loadFutureCycles(db, NOW_DAEMON);
+
+        expect(pairs).toHaveLength(1);
+        expect(pairs[0]?.cycle.id).toBe('cycle-future');
+        expect(pairs[0]?.cycle.durationMin).toBe(30);
+        expect(pairs[0]?.cycle.startTime).toBeInstanceOf(Date);
+        expect(pairs[0]?.zone.id).toBe('zone-future');
+        expect(pairs[0]?.zone.name).toBe('Future Zone');
+    });
+
+    it('builds the zone with site-fallback location when the zone has none', async () => {
+        const row = buildFutureCycleRow({
+            zone: { latitude: null, longitude: null },
+            site: { latitude: 51.05, longitude: -114.07 },
+        });
+        const { db } = createFutureCyclesStub([row]);
+
+        const pairs = await loadFutureCycles(db, NOW_DAEMON);
+
+        expect(pairs[0]?.zone.location).toEqual({ lat: 51.05, lon: -114.07 });
+    });
+
+    it('passes the standard joined columns to db.select', async () => {
+        const { db, getSelectColumns } = createFutureCyclesStub([]);
+
+        await loadFutureCycles(db, NOW_DAEMON);
+
+        const cols = getSelectColumns() as Record<string, unknown>;
+        expect(cols['cycle']).toBe(irrigationCycles);
+        expect(cols['scheduleEntry']).toBe(scheduleEntries);
+        expect(cols['zone']).toBe(zones);
+        expect(cols['grassType']).toBe(grassTypes);
+        expect(cols['soilType']).toBe(soilTypes);
+        expect(cols['site']).toBe(sites);
+    });
+
+    it('issues exactly one .where(...) call per invocation', async () => {
+        const { db, whereCalls } = createFutureCyclesStub([buildFutureCycleRow()]);
+
+        await loadFutureCycles(db, NOW_DAEMON);
+
+        expect(whereCalls).toHaveLength(1);
+    });
+
+    it('returns an empty array when the query yields no rows', async () => {
+        const { db } = createFutureCyclesStub([]);
+
+        const result = await loadFutureCycles(db, NOW_DAEMON);
 
         expect(result).toEqual([]);
     });

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -1,0 +1,137 @@
+import dayjs from 'dayjs';
+import { closeZone as defaultCloseZone, openZone as defaultOpenZone } from '@/data/home-assistant';
+import type { IrrigationScheduleEntry, Zone } from '@/models';
+import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
+import { loadFutureCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
+import { armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
+import { loadEnabledZones, type ZoneLoaderDb } from './zones';
+
+const DEFAULT_REPLAN_HOUR_LOCAL = 4;
+
+/**
+ * Composite db type the daemon needs across its helpers. Production callers
+ * pass the eager `db` export from `@/db`; tests pass a recording stub that
+ * implements the union of the smaller per-helper interfaces.
+ */
+export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb;
+
+/**
+ * Caller-overridable hooks. Defaults wire to the real planning function and
+ * the real Home Assistant client. The clock defaults to `realClock`.
+ */
+export type DaemonOptions = {
+    /** Local hour at which the daily re-plan fires. Default 4. */
+    rePlanHourLocal?: number;
+
+    /** Planner override. Defaults to the real `runScheduleForZone`. */
+    runPlan?: (zone: Zone, options?: RunScheduleForZoneOptions) => Promise<IrrigationScheduleEntry[]>;
+
+    /** Override the HA open-relay primitive. */
+    openZone?: (zone: Zone) => Promise<void>;
+
+    /** Override the HA close-relay primitive. */
+    closeZone?: (zone: Zone) => Promise<void>;
+
+    /** Override for time/timer access. */
+    clock?: Clock;
+};
+
+/**
+ * Control surface returned from `start`. Lets the unified entrypoint (and
+ * tests) drive the daemon without reaching into its internals.
+ */
+export type DaemonControl = {
+    /** Forces an immediate re-plan + arm cycle. */
+    rePlan: () => Promise<void>;
+
+    /** Cancels all timers and closes any in-flight relay. */
+    shutdown: () => Promise<void>;
+};
+
+/**
+ * Boots the daemon: arms whatever future cycles already exist in the DB and
+ * schedules the next daily re-plan. Does **not** trigger an immediate re-plan
+ * — bootstrapping a fresh DB requires either waiting for the configured hour
+ * or calling `rePlan()` on the returned control handle.
+ *
+ * @param db - Daemon-compatible Drizzle client.
+ * @param options - Overrides for hooks, hour, or clock.
+ * @returns Control handle for forcing re-plan or shutting down.
+ */
+export async function start(db: DaemonDb, options?: DaemonOptions): Promise<DaemonControl> {
+    const clock = options?.clock ?? realClock;
+    const rePlanHourLocal = options?.rePlanHourLocal ?? DEFAULT_REPLAN_HOUR_LOCAL;
+    const runPlan = options?.runPlan ?? ((zone, opts) => runScheduleForZone(zone, opts));
+    const openZone = options?.openZone ?? defaultOpenZone;
+    const closeZone = options?.closeZone ?? defaultCloseZone;
+
+    const registry = new TimerRegistry();
+
+    console.log(`daemon: starting (re-plan hour: ${rePlanHourLocal}:00 local).`);
+
+    const futureCycles = await loadFutureCycles(db, clock.now());
+    for (const { cycle, zone } of futureCycles) {
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+    }
+
+    const scheduleNextRePlan = (): void => {
+        const next = computeNextRePlanAt(clock.now(), rePlanHourLocal);
+        const delay = Math.max(0, next.getTime() - clock.now().getTime());
+        console.log(`daemon: next re-plan scheduled at ${next.toISOString()} (${delay}ms from now).`);
+        const handle = clock.setTimeout(() => {
+            rePlan().catch(err => {
+                console.error('daemon: unhandled error in scheduled re-plan.', err);
+            });
+        }, delay);
+        registry.setRePlanHandle(handle);
+    };
+
+    const rePlan = async (): Promise<void> => {
+        console.log('daemon: re-plan starting.');
+        registry.cancelOpenTimers(clock);
+
+        const enabledZones = await loadEnabledZones(db);
+        const today = dayjs(clock.now()).format('YYYY-MM-DD');
+
+        for (const zone of enabledZones) {
+            try {
+                const entries = await runPlan(zone);
+                const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today);
+                for (const cycle of cycles) {
+                    armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+                }
+            } catch (err) {
+                console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
+            }
+        }
+
+        scheduleNextRePlan();
+        console.log('daemon: re-plan complete.');
+    };
+
+    const shutdown = async (): Promise<void> => {
+        console.log('daemon: shutdown starting.');
+        registry.cancelAllTimers(clock);
+        await closeAllInFlight({ db, clock, registry, closeZone });
+        console.log('daemon: shutdown complete.');
+    };
+
+    scheduleNextRePlan();
+
+    return { rePlan, shutdown };
+}
+
+/**
+ * Returns the next wall-clock occurrence of `hourLocal:00` after `now`. Pure
+ * function exported so the scheduling math is unit-testable directly.
+ *
+ * @param now - Current time.
+ * @param hourLocal - Target hour-of-day (0-23) in the system local timezone.
+ * @returns The next Date at which the hour rolls over.
+ */
+export function computeNextRePlanAt(now: Date, hourLocal: number): Date {
+    const ref = dayjs(now);
+    const todayAtHour = ref.hour(hourLocal).minute(0).second(0).millisecond(0);
+    const next = todayAtHour.isAfter(ref) ? todayAtHour : todayAtHour.add(1, 'day');
+    return next.toDate();
+}

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -1,0 +1,224 @@
+import { eq } from 'drizzle-orm';
+import { irrigationCycles } from '@/db/schema';
+import type { Zone } from '@/models';
+import type { PersistedCycle } from './schedules';
+
+/**
+ * Opaque handle returned by `Clock.setTimeout`. The runtime doesn't introspect
+ * it — production wiring uses Node's setTimeout which returns a Timeout
+ * object, while tests use numeric handles.
+ */
+export type TimerHandle = unknown;
+
+/**
+ * Abstraction over time-related globals so the daemon's timing can be driven
+ * deterministically in tests. Production wiring is the `realClock` below.
+ */
+export type Clock = {
+    /** Returns the current wall-clock time. */
+    now: () => Date;
+
+    /** Schedules `cb` to run after `ms` milliseconds and returns a cancel handle. */
+    setTimeout: (cb: () => void, ms: number) => TimerHandle;
+
+    /** Cancels a previously-scheduled timer. */
+    clearTimeout: (handle: TimerHandle) => void;
+};
+
+/**
+ * Production `Clock` implementation backed by the host JS runtime.
+ */
+export const realClock: Clock = {
+    now: () => new Date(),
+    setTimeout: (cb, ms) => globalThis.setTimeout(cb, ms),
+    clearTimeout: (handle) => globalThis.clearTimeout(handle as Parameters<typeof globalThis.clearTimeout>[0]),
+};
+
+/**
+ * Tracks timers and in-flight cycles so the daemon can tear things down in
+ * the right order on `rePlan` and `shutdown`. Two slots:
+ *
+ * - `openHandles`: setTimeout handles for cycles whose open hasn't fired yet.
+ * - `inFlight`: cycles whose open succeeded but whose close timer is still
+ *   pending — they have an active relay in HA.
+ */
+export class TimerRegistry {
+    private readonly openHandles = new Set<TimerHandle>();
+    private readonly inFlight = new Map<string, { zone: Zone; closeHandle: TimerHandle }>();
+    private rePlanHandle: TimerHandle | undefined;
+
+    addOpen(handle: TimerHandle): void {
+        this.openHandles.add(handle);
+    }
+
+    consumeOpen(handle: TimerHandle): void {
+        this.openHandles.delete(handle);
+    }
+
+    addInFlight(cycleId: string, zone: Zone, closeHandle: TimerHandle): void {
+        this.inFlight.set(cycleId, { zone, closeHandle });
+    }
+
+    clearInFlight(cycleId: string): void {
+        this.inFlight.delete(cycleId);
+    }
+
+    setRePlanHandle(handle: TimerHandle | undefined): void {
+        this.rePlanHandle = handle;
+    }
+
+    /**
+     * Cancels every pending open timer. Leaves in-flight cycles alone so a
+     * watering cycle that's already running can finish before the new plan
+     * takes over.
+     */
+    cancelOpenTimers(clock: Clock): void {
+        for (const handle of this.openHandles) clock.clearTimeout(handle);
+        this.openHandles.clear();
+    }
+
+    /**
+     * Cancels every timer the daemon owns: open, close, and the next-re-plan
+     * timer. Used by `shutdown`. The caller is responsible for closing any
+     * in-flight relays before clearing them from the registry.
+     */
+    cancelAllTimers(clock: Clock): void {
+        this.cancelOpenTimers(clock);
+        for (const { closeHandle } of this.inFlight.values()) clock.clearTimeout(closeHandle);
+        if (this.rePlanHandle !== undefined) {
+            clock.clearTimeout(this.rePlanHandle);
+            this.rePlanHandle = undefined;
+        }
+    }
+
+    snapshotInFlight(): ReadonlyArray<{ cycleId: string; zone: Zone }> {
+        return [...this.inFlight.entries()].map(([cycleId, value]) => ({ cycleId, zone: value.zone }));
+    }
+}
+
+/**
+ * Minimal db interface for cycle-row updates. Mirrors Drizzle's
+ * `update().set().where()` chain.
+ */
+export type RuntimeDb = {
+    update: (table: typeof irrigationCycles) => {
+        set: (values: Record<string, unknown>) => {
+            where: (cond: unknown) => Promise<unknown>;
+        };
+    };
+};
+
+/**
+ * Inputs to `armCycle` — every external collaborator is injected so tests can
+ * substitute deterministic stubs.
+ */
+export type ArmCycleInputs = {
+    db: RuntimeDb;
+    clock: Clock;
+    registry: TimerRegistry;
+    zone: Zone;
+    cycle: PersistedCycle;
+    openZone: (zone: Zone) => Promise<void>;
+    closeZone: (zone: Zone) => Promise<void>;
+};
+
+/**
+ * Schedules the open-then-close lifecycle for a single irrigation cycle.
+ * Records `fired_at` after a successful open; chains a close timer for
+ * `durationMin * 60_000` ms; records `closed_at` after a successful close.
+ * Failures at either step log to console.error and leave the corresponding
+ * column NULL — the daemon never re-fires a failed cycle.
+ *
+ * @param inputs - Collaborators and the cycle/zone being armed.
+ */
+export function armCycle(inputs: ArmCycleInputs): void {
+    const { clock, registry, cycle } = inputs;
+    const openDelay = Math.max(0, cycle.startTime.getTime() - clock.now().getTime());
+
+    let openHandle: TimerHandle;
+    openHandle = clock.setTimeout(() => {
+        registry.consumeOpen(openHandle);
+        runOpen(inputs).catch(err => {
+            console.error(`daemon: unhandled error in cycle open path for ${cycle.id}.`, err);
+        });
+    }, openDelay);
+    registry.addOpen(openHandle);
+}
+
+async function runOpen(inputs: ArmCycleInputs): Promise<void> {
+    const { db, clock, registry, zone, cycle, openZone, closeZone } = inputs;
+
+    try {
+        await openZone(zone);
+    } catch (err) {
+        console.error(`daemon: openZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving fired_at NULL.`, err);
+        return;
+    }
+
+    const firedAt = clock.now();
+    await db.update(irrigationCycles).set({ firedAt }).where(eq(irrigationCycles.id, cycle.id));
+    console.log(`daemon: opened zone ${zone.id} for cycle ${cycle.id} at ${firedAt.toISOString()}.`);
+
+    const closeDelay = cycle.durationMin * 60_000;
+    const closeHandle = clock.setTimeout(() => {
+        runClose({ db, clock, registry, zone, cycle, closeZone }).catch(err => {
+            console.error(`daemon: unhandled error in cycle close path for ${cycle.id}.`, err);
+        });
+    }, closeDelay);
+    registry.addInFlight(cycle.id, zone, closeHandle);
+}
+
+type RunCloseInputs = {
+    db: RuntimeDb;
+    clock: Clock;
+    registry: TimerRegistry;
+    zone: Zone;
+    cycle: PersistedCycle;
+    closeZone: (zone: Zone) => Promise<void>;
+};
+
+async function runClose(inputs: RunCloseInputs): Promise<void> {
+    const { db, clock, registry, zone, cycle, closeZone } = inputs;
+
+    try {
+        await closeZone(zone);
+    } catch (err) {
+        console.error(`daemon: closeZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving closed_at NULL.`, err);
+        registry.clearInFlight(cycle.id);
+        return;
+    }
+
+    const closedAt = clock.now();
+    await db.update(irrigationCycles).set({ closedAt }).where(eq(irrigationCycles.id, cycle.id));
+    registry.clearInFlight(cycle.id);
+    console.log(`daemon: closed zone ${zone.id} for cycle ${cycle.id} at ${closedAt.toISOString()}.`);
+}
+
+/**
+ * Closes every relay the daemon currently has marked in-flight. Used by
+ * `shutdown`. Caller must have cancelled the close timers via
+ * `registry.cancelAllTimers` first; this function only does the close + DB
+ * update side. Tolerates `closeZone` failures (logs and continues).
+ */
+export async function closeAllInFlight(inputs: {
+    db: RuntimeDb;
+    clock: Clock;
+    registry: TimerRegistry;
+    closeZone: (zone: Zone) => Promise<void>;
+}): Promise<void> {
+    const { db, clock, registry, closeZone } = inputs;
+    const inFlight = registry.snapshotInFlight();
+
+    if (inFlight.length === 0) return;
+    console.log(`daemon: closing ${inFlight.length} in-flight relay(s) on shutdown.`);
+
+    for (const { cycleId, zone } of inFlight) {
+        try {
+            await closeZone(zone);
+            await db.update(irrigationCycles).set({ closedAt: clock.now() }).where(eq(irrigationCycles.id, cycleId));
+        } catch (err) {
+            console.error(`daemon: shutdown closeZone failed for cycle ${cycleId} on zone ${zone.id}.`, err);
+        }
+        registry.clearInFlight(cycleId);
+    }
+}

--- a/api/daemon/schedules.ts
+++ b/api/daemon/schedules.ts
@@ -8,7 +8,7 @@ import {
     zones,
 } from '@/db/schema';
 import type { IrrigationScheduleEntry, Zone } from '@/models';
-import { joinedRowToZone, type ZoneJoinedRow } from './zones';
+import { joinedRowToZone, type SelectJoinChain, type ZoneJoinedRow } from './zones';
 
 /**
  * Compact representation of an inserted irrigation cycle, scoped to what the
@@ -138,8 +138,8 @@ export type FutureCyclePair = {
 };
 
 /**
- * Minimal db interface for `loadFutureCycles`. Mirrors the chained
- * `select().from().innerJoin()*5.where()` call.
+ * Minimal db interface for `loadFutureCycles`. Mirrors the chained Drizzle
+ * select-with-joins query.
  */
 export type FutureCyclesDb = {
     select: (columns: {
@@ -150,19 +150,7 @@ export type FutureCyclesDb = {
         soilType: typeof soilTypes;
         site: typeof sites;
     }) => {
-        from: (table: typeof irrigationCycles) => {
-            innerJoin: (table: unknown, on: unknown) => {
-                innerJoin: (table: unknown, on: unknown) => {
-                    innerJoin: (table: unknown, on: unknown) => {
-                        innerJoin: (table: unknown, on: unknown) => {
-                            innerJoin: (table: unknown, on: unknown) => {
-                                where: (cond: unknown) => Promise<FutureCycleJoinedRow[]>;
-                            };
-                        };
-                    };
-                };
-            };
-        };
+        from: (table: typeof irrigationCycles) => SelectJoinChain<FutureCycleJoinedRow>;
     };
 };
 

--- a/api/daemon/schedules.ts
+++ b/api/daemon/schedules.ts
@@ -1,0 +1,221 @@
+import { and, eq, gt, gte, isNull } from 'drizzle-orm';
+import {
+    grassTypes,
+    irrigationCycles,
+    scheduleEntries,
+    sites,
+    soilTypes,
+    zones,
+} from '@/db/schema';
+import type { IrrigationScheduleEntry, Zone } from '@/models';
+import { joinedRowToZone, type ZoneJoinedRow } from './zones';
+
+/**
+ * Compact representation of an inserted irrigation cycle, scoped to what the
+ * runtime needs to arm timers and update the row on fire/close.
+ */
+export type PersistedCycle = {
+    id: string;
+    startTime: Date;
+    durationMin: number;
+};
+
+/**
+ * Per-zone return value from `replaceZoneSchedule`: the inserted cycles in
+ * chronological order, ready for the runtime to arm.
+ */
+export type PersistedScheduleResult = {
+    cycles: PersistedCycle[];
+};
+
+/**
+ * Minimal db interface for `replaceZoneSchedule`. Mirrors Drizzle's `delete()`
+ * and `insert().values().returning()` chains so a recording stub can stand in
+ * for tests.
+ */
+export type ScheduleWriterDb = {
+    delete: (table: typeof scheduleEntries) => {
+        where: (cond: unknown) => Promise<unknown>;
+    };
+    insert: (table: typeof scheduleEntries | typeof irrigationCycles) => {
+        values: (rows: ReadonlyArray<Record<string, unknown>>) => {
+            returning: (cols: Record<string, unknown>) => Promise<Array<Record<string, unknown>>>;
+        };
+    };
+};
+
+/**
+ * Replaces today's-and-future schedule_entries for a zone with the planner's
+ * fresh output, cascading future cycles through the FK delete. Past entries
+ * (date < today) are left untouched for history.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param zoneId - The zone whose schedule is being replaced.
+ * @param entries - Planner output for the next forecast window.
+ * @param today - Local date string in YYYY-MM-DD; entries on this date and
+ *   later are deleted before re-insert.
+ * @returns The inserted cycles in input order, ready for arming.
+ */
+export async function replaceZoneSchedule(
+    db: ScheduleWriterDb,
+    zoneId: string,
+    entries: ReadonlyArray<IrrigationScheduleEntry>,
+    today: string,
+): Promise<PersistedScheduleResult> {
+    console.log(`daemon: replacing schedule for zone ${zoneId} from ${today} (${entries.length} entry/entries).`);
+
+    await db
+        .delete(scheduleEntries)
+        .where(and(eq(scheduleEntries.zoneId, zoneId), gte(scheduleEntries.date, today)));
+
+    const persisted: PersistedCycle[] = [];
+
+    for (const entry of entries) {
+        const inserted = await db
+            .insert(scheduleEntries)
+            .values([
+                {
+                    zoneId,
+                    date: entry.date.format('YYYY-MM-DD'),
+                    appliedDepthMm: entry.appliedDepthMm,
+                    depletionBeforeMm: entry.depletionBeforeMm,
+                    depletionAfterMm: entry.depletionAfterMm,
+                },
+            ])
+            .returning({ id: scheduleEntries.id });
+
+        const entryId = (inserted[0] as { id: string } | undefined)?.id;
+        if (!entryId) {
+            console.warn(`daemon: schedule_entries insert returned no id for zone ${zoneId} on ${entry.date.format('YYYY-MM-DD')}; skipping cycles.`);
+            continue;
+        }
+
+        if (entry.cycles.length === 0) continue;
+
+        const cycleRows = entry.cycles.map(cycle => ({
+            scheduleEntryId: entryId,
+            startTime: cycle.startTime.toDate(),
+            durationMin: cycle.durationMin,
+        }));
+
+        const insertedCycles = await db
+            .insert(irrigationCycles)
+            .values(cycleRows)
+            .returning({
+                id: irrigationCycles.id,
+                startTime: irrigationCycles.startTime,
+                durationMin: irrigationCycles.durationMin,
+            });
+
+        for (const row of insertedCycles) {
+            persisted.push({
+                id: row['id'] as string,
+                startTime: row['startTime'] as Date,
+                durationMin: row['durationMin'] as number,
+            });
+        }
+    }
+
+    return { cycles: persisted };
+}
+
+/**
+ * Joined row produced by the future-cycles query. Carries every column needed
+ * to rebuild a `Zone` plus the cycle's own runtime fields.
+ */
+export type FutureCycleJoinedRow = {
+    cycle: typeof irrigationCycles.$inferSelect;
+    scheduleEntry: typeof scheduleEntries.$inferSelect;
+} & ZoneJoinedRow;
+
+/**
+ * Pair returned by `loadFutureCycles`: a runtime-ready cycle plus the fully-
+ * formed zone it belongs to.
+ */
+export type FutureCyclePair = {
+    cycle: PersistedCycle;
+    zone: Zone;
+};
+
+/**
+ * Minimal db interface for `loadFutureCycles`. Mirrors the chained
+ * `select().from().innerJoin()*5.where()` call.
+ */
+export type FutureCyclesDb = {
+    select: (columns: {
+        cycle: typeof irrigationCycles;
+        scheduleEntry: typeof scheduleEntries;
+        zone: typeof zones;
+        grassType: typeof grassTypes;
+        soilType: typeof soilTypes;
+        site: typeof sites;
+    }) => {
+        from: (table: typeof irrigationCycles) => {
+            innerJoin: (table: unknown, on: unknown) => {
+                innerJoin: (table: unknown, on: unknown) => {
+                    innerJoin: (table: unknown, on: unknown) => {
+                        innerJoin: (table: unknown, on: unknown) => {
+                            innerJoin: (table: unknown, on: unknown) => {
+                                where: (cond: unknown) => Promise<FutureCycleJoinedRow[]>;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+};
+
+/**
+ * Reads every cycle that hasn't fired yet and whose `start_time` is still in
+ * the future, paired with the fully-formed enabled zone it belongs to. Used at
+ * daemon startup to arm timers for cycles that survived a previous run.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param now - Reference time. Cycles with `start_time > now` are returned.
+ * @returns Pairs of (cycle, zone) ready for the runtime to arm.
+ */
+export async function loadFutureCycles(db: FutureCyclesDb, now: Date): Promise<FutureCyclePair[]> {
+    const rows = await db
+        .select({
+            cycle: irrigationCycles,
+            scheduleEntry: scheduleEntries,
+            zone: zones,
+            grassType: grassTypes,
+            soilType: soilTypes,
+            site: sites,
+        })
+        .from(irrigationCycles)
+        .innerJoin(scheduleEntries, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+        .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+        .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
+        .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
+        .innerJoin(sites, eq(zones.siteId, sites.id))
+        .where(
+            and(
+                isNull(irrigationCycles.firedAt),
+                gt(irrigationCycles.startTime, now),
+                eq(zones.isEnabled, true),
+            ),
+        );
+
+    const pairs = rows.map(row => mapFutureCycleRow(row));
+    console.log(`daemon: loaded ${pairs.length} future cycle(s).`);
+    return pairs;
+}
+
+function mapFutureCycleRow(row: FutureCycleJoinedRow): FutureCyclePair {
+    return {
+        cycle: {
+            id: row.cycle.id,
+            startTime: row.cycle.startTime,
+            durationMin: row.cycle.durationMin,
+        },
+        zone: joinedRowToZone({
+            zone: row.zone,
+            grassType: row.grassType,
+            soilType: row.soilType,
+            site: row.site,
+        }),
+    };
+}

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -1,0 +1,103 @@
+import { eq } from 'drizzle-orm';
+import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
+import type { Zone } from '@/models';
+
+/**
+ * Shape of a single row produced by the zones × grass_types × soil_types ×
+ * sites join used by the daemon's zone loader.
+ */
+export type ZoneJoinedRow = {
+    zone: typeof zones.$inferSelect;
+    grassType: typeof grassTypes.$inferSelect;
+    soilType: typeof soilTypes.$inferSelect;
+    site: typeof sites.$inferSelect;
+};
+
+/**
+ * Minimal db interface needed by `loadEnabledZones` — mirrors the chained
+ * Drizzle `select()` call. Production callers pass the real db; tests pass a
+ * recording stub. The chain stays untyped beyond the surface shape because we
+ * only care that the call sequence matches what Drizzle expects at runtime.
+ */
+export type ZoneLoaderDb = {
+    select: (columns: {
+        zone: typeof zones;
+        grassType: typeof grassTypes;
+        soilType: typeof soilTypes;
+        site: typeof sites;
+    }) => {
+        from: (table: typeof zones) => {
+            innerJoin: (table: unknown, on: unknown) => {
+                innerJoin: (table: unknown, on: unknown) => {
+                    innerJoin: (table: unknown, on: unknown) => {
+                        where: (cond: unknown) => Promise<ZoneJoinedRow[]>;
+                    };
+                };
+            };
+        };
+    };
+};
+
+/**
+ * Loads every enabled zone from the database with its grass type, soil type,
+ * and site joined in. Returns fully-formed `Zone` models suitable for handing
+ * directly to `runScheduleForZone`. Falls back to the site's lat/lon when the
+ * zone has no coordinates of its own.
+ *
+ * @param db - Drizzle client (or a compatible stub).
+ * @returns Array of enabled zones with embedded grass/soil/location.
+ */
+export async function loadEnabledZones(db: ZoneLoaderDb): Promise<Zone[]> {
+    const rows = await db
+        .select({ zone: zones, grassType: grassTypes, soilType: soilTypes, site: sites })
+        .from(zones)
+        .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
+        .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
+        .innerJoin(sites, eq(zones.siteId, sites.id))
+        .where(eq(zones.isEnabled, true));
+
+    const result = mapJoinedRowsToZones(rows);
+    console.log(`daemon: loaded ${result.length} enabled zone(s).`);
+    return result;
+}
+
+/**
+ * Pure mapping function: filters disabled rows and turns each joined row into
+ * a fully-formed `Zone` with embedded grass type, soil type, and resolved
+ * location. Tested directly to keep coverage tight without involving Drizzle.
+ *
+ * @param rows - Joined rows.
+ * @returns Mapped, enabled-only zones in the same order as the input.
+ */
+export function mapJoinedRowsToZones(rows: ReadonlyArray<ZoneJoinedRow>): Zone[] {
+    return rows.filter(row => row.zone.isEnabled !== false).map(mapJoinedRowToZone);
+}
+
+function mapJoinedRowToZone(row: ZoneJoinedRow): Zone {
+    const lat = row.zone.latitude ?? row.site.latitude,
+        lon = row.zone.longitude ?? row.site.longitude;
+
+    return {
+        id: row.zone.id,
+        name: row.zone.name,
+        grassType: {
+            name: row.grassType.name,
+            cropCoefficient: row.grassType.cropCoefficient,
+        },
+        soil: {
+            name: row.soilType.name,
+            availableWaterHoldingCapacityMmPerM: row.soilType.availableWaterHoldingCapacityMmPerM,
+            infiltrationRateMmPerHr: row.soilType.infiltrationRateMmPerHr,
+        },
+        rootDepthM: row.zone.rootDepthM,
+        allowableDepletionFraction: row.zone.allowableDepletionFraction,
+        irrigationEfficiency: row.zone.irrigationEfficiency,
+        flowRateLPerMin: row.zone.flowRateLPerMin,
+        areaM2: row.zone.areaM2,
+        precipitationRateMmPerHr: row.zone.precipitationRateMmPerHr ?? undefined,
+        currentDepletionMm: row.zone.currentDepletionMm,
+        isEnabled: row.zone.isEnabled,
+        location: { lat, lon },
+        homeAssistantEntityId: row.zone.homeAssistantEntityId ?? undefined,
+    };
+}

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -70,10 +70,18 @@ export async function loadEnabledZones(db: ZoneLoaderDb): Promise<Zone[]> {
  * @returns Mapped, enabled-only zones in the same order as the input.
  */
 export function mapJoinedRowsToZones(rows: ReadonlyArray<ZoneJoinedRow>): Zone[] {
-    return rows.filter(row => row.zone.isEnabled !== false).map(mapJoinedRowToZone);
+    return rows.filter(row => row.zone.isEnabled !== false).map(joinedRowToZone);
 }
 
-function mapJoinedRowToZone(row: ZoneJoinedRow): Zone {
+/**
+ * Maps a single joined row into a `Zone` model. Exported so other daemon
+ * helpers (e.g. the future-cycles loader) can reuse the same shaping without
+ * duplicating the field-by-field mapping.
+ *
+ * @param row - Joined row.
+ * @returns A fully-formed Zone.
+ */
+export function joinedRowToZone(row: ZoneJoinedRow): Zone {
     const lat = row.zone.latitude ?? row.site.latitude,
         lon = row.zone.longitude ?? row.site.longitude;
 

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -14,10 +14,18 @@ export type ZoneJoinedRow = {
 };
 
 /**
- * Minimal db interface needed by `loadEnabledZones` — mirrors the chained
- * Drizzle `select()` call. Production callers pass the real db; tests pass a
- * recording stub. The chain stays untyped beyond the surface shape because we
- * only care that the call sequence matches what Drizzle expects at runtime.
+ * Recursive view of Drizzle's chained select-with-joins query. Each inner
+ * join returns the same shape, so any number of joins can be added. The
+ * chain terminates at `where(...)` which yields the typed result rows.
+ */
+export type SelectJoinChain<TRow> = {
+    innerJoin: (table: unknown, on: unknown) => SelectJoinChain<TRow>;
+    where: (cond: unknown) => Promise<TRow[]>;
+};
+
+/**
+ * Minimal db interface needed by `loadEnabledZones`. Production callers pass
+ * the real Drizzle `db`; tests pass a recording stub.
  */
 export type ZoneLoaderDb = {
     select: (columns: {
@@ -26,15 +34,7 @@ export type ZoneLoaderDb = {
         soilType: typeof soilTypes;
         site: typeof sites;
     }) => {
-        from: (table: typeof zones) => {
-            innerJoin: (table: unknown, on: unknown) => {
-                innerJoin: (table: unknown, on: unknown) => {
-                    innerJoin: (table: unknown, on: unknown) => {
-                        where: (cond: unknown) => Promise<ZoneJoinedRow[]>;
-                    };
-                };
-            };
-        };
+        from: (table: typeof zones) => SelectJoinChain<ZoneJoinedRow>;
     };
 };
 

--- a/api/db/schema/.test.ts
+++ b/api/db/schema/.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'bun:test';
 import { getTableConfig } from 'drizzle-orm/pg-core';
-import { grassTypes, sites, soilTypes, zones } from '.';
+import { grassTypes, irrigationCycles, scheduleEntries, sites, soilTypes, zones } from '.';
 
 function columnsByName(table: Parameters<typeof getTableConfig>[0]) {
     const config = getTableConfig(table);
@@ -104,4 +104,65 @@ test('zones foreign keys reference the right parent tables', () => {
     expect(siteFk?.to).toBe(sites);
     expect(grassFk?.to).toBe(grassTypes);
     expect(soilFk?.to).toBe(soilTypes);
+});
+
+test('schedule_entries table has the expected columns and constraints', () => {
+    const config = getTableConfig(scheduleEntries);
+    const columns = columnsByName(scheduleEntries);
+
+    expect(config.name).toBe('schedule_entries');
+    expect(columns['id']?.primary).toBe(true);
+    expect(columns['id']?.hasDefault).toBe(true);
+    expect(columns['zone_id']?.notNull).toBe(true);
+    expect(columns['date']?.notNull).toBe(true);
+    expect(columns['date']?.columnType).toBe('PgDateString');
+    expect(columns['applied_depth_mm']?.notNull).toBe(true);
+    expect(columns['applied_depth_mm']?.columnType).toBe('PgReal');
+    expect(columns['depletion_before_mm']?.notNull).toBe(true);
+    expect(columns['depletion_after_mm']?.notNull).toBe(true);
+    expect(columns['created_at']?.notNull).toBe(true);
+    expect(columns['updated_at']?.notNull).toBe(true);
+});
+
+test('schedule_entries foreign key references zones', () => {
+    const config = getTableConfig(scheduleEntries);
+    const fkTargets = config.foreignKeys.map(fk => {
+        const reference = fk.reference();
+        return {
+            from: reference.columns.map(c => c.name),
+            to: reference.foreignTable,
+        };
+    });
+
+    const zoneFk = fkTargets.find(fk => fk.from.includes('zone_id'));
+    expect(zoneFk?.to).toBe(zones);
+});
+
+test('irrigation_cycles table has the expected columns and constraints', () => {
+    const config = getTableConfig(irrigationCycles);
+    const columns = columnsByName(irrigationCycles);
+
+    expect(config.name).toBe('irrigation_cycles');
+    expect(columns['id']?.primary).toBe(true);
+    expect(columns['id']?.hasDefault).toBe(true);
+    expect(columns['schedule_entry_id']?.notNull).toBe(true);
+    expect(columns['start_time']?.notNull).toBe(true);
+    expect(columns['start_time']?.columnType).toBe('PgTimestamp');
+    expect(columns['duration_min']?.notNull).toBe(true);
+    expect(columns['duration_min']?.columnType).toBe('PgReal');
+    expect(columns['fired_at']?.notNull).toBe(false);
+    expect(columns['closed_at']?.notNull).toBe(false);
+    expect(columns['created_at']?.notNull).toBe(true);
+    expect(columns['updated_at']?.notNull).toBe(true);
+});
+
+test('irrigation_cycles foreign key cascades on schedule_entry delete', () => {
+    const config = getTableConfig(irrigationCycles);
+    const fk = config.foreignKeys[0];
+
+    expect(fk).toBeDefined();
+    const reference = fk!.reference();
+    expect(reference.columns.map(c => c.name)).toContain('schedule_entry_id');
+    expect(reference.foreignTable).toBe(scheduleEntries);
+    expect(fk!.onDelete).toBe('cascade');
 });

--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -1,4 +1,6 @@
 export { grassTypes } from './grass-types';
+export { irrigationCycles } from './irrigation-cycles';
+export { scheduleEntries } from './schedule-entries';
 export { sites } from './sites';
 export { soilTypes } from './soil-types';
 export { zones } from './zones';

--- a/api/db/schema/irrigation-cycles.ts
+++ b/api/db/schema/irrigation-cycles.ts
@@ -1,0 +1,15 @@
+import { pgTable, real, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+import { scheduleEntries } from './schedule-entries';
+
+export const irrigationCycles = pgTable('irrigation_cycles', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    scheduleEntryId: uuid('schedule_entry_id')
+        .notNull()
+        .references(() => scheduleEntries.id, { onDelete: 'cascade' }),
+    startTime: timestamp('start_time', { withTimezone: true }).notNull(),
+    durationMin: real('duration_min').notNull(),
+    firedAt: timestamp('fired_at', { withTimezone: true }),
+    closedAt: timestamp('closed_at', { withTimezone: true }),
+    ...auditColumns,
+});

--- a/api/db/schema/schedule-entries.ts
+++ b/api/db/schema/schedule-entries.ts
@@ -1,0 +1,13 @@
+import { date, pgTable, real, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+import { zones } from './zones';
+
+export const scheduleEntries = pgTable('schedule_entries', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    zoneId: uuid('zone_id').notNull().references(() => zones.id),
+    date: date('date').notNull(),
+    appliedDepthMm: real('applied_depth_mm').notNull(),
+    depletionBeforeMm: real('depletion_before_mm').notNull(),
+    depletionAfterMm: real('depletion_after_mm').notNull(),
+    ...auditColumns,
+});

--- a/api/drizzle/0001_robust_jigsaw.sql
+++ b/api/drizzle/0001_robust_jigsaw.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "irrigation_cycles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"schedule_entry_id" uuid NOT NULL,
+	"start_time" timestamp with time zone NOT NULL,
+	"duration_min" real NOT NULL,
+	"fired_at" timestamp with time zone,
+	"closed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "schedule_entries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"zone_id" uuid NOT NULL,
+	"date" date NOT NULL,
+	"applied_depth_mm" real NOT NULL,
+	"depletion_before_mm" real NOT NULL,
+	"depletion_after_mm" real NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "irrigation_cycles" ADD CONSTRAINT "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk" FOREIGN KEY ("schedule_entry_id") REFERENCES "public"."schedule_entries"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "schedule_entries" ADD CONSTRAINT "schedule_entries_zone_id_zones_id_fk" FOREIGN KEY ("zone_id") REFERENCES "public"."zones"("id") ON DELETE no action ON UPDATE no action;

--- a/api/drizzle/meta/0001_snapshot.json
+++ b/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,559 @@
+{
+  "id": "bcb67bef-049e-437b-9f87-1a27d8692090",
+  "prevId": "fac6799f-d3d6-44cc-8a22-ff3f803dd556",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777901011548,
       "tag": "0000_ambiguous_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777945136892,
+      "tag": "0001_robust_jigsaw",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Ticket

[API-3](http://192.168.2.100:7123/irrigo/browse/API-3/) — Daemon for daily re-planning and schedule execution.

## Summary

- Adds the `schedule_entries` and `irrigation_cycles` tables (drizzle migration `0001_robust_jigsaw.sql`); cycles cascade-delete with their parent entry.
- Adds `api/daemon/` with four focused modules:
  - `zones.ts` — `loadEnabledZones` joins zones with grass/soil/site, falls back to site lat/lon when the zone has none.
  - `schedules.ts` — `replaceZoneSchedule` replaces today-and-future entries for a zone (cascading cycles); `loadFutureCycles` arms startup from the DB.
  - `runtime.ts` — `Clock` abstraction, `TimerRegistry`, `armCycle` (open → record fired_at → schedule close → record closed_at), `closeAllInFlight` for shutdown. HA failures leave the relevant column NULL and continue.
  - `index.ts` — `start(db, options)` orchestrator returning a `DaemonControl` with `rePlan` and `shutdown`. Daily re-plan fires at the configured local hour (default 04:00). In-flight cycles survive `rePlan` per the design note.
- All external collaborators (db, planner, HA client, clock) are injectable; tests use a deterministic fake clock and recording stubs. 41 daemon tests cover loader mapping, persistence, cycle execution, retry/no-retry semantics, and the orchestration flow.
- Per the ticket scope, this PR does **not** wire `start()` into `api/index.ts` — that's the unified-entrypoint ticket (API-7).