### PR TITLE
[API-8] Plumb HA env vars through docker-compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,16 @@ Irrigation control system. The repo contains:
 - **`app/`** — Expo / React Native client (NativeWind, Jest).
 - **`shared/`** — Code shared between `api` and `app`. See `shared/CLAUDE.md` for code style conventions.
 
+## Local development
+
+First-time setup for the `api/` stack:
+
+1. `cp api/.env.example api/.env` — Docker Compose loads `.env` from the directory containing the compose file, so the file must live at `api/.env`.
+2. Edit `api/.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them.
+3. From `api/`, bring the stack up: `docker compose up` (or `bun run up` for the variant that includes pgAdmin via the `tools` profile).
+
+`api/.env` is gitignored — never commit credentials.
+
 ## General Code Guidelines
 
 - Strict typing throughout. Prefer `unknown` over `any`. Treat state as readonly/immutable where possible.

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,43 @@
+# Irrigo API environment variables.
+#
+# Copy this file to `api/.env` and fill in the required values. Docker Compose
+# loads `.env` from the directory containing the compose file, so the path must
+# be `api/.env` (not the repo root). `.env` is gitignored.
+#
+# Required values are flagged below; everything else has a sensible default.
+
+# --- Home Assistant (required) ---
+# Base URL of your Home Assistant instance, e.g. http://192.168.2.100:8123.
+# No trailing slash required (the client trims it).
+HA_URL=
+
+# Long-lived access token used to authenticate to the HA REST API.
+# Mint one in HA: Profile (bottom-left) → Security tab → Long-Lived Access
+# Tokens → Create Token. Treat this as a credential — do not commit it.
+HA_TOKEN=
+
+# --- Home Assistant (optional tuning) ---
+# Base retry attempts for switch.turn_on calls. switch.turn_off doubles this
+# automatically (closing a stuck-on relay matters more than opening one).
+# HA_RETRY_MAX=3
+
+# Initial backoff (ms) between retry attempts; grows exponentially.
+# HA_RETRY_BASE_MS=1000
+
+# --- Postgres (optional; defaults work for the bundled `db` container) ---
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=postgres
+# POSTGRES_DB=irrigation
+
+# Override only if you want to point the api at a database outside the compose
+# network. Otherwise it's derived from the POSTGRES_* values above.
+# DATABASE_URL=postgresql://postgres:postgres@db:5432/irrigation
+
+# --- API runtime (optional) ---
+# NODE_ENV=production
+# PORT=9753
+
+# --- pgAdmin (optional; only used with `--profile tools`) ---
+# PGADMIN_EMAIL=admin@example.com
+# PGADMIN_PASSWORD=admin
+# PGADMIN_PORT=9754

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -48,6 +48,10 @@ services:
             NODE_ENV: ${NODE_ENV:-production}
             PORT: ${PORT:-9753}
             DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-irrigation}}
+            HA_URL: ${HA_URL}
+            HA_TOKEN: ${HA_TOKEN}
+            HA_RETRY_MAX: ${HA_RETRY_MAX:-3}
+            HA_RETRY_BASE_MS: ${HA_RETRY_BASE_MS:-1000}
         ports:
             - "${PORT:-9753}:9753"
         command: sh -c "bun run start"


### PR DESCRIPTION
## Ticket

[API-8](http://192.168.2.100:7123/irrigo/browse/API-8/) — Plumb Home Assistant env vars through docker-compose and `.env`

## Summary

- `api/docker-compose.yml`: forward `HA_URL`, `HA_TOKEN`, `HA_RETRY_MAX`, `HA_RETRY_BASE_MS` into the `api` service via `${VAR}` indirection so the HA client at `api/data/home-assistant/index.ts` actually sees credentials when the daemon runs in Docker.
- `api/.env.example`: new template covering required HA vars, optional HA retry tuning, Postgres, API runtime, and pgAdmin. Includes a comment with the HA long-lived-token mint flow.
- `CLAUDE.md`: new "Local development" section documenting the `cp api/.env.example api/.env` → fill in HA values → `docker compose up` bootstrap.

`.env` is already gitignored at `api/.gitignore:19`, so no change there.

Out of scope per the ticket: token rotation and any secrets-management beyond `.env`.