### PR TITLE
[API-15] Warn at daemon startup when no zones or all zones are disabled

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { afterEach, beforeEach, describe, it, expect, spyOn } from 'bun:test';
 import dayjs from 'dayjs';
 import {
     grassTypes,
@@ -11,9 +11,11 @@ import {
 import type { IrrigationScheduleEntry, Zone } from '@/models';
 import { computeNextRePlanAt, start, type DaemonDb } from '.';
 import {
+    countZones,
     loadEnabledZones,
     mapJoinedRowsToZones,
     type SelectJoinChain,
+    type ZoneCountDb,
     type ZoneJoinedRow,
     type ZoneLoaderDb,
 } from './zones';
@@ -129,6 +131,32 @@ function createZoneLoaderStub(rows: ZoneJoinedRow[]) {
         getSelectColumns: () => selectColumns,
     };
 }
+
+function createZoneCountStub(rows: ReadonlyArray<{ total: number; enabled: number }>): ZoneCountDb {
+    return {
+        select() {
+            return { from: () => Promise.resolve([...rows]) };
+        },
+    };
+}
+
+describe('countZones', () => {
+    it('returns the total and enabled counts from the single returned row', async () => {
+        const db = createZoneCountStub([{ total: 5, enabled: 3 }]);
+
+        const result = await countZones(db);
+
+        expect(result).toEqual({ total: 5, enabled: 3 });
+    });
+
+    it('defaults to zero counts when the query returns no rows', async () => {
+        const db = createZoneCountStub([]);
+
+        const result = await countZones(db);
+
+        expect(result).toEqual({ total: 0, enabled: 0 });
+    });
+});
 
 describe('mapJoinedRowsToZones', () => {
     it('drops zones whose is_enabled flag is false', () => {
@@ -826,6 +854,7 @@ describe('closeAllInFlight', () => {
 type DaemonStubInputs = {
     futureCycles?: FutureCycleJoinedRow[];
     enabledZones?: ZoneJoinedRow[];
+    zoneCounts?: { total: number; enabled: number };
 };
 
 function createDaemonDbStub(inputs?: DaemonStubInputs) {
@@ -834,10 +863,14 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
     const deletes: DeleteCall[] = [];
     const whereCallsZone: WhereCall[] = [];
     const whereCallsCycles: WhereCall[] = [];
+    const counts = inputs?.zoneCounts ?? { total: 1, enabled: 1 };
 
     const db: DaemonDb = {
         select(columns) {
             const cols = columns as Record<string, unknown>;
+            if ('total' in cols && 'enabled' in cols) {
+                return { from: () => Promise.resolve([counts]) } as never;
+            }
             const isFutureCyclesQuery = 'cycle' in cols;
             const rows = (isFutureCyclesQuery ? inputs?.futureCycles : inputs?.enabledZones) ?? [];
             const whereSink = isFutureCyclesQuery ? whereCallsCycles : whereCallsZone;
@@ -1115,5 +1148,47 @@ describe('start', () => {
         await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
 
         expect(closes).toEqual([futureRow.zone.id]);
+    });
+
+    describe('startup zone warnings', () => {
+        let warnSpy: ReturnType<typeof spyOn>;
+
+        beforeEach(() => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it('warns about an empty zones table when total is zero', async () => {
+            const { db } = createDaemonDbStub({ zoneCounts: { total: 0, enabled: 0 } });
+            const { clock } = createFakeClock(NOW);
+
+            await start(db, { clock, rePlanHourLocal: 4 });
+
+            const messages = warnSpy.mock.calls.map((args: unknown[]) => String(args[0]));
+            expect(messages.some((m: string) => m.includes('has no zones to manage') && m.includes('bun run seed'))).toBe(true);
+        });
+
+        it('warns that all zones are disabled when total > 0 but enabled is zero', async () => {
+            const { db } = createDaemonDbStub({ zoneCounts: { total: 4, enabled: 0 } });
+            const { clock } = createFakeClock(NOW);
+
+            await start(db, { clock, rePlanHourLocal: 4 });
+
+            const messages = warnSpy.mock.calls.map((args: unknown[]) => String(args[0]));
+            expect(messages.some((m: string) => m.includes('all zones are disabled'))).toBe(true);
+            expect(messages.some((m: string) => m.includes('has no zones to manage'))).toBe(false);
+        });
+
+        it('emits no startup warning when at least one zone is enabled', async () => {
+            const { db } = createDaemonDbStub({ zoneCounts: { total: 4, enabled: 2 } });
+            const { clock } = createFakeClock(NOW);
+
+            await start(db, { clock, rePlanHourLocal: 4 });
+
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -4,7 +4,7 @@ import type { IrrigationScheduleEntry, Zone } from '@/models';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import { loadFutureCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
 import { armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
-import { loadEnabledZones, type ZoneLoaderDb } from './zones';
+import { countZones, loadEnabledZones, type ZoneCountDb, type ZoneLoaderDb } from './zones';
 
 const DEFAULT_REPLAN_HOUR_LOCAL = 4;
 
@@ -13,7 +13,7 @@ const DEFAULT_REPLAN_HOUR_LOCAL = 4;
  * pass the eager `db` export from `@/db`; tests pass a recording stub that
  * implements the union of the smaller per-helper interfaces.
  */
-export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb;
+export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb;
 
 /**
  * Caller-overridable hooks. Defaults wire to the real planning function and
@@ -72,6 +72,13 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const futureCycles = await loadFutureCycles(db, clock.now());
     for (const { cycle, zone } of futureCycles) {
         armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+    }
+
+    const { total, enabled } = await countZones(db);
+    if (total === 0) {
+        console.warn('daemon: has no zones to manage. Did you run `bun run seed`? Daemon is idle until zones are added.');
+    } else if (enabled === 0) {
+        console.warn('daemon: all zones are disabled. Daemon is idle until at least one zone is enabled.');
     }
 
     const scheduleNextRePlan = (): void => {

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
 import type { Zone } from '@/models';
 
@@ -37,6 +37,46 @@ export type ZoneLoaderDb = {
         from: (table: typeof zones) => SelectJoinChain<ZoneJoinedRow>;
     };
 };
+
+/**
+ * Result of `countZones`. Used at daemon startup to distinguish "no zones in
+ * the table at all" from "zones exist but every one is disabled".
+ */
+export type ZoneCountResult = {
+    total: number;
+    enabled: number;
+};
+
+/**
+ * Minimal db interface for the count query. Single `select(...).from(zones)`
+ * with no joins or where — Drizzle returns the chained promise directly.
+ */
+export type ZoneCountDb = {
+    select: (columns: Record<string, unknown>) => {
+        from: (table: typeof zones) => Promise<Array<{ total: number; enabled: number }>>;
+    };
+};
+
+/**
+ * Counts every zone row in a single query. Returns both the total and the
+ * enabled-only count so callers can tell an empty table from one whose
+ * zones are all disabled.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns `{ total, enabled }` zone counts.
+ */
+export async function countZones(db: ZoneCountDb): Promise<ZoneCountResult> {
+    const rows = await db
+        .select({
+            total: sql<number>`count(*)::int`,
+            enabled: sql<number>`count(*) filter (where ${zones.isEnabled})::int`,
+        })
+        .from(zones);
+
+    const row = rows[0];
+    if (!row) return { total: 0, enabled: 0 };
+    return { total: row.total, enabled: row.enabled };
+}
 
 /**
  * Loads every enabled zone from the database with its grass type, soil type,


### PR DESCRIPTION
## Ticket

[API-15](http://192.168.2.100:7123/irrigo/browse/API-15/) Warn loudly when daemon starts with no enabled zones.

## Summary

- Added `countZones(db)` helper in `api/daemon/zones.ts` running a single `select` with `count(*)` and `count(*) filter (where is_enabled)` to distinguish empty-table from all-disabled in one round-trip.
- `start()` calls `countZones` at boot (after `loadFutureCycles`, before `scheduleNextRePlan`) and emits one of two `console.warn` messages — "has no zones to manage" or "all zones are disabled" — or stays quiet when at least one zone is enabled. Daemon keeps running either way; HTTP and the next-re-plan timer aren't blocked.
- Tests: 2 new `countZones` tests (returns row, defaults to zeroes on empty result), 3 new `start()` tests under "startup zone warnings" using `spyOn(console, 'warn')`. Full api suite: 212 pass / 0 fail.