### PR TITLE
[API-14] Use site timezone for daemon re-plan scheduling math

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, it, expect, spyOn } from 'bun:test';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import {
     grassTypes,
     irrigationCycles,
@@ -8,6 +10,9 @@ import {
     soilTypes,
     zones,
 } from '@/db/schema';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 import type { IrrigationScheduleEntry, Zone } from '@/models';
 import { computeNextRePlanAt, start, type DaemonDb } from '.';
 import {
@@ -19,6 +24,7 @@ import {
     type ZoneJoinedRow,
     type ZoneLoaderDb,
 } from './zones';
+import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
 import {
     loadFutureCycles,
     replaceZoneSchedule,
@@ -234,6 +240,14 @@ describe('mapJoinedRowsToZones', () => {
 
         expect(result[0]?.precipitationRateMmPerHr).toBe(12.5);
         expect(result[0]?.homeAssistantEntityId).toBe('switch.front_yard');
+    });
+
+    it('propagates the site timezone onto the zone model', () => {
+        const row = buildJoinedRow({ site: { timezone: 'Europe/London' } });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.siteTimezone).toBe('Europe/London');
     });
 });
 
@@ -578,26 +592,103 @@ describe('loadFutureCycles', () => {
 });
 
 describe('computeNextRePlanAt', () => {
-    it('returns todays hour when the current time is before that hour', () => {
+    it('UTC: returns todays hour when the current time is before that hour', () => {
         const now = new Date('2026-05-04T01:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4);
+        const next = computeNextRePlanAt(now, 4, 'UTC');
 
-        expect(dayjs(next).format('YYYY-MM-DDTHH:mm')).toBe(dayjs(now).hour(4).minute(0).format('YYYY-MM-DDTHH:mm'));
+        expect(next.toISOString()).toBe('2026-05-04T04:00:00.000Z');
     });
 
-    it('returns tomorrows hour when the current time is past todays hour', () => {
+    it('UTC: returns tomorrows hour when the current time is past todays hour', () => {
         const now = new Date('2026-05-04T18:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4);
+        const next = computeNextRePlanAt(now, 4, 'UTC');
 
-        const expected = dayjs(now).add(1, 'day').hour(4).minute(0).second(0).millisecond(0);
-        expect(dayjs(next).format('YYYY-MM-DDTHH:mm:ss')).toBe(expected.format('YYYY-MM-DDTHH:mm:ss'));
+        expect(next.toISOString()).toBe('2026-05-05T04:00:00.000Z');
     });
 
-    it('returns tomorrows hour when the current time exactly matches todays hour', () => {
-        const now = dayjs(NOW_DAEMON).hour(4).minute(0).second(0).millisecond(0).toDate();
-        const next = computeNextRePlanAt(now, 4);
+    it('UTC: returns tomorrows hour when the current time exactly matches todays hour', () => {
+        const now = new Date('2026-05-04T04:00:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'UTC');
 
-        expect(dayjs(next).diff(dayjs(now), 'hour')).toBe(24);
+        expect(next.toISOString()).toBe('2026-05-05T04:00:00.000Z');
+    });
+
+    it('Edmonton MDT: maps local 04:00 to the correct UTC instant when now is before it', () => {
+        // 2026-05-04T01:30Z = 2026-05-03T19:30 MDT (UTC-6 during DST). Next local 04:00 is 2026-05-04T04:00 MDT = 2026-05-04T10:00Z.
+        const now = new Date('2026-05-04T01:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
+
+        expect(next.toISOString()).toBe('2026-05-04T10:00:00.000Z');
+    });
+
+    it('Edmonton MDT: rolls to tomorrow when now is past local 04:00', () => {
+        // 2026-05-04T18:30Z = 2026-05-04T12:30 MDT. Next local 04:00 is 2026-05-05T04:00 MDT = 2026-05-05T10:00Z.
+        const now = new Date('2026-05-04T18:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
+
+        expect(next.toISOString()).toBe('2026-05-05T10:00:00.000Z');
+    });
+
+    it('Edmonton MST: maps local 04:00 to the correct UTC instant outside DST', () => {
+        // 2026-01-15T18:30Z = 2026-01-15T11:30 MST (UTC-7 outside DST). Next local 04:00 is 2026-01-16T04:00 MST = 2026-01-16T11:00Z.
+        const now = new Date('2026-01-15T18:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
+
+        expect(next.toISOString()).toBe('2026-01-16T11:00:00.000Z');
+    });
+});
+
+describe('loadSiteTimezone', () => {
+    function createSiteStub(rows: ReadonlyArray<{ timezone: string }>): SiteTimezoneDb {
+        return {
+            select() {
+                return { from: () => Promise.resolve([...rows]) };
+            },
+        };
+    }
+
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it(`returns the single site's timezone without warning`, async () => {
+        const db = createSiteStub([{ timezone: 'America/Edmonton' }]);
+
+        const result = await loadSiteTimezone(db);
+
+        expect(result).toBe('America/Edmonton');
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns UTC and warns when no sites exist', async () => {
+        const db = createSiteStub([]);
+
+        const result = await loadSiteTimezone(db);
+
+        expect(result).toBe('UTC');
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const message = String((warnSpy.mock.calls[0] as unknown[])[0] as string);
+        expect(message).toContain('no sites found');
+    });
+
+    it(`picks the first row's timezone and warns when multiple sites exist`, async () => {
+        const db = createSiteStub([
+            { timezone: 'America/Edmonton' },
+            { timezone: 'Europe/London' },
+        ]);
+
+        const result = await loadSiteTimezone(db);
+
+        expect(result).toBe('America/Edmonton');
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const message = String((warnSpy.mock.calls[0] as unknown[])[0] as string);
+        expect(message).toContain('multiple sites');
     });
 });
 
@@ -889,6 +980,7 @@ type DaemonStubInputs = {
     futureCycles?: FutureCycleJoinedRow[];
     enabledZones?: ZoneJoinedRow[];
     zoneCounts?: { total: number; enabled: number };
+    siteTimezones?: ReadonlyArray<{ timezone: string }>;
 };
 
 function createDaemonDbStub(inputs?: DaemonStubInputs) {
@@ -903,11 +995,17 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
     // are reflected by subsequent loadEnabledZones calls (day-N reads day-(N-1)).
     const enabledZoneRows = inputs?.enabledZones?.map(row => ({ ...row, zone: { ...row.zone } })) ?? [];
 
+    const siteTimezoneRows = inputs?.siteTimezones ?? [{ timezone: 'America/Edmonton' }];
+
     const db: DaemonDb = {
         select(columns) {
             const cols = columns as Record<string, unknown>;
             if ('total' in cols && 'enabled' in cols) {
                 return { from: () => Promise.resolve([counts]) } as never;
+            }
+            // SiteTimezoneDb shape: a single `timezone` column, no other keys.
+            if ('timezone' in cols && Object.keys(cols).length === 1) {
+                return { from: () => Promise.resolve([...siteTimezoneRows]) } as never;
             }
             const isFutureCyclesQuery = 'cycle' in cols;
             const rows = isFutureCyclesQuery ? (inputs?.futureCycles ?? []) : enabledZoneRows;
@@ -1034,15 +1132,26 @@ describe('start', () => {
         expect(closes).toEqual([futureRow.zone.id]);
     });
 
-    it('schedules the next re-plan timer for the configured local hour', async () => {
+    it('schedules the next re-plan timer for the configured local hour (UTC)', async () => {
         const { db } = createDaemonDbStub();
-        // Set initial time to 12:00, hour=4 -> next re-plan should be 04:00 next day = +16h
+        // Set initial time to 12:00 UTC, hour=4, tz=UTC -> next re-plan should be 04:00 next day = +16h
         const { clock, getPendingDelays } = createFakeClock(NOW);
 
-        await start(db, { clock, rePlanHourLocal: 4 });
+        await start(db, { clock, rePlanHourLocal: 4, siteTimezone: 'UTC' });
 
         const sixteenHoursMs = 16 * 60 * 60 * 1000;
         expect(getPendingDelays()).toContain(sixteenHoursMs);
+    });
+
+    it('schedules the next re-plan in the site timezone, not the container timezone', async () => {
+        const { db } = createDaemonDbStub();
+        // NOW = 2026-05-04T12:00Z = 06:00 MDT. Next 04:00 MDT is tomorrow = 2026-05-05T10:00Z = +22h from now.
+        const { clock, getPendingDelays } = createFakeClock(NOW);
+
+        await start(db, { clock, rePlanHourLocal: 4, siteTimezone: 'America/Edmonton' });
+
+        const twentyTwoHoursMs = 22 * 60 * 60 * 1000;
+        expect(getPendingDelays()).toContain(twentyTwoHoursMs);
     });
 
     it('returned rePlan() runs the planner for every enabled zone and inserts the planner output', async () => {
@@ -1179,6 +1288,7 @@ describe('start', () => {
         await start(db, {
             clock,
             rePlanHourLocal: 4,
+            siteTimezone: 'UTC',
             runPlan: async (z) => {
                 planCalls.push(z.id);
                 return { entries: [], projectedNextDepletionMm: 0 };
@@ -1187,7 +1297,7 @@ describe('start', () => {
             closeZone: async () => {},
         });
 
-        // Advance to just past the next 04:00 — the scheduled timer should fire and
+        // Advance to just past the next 04:00 UTC — the scheduled timer should fire and
         // call rePlan, which iterates enabled zones.
         await advanceTo(new Date('2026-05-05T04:00:01.000Z'));
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -1,11 +1,17 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import { closeZone as defaultCloseZone, openZone as defaultOpenZone } from '@/data/home-assistant';
 import type { Zone } from '@/models';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { loadFutureCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
 import { armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
+import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
 import { countZones, loadEnabledZones, type ZoneCountDb, type ZoneLoaderDb } from './zones';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const DEFAULT_REPLAN_HOUR_LOCAL = 4;
 
@@ -14,7 +20,7 @@ const DEFAULT_REPLAN_HOUR_LOCAL = 4;
  * pass the eager `db` export from `@/db`; tests pass a recording stub that
  * implements the union of the smaller per-helper interfaces.
  */
-export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb;
+export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb;
 
 /**
  * Caller-overridable hooks. Defaults wire to the real planning function and
@@ -35,6 +41,9 @@ export type DaemonOptions = {
 
     /** Override for time/timer access. */
     clock?: Clock;
+
+    /** Override the resolved site timezone (skips the DB lookup). Used by tests. */
+    siteTimezone?: string;
 };
 
 /**
@@ -90,7 +99,9 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     let lastRePlanAt: Date | null = null;
     let started = false;
 
-    console.log(`daemon: starting (re-plan hour: ${rePlanHourLocal}:00 local).`);
+    const siteTimezone = options?.siteTimezone ?? await loadSiteTimezone(db);
+
+    console.log(`daemon: starting (re-plan hour: ${rePlanHourLocal}:00 ${siteTimezone}).`);
 
     const futureCycles = await loadFutureCycles(db, clock.now());
     for (const { cycle, zone } of futureCycles) {
@@ -105,7 +116,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     }
 
     const scheduleNextRePlan = (): void => {
-        const next = computeNextRePlanAt(clock.now(), rePlanHourLocal);
+        const next = computeNextRePlanAt(clock.now(), rePlanHourLocal, siteTimezone);
         const delay = Math.max(0, next.getTime() - clock.now().getTime());
         console.log(`daemon: next re-plan scheduled at ${next.toISOString()} (${delay}ms from now).`);
         const handle = clock.setTimeout(() => {
@@ -160,15 +171,18 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
 }
 
 /**
- * Returns the next wall-clock occurrence of `hourLocal:00` after `now`. Pure
- * function exported so the scheduling math is unit-testable directly.
+ * Returns the next wall-clock occurrence of `hourLocal:00` after `now`,
+ * resolved against the supplied IANA timezone. Pure function exported so the
+ * scheduling math is unit-testable directly. The container TZ is irrelevant
+ * — the target is always the next 04:00 (or whatever) at the *site*.
  *
- * @param now - Current time.
- * @param hourLocal - Target hour-of-day (0-23) in the system local timezone.
- * @returns The next Date at which the hour rolls over.
+ * @param now - Current time (any TZ — only the absolute instant is used).
+ * @param hourLocal - Target hour-of-day (0-23) at the site.
+ * @param timezone - IANA timezone of the site (e.g. `America/Edmonton`).
+ * @returns The absolute Date at which the hour rolls over at the site.
  */
-export function computeNextRePlanAt(now: Date, hourLocal: number): Date {
-    const ref = dayjs(now);
+export function computeNextRePlanAt(now: Date, hourLocal: number, timezone: string): Date {
+    const ref = dayjs(now).tz(timezone);
     const todayAtHour = ref.hour(hourLocal).minute(0).second(0).millisecond(0);
     const next = todayAtHour.isAfter(ref) ? todayAtHour : todayAtHour.add(1, 'day');
     return next.toDate();

--- a/api/daemon/sites.ts
+++ b/api/daemon/sites.ts
@@ -1,0 +1,33 @@
+import { sites } from '@/db/schema';
+
+/**
+ * Minimal db interface for `loadSiteTimezone`. Single `select(...).from(sites)`
+ * with no joins or where — Drizzle returns the chained promise directly.
+ */
+export type SiteTimezoneDb = {
+    select: (columns: { timezone: typeof sites.timezone }) => {
+        from: (table: typeof sites) => Promise<Array<{ timezone: string }>>;
+    };
+};
+
+/**
+ * Resolves the site timezone the daemon should use for re-plan scheduling
+ * math. The system today assumes a single site; if zero or many rows are
+ * present this logs a warning and falls back to the first row (or `'UTC'`
+ * for the empty case) so the daemon can still boot.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns The site's IANA timezone string.
+ */
+export async function loadSiteTimezone(db: SiteTimezoneDb): Promise<string> {
+    const rows = await db.select({ timezone: sites.timezone }).from(sites);
+
+    if (rows.length === 0) {
+        console.warn('daemon: no sites found; defaulting re-plan timezone to UTC.');
+        return 'UTC';
+    }
+    if (rows.length > 1) {
+        console.warn(`daemon: multiple sites found (${rows.length}); using the first row's timezone for re-plan scheduling.`);
+    }
+    return rows[0]!.timezone;
+}

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -144,6 +144,7 @@ export function joinedRowToZone(row: ZoneJoinedRow): Zone {
         areaM2: row.zone.areaM2,
         precipitationRateMmPerHr: row.zone.precipitationRateMmPerHr ?? undefined,
         currentDepletionMm: row.zone.currentDepletionMm,
+        siteTimezone: row.site.timezone,
         isEnabled: row.zone.isEnabled,
         location: { lat, lon },
         homeAssistantEntityId: row.zone.homeAssistantEntityId ?? undefined,

--- a/api/mock/zone.ts
+++ b/api/mock/zone.ts
@@ -27,6 +27,7 @@ export function createTestZone(overrides?: Partial<Zone>): Zone {
         areaM2: 100,
         precipitationRateMmPerHr: 9,
         currentDepletionMm: 0,
+        siteTimezone: 'America/Edmonton',
         isEnabled: true,
         location: {
             lat: 51.0447,

--- a/api/models.ts
+++ b/api/models.ts
@@ -87,6 +87,9 @@ export type Zone = {
     /** Required. The current soil moisture deficit (0 = full). */
     currentDepletionMm: number;
 
+    /** Required. The IANA timezone of the site this zone belongs to. */
+    siteTimezone: string;
+
     /** Optional. Whether the zone is enabled for irrigation. Default true. */
     isEnabled?: boolean;
 


### PR DESCRIPTION
## Ticket

[API-14](http://192.168.2.100:7123/irrigo/browse/API-14/) Use site timezone for all scheduling math.

## Summary

- Wired `dayjs/plugin/utc` and `dayjs/plugin/timezone` and changed `computeNextRePlanAt(now, hour, timezone)` to resolve the next 04:00 (or whatever) at the **site**, not the container. The container TZ is irrelevant — only the absolute UTC instant is returned.
- Added `loadSiteTimezone(db)` in a new `api/daemon/sites.ts`. Single-row → returns the timezone; empty → defaults to `'UTC'` with a warn; multi-row → picks the first and warns. Wired into `start()` once at boot, captured in the `scheduleNextRePlan` closure. New `siteTimezone?: string` option on `DaemonOptions` lets tests bypass the DB lookup.
- Surfaced `siteTimezone: string` on the `Zone` model (already in the joined row from the zones loader, just discarded before today). `joinedRowToZone` now propagates it.
- Cycle `setTimeout` deltas already work in absolute UTC ms (the planner emits absolute Dates from sunrise math) — no change needed there.
- Tests: `computeNextRePlanAt` gains 6 tests covering UTC + Edmonton MDT (DST) + Edmonton MST (non-DST) for both before/past today's local hour. New `loadSiteTimezone` describe with 3 tests (single, empty, multi). `mapJoinedRowsToZones` test asserts the `siteTimezone` propagation. `start()` regression test asserts the next-re-plan delay differs in container-TZ vs site-TZ. Existing UTC-dependent timer tests pinned with `siteTimezone: 'UTC'`. Full api suite: 237 pass / 0 fail.

DST shifts (the open design question on the ticket) are intentionally not handled here — the next morning's re-plan corrects.