### PR TITLE
[API-22] Add Dev Container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Irrigo",
+    "dockerComposeFile": ["../docker-compose.yml"],
+    "service": "dev",
+    "workspaceFolder": "/app",
+    "shutdownAction": "none",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "oven.bun-vscode",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "bradlc.vscode-tailwindcss"
+            ]
+        }
+    }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-# Irrigo API environment variables.
+# Irrigo environment variables.
 #
-# Copy this file to `api/.env` and fill in the required values. Docker Compose
-# loads `.env` from the directory containing the compose file, so the path must
-# be `api/.env` (not the repo root). `.env` is gitignored.
+# Copy this file to `.env` at the repo root and fill in the required values.
+# Docker Compose loads `.env` from the directory containing the compose file.
+# `.env` is gitignored.
 #
 # Required values are flagged below; everything else has a sensible default.
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ expo-env.d.ts
 .expo
 node_modules
 .claude/settings.local.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@ Irrigation control system. The repo contains:
 
 ## Local development
 
-First-time setup for the `api/` stack:
+First-time setup:
 
-1. `cp api/.env.example api/.env` — Docker Compose loads `.env` from the directory containing the compose file, so the file must live at `api/.env`.
-2. Edit `api/.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them.
-3. From `api/`, bring the stack up: `docker compose up` (or `bun run up` for the variant that includes pgAdmin via the `tools` profile).
+1. `cp .env.example .env` — at the repo root. Docker Compose loads `.env` from the directory containing the compose file.
+2. Edit `.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them.
+3. From the repo root, bring the stack up: `docker compose up` (or `bun --cwd api run up` for the variant that includes pgAdmin via the `tools` profile).
 
-`api/.env` is gitignored — never commit credentials.
+`.env` is gitignored — never commit credentials.
 
 ## General Code Guidelines
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -45,4 +45,7 @@ RUN (getent group $DEV_GID > /dev/null 2>&1 || groupadd --gid $DEV_GID $DEV_USER
 WORKDIR /app
 USER ${DEV_USER}
 
-CMD ["sleep", "infinity"]
+# Print a ready line on startup so `docker compose logs dev` confirms the
+# container came up healthy. `exec` hands PID 1 to sleep so the container
+# still exits cleanly on stop signals.
+CMD ["sh", "-c", "echo \"irrigo dev: ready (user=$(whoami) workspace=/app)\" && exec sleep infinity"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,48 @@
+# VS Code Dev Container — editor host with bun + git + gh tooling.
+#
+# This container is NOT a runtime service. It runs `sleep infinity` and exists
+# solely so VS Code (via the Dev Containers extension) can attach and run dev
+# tasks: bun install, bun test, drizzle-kit migrations, gh pr create, etc.
+#
+# Lifecycle is independent from the `api` service. Restarting api won't drop
+# editor sessions, and the daemon survives editor restarts.
+FROM oven/bun:latest
+
+ARG DEV_USER=chrisharrington
+ARG DEV_UID=1000
+ARG DEV_GID=1000
+
+ENV DEV_USER=${DEV_USER} DEV_UID=${DEV_UID} DEV_GID=${DEV_GID}
+
+# curl + ca-certificates: needed by the gh installer below.
+# git: source control inside the editor.
+# nodejs: some VS Code extensions (ESLint, JS debugger) shell out to `node` and
+# don't honor bun-as-node configuration. Bun stays the package manager and
+# runtime; node is here only to satisfy extension hosts.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates git nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI — used for PR creation and other GitHub workflows from inside the
+# dev container. Installed from GitHub's official apt repository.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Align the dev user's UID/GID with the host's so bind-mount file ownership is
+# consistent. The bun base image already ships a `bun` user at UID 1000, so
+# rename in place when DEV_UID matches an existing user; create fresh otherwise.
+RUN (getent group $DEV_GID > /dev/null 2>&1 || groupadd --gid $DEV_GID $DEV_USER) \
+    && (getent passwd $DEV_UID > /dev/null 2>&1 \
+        && usermod -l $DEV_USER -d /home/$DEV_USER -m $(getent passwd $DEV_UID | cut -d: -f1) \
+        || useradd --uid $DEV_UID --gid $DEV_GID --create-home --shell /bin/bash $DEV_USER)
+
+WORKDIR /app
+USER ${DEV_USER}
+
+CMD ["sleep", "infinity"]

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -15,13 +15,6 @@ logs
 _.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
-# dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
-
 # caches
 .eslintcache
 .cache

--- a/api/package.json
+++ b/api/package.json
@@ -12,9 +12,9 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "logs": "docker compose logs -f --tail 100 api",
-    "up": "docker compose --profile tools up -d",
-    "down": "docker compose --profile tools down"
+    "logs": "docker compose -f ../docker-compose.yml logs -f --tail 100 api",
+    "up": "docker compose -f ../docker-compose.yml --profile tools up -d",
+    "down": "docker compose -f ../docker-compose.yml --profile tools down"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,41 @@ services:
             - backend
             - frontend
 
+    # VS Code Dev Container — editor host that VS Code's Dev Containers
+    # extension attaches to. Runs `sleep infinity`; lifecycle independent from
+    # the `api` service so editor sessions survive api restarts.
+    dev:
+        build:
+            context: .
+            dockerfile: Dockerfile.dev
+            args:
+                DEV_USER: ${DEV_USER:-chrisharrington}
+                DEV_UID: ${DEV_UID:-1000}
+                DEV_GID: ${DEV_GID:-1000}
+        container_name: irrigo_dev
+        restart: unless-stopped
+        depends_on:
+            db:
+                condition: service_healthy
+        volumes:
+            # Whole repo bind-mounted so the editor sees api/, app/, shared/.
+            - .:/app
+            # Shared with host so Claude sessions inside the container see the
+            # same skills/commands and can write auth, history, and session
+            # state back. Same path on both sides because DEV_USER aligns.
+            - ${HOME}/.claude:/home/${DEV_USER:-chrisharrington}/.claude
+            # Share the host's gh CLI auth so `gh` works without re-login.
+            - ${HOME}/.config/gh:/home/${DEV_USER:-chrisharrington}/.config/gh
+            # Share the host's git identity (user.name, user.email, signing
+            # keys, aliases) so commits made inside the container are
+            # attributed correctly without per-container configuration.
+            - ${HOME}/.gitconfig:/home/${DEV_USER:-chrisharrington}/.gitconfig:ro
+        networks:
+            # backend → reach the `db` container.
+            # frontend → outbound internet for bun install, gh, etc.
+            - backend
+            - frontend
+
     pgadmin:
         image: dpage/pgadmin4:8
         container_name: irrigo_pgadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,8 @@ services:
             NODE_ENV: ${NODE_ENV:-production}
             PORT: ${PORT:-9753}
             DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-irrigation}}
-            HA_URL: ${HA_URL}
-            HA_TOKEN: ${HA_TOKEN}
+            HA_URL: ${HA_URL:-}
+            HA_TOKEN: ${HA_TOKEN:-}
             HA_RETRY_MAX: ${HA_RETRY_MAX:-3}
             HA_RETRY_BASE_MS: ${HA_RETRY_BASE_MS:-1000}
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
     api:
         build:
-            context: .
+            context: ./api
             dockerfile: Dockerfile
         container_name: irrigo_api
         restart: unless-stopped
@@ -42,7 +42,7 @@ services:
             db:
                 condition: service_healthy
         volumes:
-            - .:/app
+            - ./api:/app
             - /app/node_modules
         environment:
             NODE_ENV: ${NODE_ENV:-production}


### PR DESCRIPTION
## Ticket

[API-22](http://192.168.2.100:7123/irrigo/browse/API-22/) — Add Dev Container configuration to standardize the development environment.

## Summary

- **Move `docker-compose.yml` and `.env.example` to the repo root** so a single compose file covers the whole stack. `api/package.json` `up`/`down`/`logs` scripts reference the new path via `-f ../docker-compose.yml`. `CLAUDE.md` "Local development" section updated.
- **Add `Dockerfile.dev`** based on `oven/bun:latest` with `git`, `gh`, `nodejs`, `ca-certificates` installed. The bun image's UID-1000 user is renamed to match the host so bind-mount file ownership is consistent.
- **Add a `dev` compose service** that runs `sleep infinity` for VS Code's Dev Containers extension to attach to. Bind-mounts the repo at `/app`; host-mounts `~/.claude` (rw), `~/.config/gh` (rw), `~/.gitconfig` (ro). Joins both `backend` (for `db`) and `frontend` (for outbound internet) networks. Lifecycle independent from `api`.
- **Add `.devcontainer/devcontainer.json`** pointing at the `dev` service with recommended extensions (bun, eslint, prettier, tailwind) and `shutdownAction: none` so closing the editor doesn't take down the runtime stack.

Out of scope (intentional): Expo / `app/` tooling, `~/.vscode-server` named volume + entrypoint script (accepting the rebuild-time extension reinstall cost), replacing the runtime `api` service.

## Test plan

- [x] `docker compose -f docker-compose.yml config` parses cleanly
- [x] `docker compose build dev` succeeds
- [x] `docker compose up -d dev` brings db + dev up; both healthy
- [x] Inside the container: `bun`, `git`, `gh`, `node` all resolve; user is `chrisharrington` at UID 1000; `/app` shows the repo; `~/.claude`, `~/.config/gh`, `~/.gitconfig` are mounted from host
- [x] `getent hosts db` resolves (backend network reachable)
- [x] `bun --cwd api run type-check` clean
- [x] `bun --cwd api test` — 207 pass, 0 fail
- [ ] Manual: open the workspace in VS Code with the Dev Containers extension and confirm attach + recommended extensions surface