### PR TITLE
[API-12] Notification framework via Home Assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,18 @@ HA_TOKEN=
 # Initial backoff (ms) between retry attempts; grows exponentially.
 # HA_RETRY_BASE_MS=1000
 
+# --- Home Assistant notifications (optional) ---
+# Name of the HA notify service to call (e.g. `mobile_app_pixel_8`,
+# `persistent_notification`). When unset, all notifications are disabled
+# regardless of the per-event flags below.
+# HA_NOTIFY_SERVICE=
+
+# Per-event opt-in flags. Default false for the chatty start/end events;
+# default true for errors so failures stay loud.
+# NOTIFY_ON_WATERING_START=false
+# NOTIFY_ON_WATERING_END=false
+# NOTIFY_ON_ERROR=true
+
 # --- Postgres (optional; defaults work for the bundled `db` container) ---
 # POSTGRES_USER=postgres
 # POSTGRES_PASSWORD=postgres

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Irrigation control system. The repo contains:
 First-time setup:
 
 1. `cp .env.example .env` — at the repo root. Docker Compose loads `.env` from the directory containing the compose file.
-2. Edit `.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them.
+2. Edit `.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them. To opt into push notifications via Home Assistant, set `HA_NOTIFY_SERVICE` (e.g. `mobile_app_pixel_8`); the `NOTIFY_ON_WATERING_START` / `NOTIFY_ON_WATERING_END` / `NOTIFY_ON_ERROR` flags toggle each event type (defaults: `false`/`false`/`true`).
 3. From the repo root, bring the stack up: `docker compose up` (or `bun --cwd api run up` for the variant that includes pgAdmin via the `tools` profile).
 
 `.env` is gitignored — never commit credentials.

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -25,6 +25,17 @@ import {
     type ZoneLoaderDb,
 } from './zones';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
+import { noopNotifier, type NotificationContext, type NotificationEvent, type Notifier } from '@/notifications';
+
+type RecordedNotification = { event: NotificationEvent; context: NotificationContext | undefined };
+
+function recordingNotifier(): { notifier: Notifier; calls: RecordedNotification[] } {
+    const calls: RecordedNotification[] = [];
+    const notifier: Notifier = async (event, context) => {
+        calls.push({ event, context });
+    };
+    return { notifier, calls };
+}
 import {
     loadFutureCycles,
     replaceZoneSchedule,
@@ -844,7 +855,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
 
         await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
 
@@ -871,7 +882,7 @@ describe('armCycle', () => {
         const openZone = async () => { throw new Error('HA down'); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(closes).toEqual([]);
@@ -892,7 +903,7 @@ describe('armCycle', () => {
         const openZone = async () => { /* success */ };
         const closeZone = async () => { throw new Error('close failed'); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(updates).toHaveLength(1);
@@ -915,11 +926,98 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async () => { /* success */ };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
         await advanceTo(new Date('2026-05-04T12:05:01.000Z'));
 
         expect(opens).toHaveLength(1);
         expect(updates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('notifies watering-started without a reason qualifier when armReason is omitted', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-N', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 12 });
+        const { notifier, calls } = recordingNotifier();
+
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
+        await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
+
+        const started = calls.find(c => c.event === 'watering-started');
+        expect(started?.context).toEqual({ zoneName: 'Front Lawn', durationMin: 12 });
+    });
+
+    it('flags watering-started with reason=boot when armReason is boot', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T11:00:00.000Z'), durationMin: 12 });
+        const { notifier, calls } = recordingNotifier();
+
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, armReason: 'boot' });
+        await advanceTo(new Date('2026-05-04T12:00:30.000Z'));
+
+        const started = calls.find(c => c.event === 'watering-started');
+        expect(started?.context).toEqual({ zoneName: 'Front Lawn', durationMin: 12, reason: 'boot' });
+    });
+
+    it('emits an error notification when openZone fails', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-E', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 10 });
+        const { notifier, calls } = recordingNotifier();
+
+        armCycle({
+            db, clock, registry, zone, cycle,
+            openZone: async () => { throw new Error('HA 502'); },
+            closeZone: async () => {},
+            notifier,
+        });
+        await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
+
+        expect(calls.find(c => c.event === 'watering-started')).toBeUndefined();
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
+    });
+
+    it('notifies watering-ended without a reason when a cycle closes naturally', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-OK', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
+        const { notifier, calls } = recordingNotifier();
+
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
+        await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
+
+        const ended = calls.find(c => c.event === 'watering-ended');
+        expect(ended?.context).toEqual({ zoneName: 'Front Lawn' });
+    });
+
+    it('emits an error notification when closeZone fails after a successful open', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-F', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
+        const { notifier, calls } = recordingNotifier();
+
+        armCycle({
+            db, clock, registry, zone, cycle,
+            openZone: async () => {},
+            closeZone: async () => { throw new Error('close failed'); },
+            notifier,
+        });
+        await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
+
+        expect(calls.some(c => c.event === 'watering-started')).toBe(true);
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'close', reason: 'close failed' });
     });
 });
 
@@ -937,7 +1035,7 @@ describe('closeAllInFlight', () => {
         const closes: Zone[] = [];
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        await closeAllInFlight({ db, clock, registry, closeZone });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier });
 
         expect(closes.map(z => z.id)).toEqual(['zone-A', 'zone-B']);
         expect(updates.filter(u => u.closedAt instanceof Date)).toHaveLength(2);
@@ -956,7 +1054,7 @@ describe('closeAllInFlight', () => {
             if (calls === 1) throw new Error('HA flaky');
         };
 
-        await closeAllInFlight({ db, clock, registry, closeZone });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier });
 
         expect(calls).toBe(2);
         expect(updates).toHaveLength(1); // only the second one updated closedAt
@@ -969,10 +1067,46 @@ describe('closeAllInFlight', () => {
         const registry = new TimerRegistry();
         const closes: Zone[] = [];
 
-        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); } });
+        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); }, notifier: noopNotifier });
 
         expect(closes).toEqual([]);
         expect(updates).toEqual([]);
+    });
+
+    it('notifies watering-ended with reason=shutdown for each successfully closed relay', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zoneA = buildZoneModel({ id: 'zone-A', name: 'Front Lawn' });
+        const zoneB = buildZoneModel({ id: 'zone-B', name: 'Back Yard' });
+        registry.addInFlight('cycle-X', zoneA, 999);
+        registry.addInFlight('cycle-Y', zoneB, 998);
+        const { notifier, calls } = recordingNotifier();
+
+        await closeAllInFlight({ db, clock, registry, closeZone: async () => {}, notifier });
+
+        expect(calls.map(c => c.event)).toEqual(['watering-ended', 'watering-ended']);
+        expect(calls[0]?.context).toEqual({ zoneName: 'Front Lawn', reason: 'shutdown' });
+        expect(calls[1]?.context).toEqual({ zoneName: 'Back Yard', reason: 'shutdown' });
+    });
+
+    it('notifies an error when shutdown closeZone fails for a relay', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-A', name: 'Front Lawn' });
+        registry.addInFlight('cycle-X', zone, 999);
+        const { notifier, calls } = recordingNotifier();
+
+        await closeAllInFlight({
+            db, clock, registry,
+            closeZone: async () => { throw new Error('HA flaky'); },
+            notifier,
+        });
+
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'shutdown-close', reason: 'HA flaky' });
+        expect(calls.some(c => c.event === 'watering-ended')).toBe(false);
     });
 });
 
@@ -1416,6 +1550,83 @@ describe('start', () => {
             { zoneId: 'zone-001', currentDepletionMm: 7.5 },
         ]);
         expect(seenDepletionsByCall).toEqual([0, 7.5]);
+    });
+
+    it('flags boot-armed cycles with reason=boot in their watering-started notifications', async () => {
+        const futureRow = buildFutureCycleRow({
+            cycle: {
+                id: 'cycle-boot',
+                startTime: new Date('2026-05-04T11:00:00.000Z'),
+                durationMin: 8,
+            },
+            zone: { id: 'zone-boot', name: 'Boot Zone' },
+        });
+        const { db } = createDaemonDbStub({ futureCycles: [futureRow] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { notifier, calls } = recordingNotifier();
+
+        await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            siteTimezone: 'UTC',
+            notifier,
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        // Past start time fires immediately on boot.
+        await advanceTo(new Date('2026-05-04T12:00:01.000Z'));
+
+        const started = calls.find(c => c.event === 'watering-started');
+        expect(started?.context).toEqual({ zoneName: 'Boot Zone', durationMin: 8, reason: 'boot' });
+    });
+
+    it('does not flag rePlan-armed cycles with reason=boot in their watering-started notifications', async () => {
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-rp', name: 'Replan Zone' } });
+        const { db } = createDaemonDbStub({ enabledZones: [enabledRow] });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { notifier, calls } = recordingNotifier();
+        const planned = buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 6 }]);
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            siteTimezone: 'UTC',
+            notifier,
+            runPlan: async () => ({ entries: [planned], projectedNextDepletionMm: 0 }),
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await control.rePlan();
+        await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
+
+        const started = calls.find(c => c.event === 'watering-started');
+        expect(started?.context).toEqual({ zoneName: 'Replan Zone', durationMin: 6 });
+        expect(started?.context).not.toHaveProperty('reason');
+    });
+
+    it('emits an error notification when the planner throws for a zone during rePlan', async () => {
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-bad', name: 'Bad Zone' } });
+        const { db } = createDaemonDbStub({ enabledZones: [enabledRow] });
+        const { clock } = createFakeClock(NOW);
+        const { notifier, calls } = recordingNotifier();
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            siteTimezone: 'UTC',
+            notifier,
+            runPlan: async () => { throw new Error('forecast unavailable'); },
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await control.rePlan();
+
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context).toEqual({ zoneName: 'Bad Zone', operation: 're-plan', reason: 'forecast unavailable' });
     });
 
     describe('startup zone warnings', () => {

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -3,6 +3,7 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import { closeZone as defaultCloseZone, openZone as defaultOpenZone } from '@/data/home-assistant';
 import type { Zone } from '@/models';
+import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { loadFutureCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
@@ -44,6 +45,9 @@ export type DaemonOptions = {
 
     /** Override the resolved site timezone (skips the DB lookup). Used by tests. */
     siteTimezone?: string;
+
+    /** Override the notifier. Defaults to the no-op so tests don't have to. */
+    notifier?: Notifier;
 };
 
 /**
@@ -96,6 +100,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const closeZone = options?.closeZone ?? defaultCloseZone;
 
     const registry = new TimerRegistry();
+    const notifier = options?.notifier ?? noopNotifier;
     let lastRePlanAt: Date | null = null;
     let started = false;
 
@@ -105,7 +110,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
 
     const futureCycles = await loadFutureCycles(db, clock.now());
     for (const { cycle, zone } of futureCycles) {
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, armReason: 'boot' });
     }
 
     const { total, enabled } = await countZones(db);
@@ -139,10 +144,15 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                 const { entries, projectedNextDepletionMm } = await runPlan(zone);
                 const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm);
                 for (const cycle of cycles) {
-                    armCycle({ db, clock, registry, zone, cycle, openZone, closeZone });
+                    armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier });
                 }
             } catch (err) {
                 console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
+                await notifier('error', {
+                    zoneName: zone.name,
+                    operation: 're-plan',
+                    reason: err instanceof Error ? err.message : String(err),
+                });
             }
         }
 
@@ -154,7 +164,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const shutdown = async (): Promise<void> => {
         console.log('daemon: shutdown starting.');
         registry.cancelAllTimers(clock);
-        await closeAllInFlight({ db, clock, registry, closeZone });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier });
         console.log('daemon: shutdown complete.');
     };
 

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { irrigationCycles } from '@/db/schema';
 import type { Zone } from '@/models';
+import type { Notifier } from '@/notifications';
 import type { PersistedCycle } from './schedules';
 
 /**
@@ -120,6 +121,15 @@ export type ArmCycleInputs = {
     cycle: PersistedCycle;
     openZone: (zone: Zone) => Promise<void>;
     closeZone: (zone: Zone) => Promise<void>;
+    notifier: Notifier;
+
+    /**
+     * Why this cycle is being armed. `'boot'` cycles fire from the daemon's
+     * startup loop (recovering future cycles from a previous run); `'scheduled'`
+     * fires from a fresh re-plan. Surfaced in notifications so the user can
+     * tell a boot-recovery firing from a freshly planned one.
+     */
+    armReason?: 'boot' | 'scheduled';
 };
 
 /**
@@ -146,22 +156,28 @@ export function armCycle(inputs: ArmCycleInputs): void {
 }
 
 async function runOpen(inputs: ArmCycleInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, openZone, closeZone } = inputs;
+    const { db, clock, registry, zone, cycle, openZone, closeZone, notifier, armReason } = inputs;
 
     try {
         await openZone(zone);
     } catch (err) {
         console.error(`daemon: openZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving fired_at NULL.`, err);
+        await notifier('error', { zoneName: zone.name, operation: 'open', reason: errorMessage(err) });
         return;
     }
 
     const firedAt = clock.now();
     await db.update(irrigationCycles).set({ firedAt }).where(eq(irrigationCycles.id, cycle.id));
     console.log(`daemon: opened zone ${zone.id} for cycle ${cycle.id} at ${firedAt.toISOString()}.`);
+    await notifier('watering-started', {
+        zoneName: zone.name,
+        durationMin: cycle.durationMin,
+        ...(armReason === 'boot' ? { reason: 'boot' } : {}),
+    });
 
     const closeDelay = cycle.durationMin * 60_000;
     const closeHandle = clock.setTimeout(() => {
-        runClose({ db, clock, registry, zone, cycle, closeZone }).catch(err => {
+        runClose({ db, clock, registry, zone, cycle, closeZone, notifier }).catch(err => {
             console.error(`daemon: unhandled error in cycle close path for ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -175,16 +191,18 @@ type RunCloseInputs = {
     zone: Zone;
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
+    notifier: Notifier;
 };
 
 async function runClose(inputs: RunCloseInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, closeZone } = inputs;
+    const { db, clock, registry, zone, cycle, closeZone, notifier } = inputs;
 
     try {
         await closeZone(zone);
     } catch (err) {
         console.error(`daemon: closeZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving closed_at NULL.`, err);
         registry.clearInFlight(cycle.id);
+        await notifier('error', { zoneName: zone.name, operation: 'close', reason: errorMessage(err) });
         return;
     }
 
@@ -192,6 +210,7 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
     await db.update(irrigationCycles).set({ closedAt }).where(eq(irrigationCycles.id, cycle.id));
     registry.clearInFlight(cycle.id);
     console.log(`daemon: closed zone ${zone.id} for cycle ${cycle.id} at ${closedAt.toISOString()}.`);
+    await notifier('watering-ended', { zoneName: zone.name });
 }
 
 /**
@@ -205,8 +224,9 @@ export async function closeAllInFlight(inputs: {
     clock: Clock;
     registry: TimerRegistry;
     closeZone: (zone: Zone) => Promise<void>;
+    notifier: Notifier;
 }): Promise<void> {
-    const { db, clock, registry, closeZone } = inputs;
+    const { db, clock, registry, closeZone, notifier } = inputs;
     const inFlight = registry.snapshotInFlight();
 
     if (inFlight.length === 0) return;
@@ -216,9 +236,16 @@ export async function closeAllInFlight(inputs: {
         try {
             await closeZone(zone);
             await db.update(irrigationCycles).set({ closedAt: clock.now() }).where(eq(irrigationCycles.id, cycleId));
+            await notifier('watering-ended', { zoneName: zone.name, reason: 'shutdown' });
         } catch (err) {
             console.error(`daemon: shutdown closeZone failed for cycle ${cycleId} on zone ${zone.id}.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'shutdown-close', reason: errorMessage(err) });
         }
         registry.clearInFlight(cycleId);
     }
+}
+
+function errorMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    return String(err);
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,6 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import Config from '@/config';
 import { start as daemonStart, type DaemonControl, type DaemonDb, type DaemonStatus } from '@/daemon';
+import { createNotifier } from '@/notifications';
 
 const shutdownStarted = new WeakSet<FastifyInstance>();
 
@@ -37,7 +38,8 @@ export async function gracefulShutdown(app: FastifyInstance, daemon: DaemonContr
 
 if (import.meta.main) {
     const { db } = await import('@/db');
-    const daemon = await daemonStart(db as unknown as DaemonDb);
+    const notifier = createNotifier();
+    const daemon = await daemonStart(db as unknown as DaemonDb, { notifier });
     const app = buildApp({ getStatus: daemon.getStatus });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/notifications/.test.ts
+++ b/api/notifications/.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { createNotifier, noopNotifier } from '.';
+
+const mockFetch = mock(() => Promise.resolve({} as Response));
+(global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+const HA_URL = 'http://ha.local:8123';
+const HA_TOKEN = 'test-token-456';
+const HA_NOTIFY_SERVICE = 'mobile_app_pixel_8';
+
+const ENV_KEYS = [
+    'HA_URL',
+    'HA_TOKEN',
+    'HA_NOTIFY_SERVICE',
+    'NOTIFY_ON_WATERING_START',
+    'NOTIFY_ON_WATERING_END',
+    'NOTIFY_ON_ERROR',
+] as const;
+
+describe('createNotifier', () => {
+    let saved: Record<string, string | undefined>;
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        saved = {};
+        for (const key of ENV_KEYS) saved[key] = process.env[key];
+        process.env.HA_URL = HA_URL;
+        process.env.HA_TOKEN = HA_TOKEN;
+        process.env.HA_NOTIFY_SERVICE = HA_NOTIFY_SERVICE;
+        delete process.env.NOTIFY_ON_WATERING_START;
+        delete process.env.NOTIFY_ON_WATERING_END;
+        delete process.env.NOTIFY_ON_ERROR;
+        mockFetch.mockClear();
+        mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' } as Response);
+        warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (saved[key] === undefined) delete process.env[key];
+            else process.env[key] = saved[key];
+        }
+        warnSpy.mockRestore();
+    });
+
+    it('returns the no-op notifier and warns when HA_NOTIFY_SERVICE is unset', async () => {
+        delete process.env.HA_NOTIFY_SERVICE;
+
+        const notifier = createNotifier();
+
+        expect(notifier).toBe(noopNotifier);
+        await notifier('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'oops' });
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the no-op notifier when HA_URL is missing', () => {
+        delete process.env.HA_URL;
+
+        const notifier = createNotifier();
+
+        expect(notifier).toBe(noopNotifier);
+    });
+
+    it('returns the no-op notifier when HA_TOKEN is missing', () => {
+        delete process.env.HA_TOKEN;
+
+        const notifier = createNotifier();
+
+        expect(notifier).toBe(noopNotifier);
+    });
+
+    it('does not POST a watering-started event by default (opt-in)', async () => {
+        const notifier = createNotifier();
+
+        await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20 });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not POST a watering-ended event by default (opt-in)', async () => {
+        const notifier = createNotifier();
+
+        await notifier('watering-ended', { zoneName: 'Front Lawn' });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('POSTs an error event by default (errors should be loud)', async () => {
+        const notifier = createNotifier();
+
+        await notifier('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'HA down' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('POSTs a watering-started event when NOTIFY_ON_WATERING_START=true', async () => {
+        process.env.NOTIFY_ON_WATERING_START = 'true';
+        const notifier = createNotifier();
+
+        await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20 });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('POSTs to the HA notify service URL with bearer auth and JSON body shape', async () => {
+        process.env.NOTIFY_ON_WATERING_START = 'true';
+        const notifier = createNotifier();
+
+        await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20 });
+
+        const [calledUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+        expect(calledUrl).toBe(`${HA_URL}/api/services/notify/${HA_NOTIFY_SERVICE}`);
+        expect(init.method).toBe('POST');
+        const headers = init.headers as Record<string, string>;
+        expect(headers['Authorization']).toBe(`Bearer ${HA_TOKEN}`);
+        expect(headers['Content-Type']).toBe('application/json');
+        const parsed = JSON.parse(init.body as string) as { message: string; title: string };
+        expect(parsed.title).toBe('Irrigo');
+        expect(parsed.message).toContain('Front Lawn');
+        expect(parsed.message).toContain('20');
+    });
+
+    it('builds different messages for boot-armed and natural watering-started events', async () => {
+        process.env.NOTIFY_ON_WATERING_START = 'true';
+        const notifier = createNotifier();
+
+        await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20 });
+        await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20, reason: 'boot' });
+
+        const calls = mockFetch.mock.calls as Array<[string, RequestInit]>;
+        const firstMessage = (JSON.parse(calls[0]![1].body as string) as { message: string }).message;
+        const secondMessage = (JSON.parse(calls[1]![1].body as string) as { message: string }).message;
+        expect(firstMessage).not.toContain('daemon restart');
+        expect(secondMessage).toContain('daemon restart');
+    });
+
+    it('builds a shutdown-qualified message for shutdown-driven watering-ended events', async () => {
+        process.env.NOTIFY_ON_WATERING_END = 'true';
+        const notifier = createNotifier();
+
+        await notifier('watering-ended', { zoneName: 'Front Lawn', reason: 'shutdown' });
+
+        const init = mockFetch.mock.calls[0]![1] as RequestInit;
+        const message = (JSON.parse(init.body as string) as { message: string }).message;
+        expect(message).toContain('shutdown');
+    });
+
+    it('includes operation and reason in error event messages', async () => {
+        const notifier = createNotifier();
+
+        await notifier('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
+
+        const init = mockFetch.mock.calls[0]![1] as RequestInit;
+        const message = (JSON.parse(init.body as string) as { message: string }).message;
+        expect(message).toContain('open');
+        expect(message).toContain('HA 502');
+        expect(message).toContain('Front Lawn');
+    });
+
+    it('swallows fetch rejections without throwing and logs a warning', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('network down'));
+        const notifier = createNotifier();
+
+        await expect(notifier('error', { operation: 'open', reason: 'oops' })).resolves.toBeUndefined();
+        expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('swallows non-2xx responses without throwing and logs a warning', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 502, statusText: 'Bad Gateway' } as Response);
+        const notifier = createNotifier();
+
+        await expect(notifier('error', { operation: 'open', reason: 'oops' })).resolves.toBeUndefined();
+        expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('treats NOTIFY_ON_ERROR=false as disabled', async () => {
+        process.env.NOTIFY_ON_ERROR = 'false';
+        const notifier = createNotifier();
+
+        await notifier('error', { operation: 'open', reason: 'oops' });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('parses 1/0 as truthy/falsy for the flags', async () => {
+        process.env.NOTIFY_ON_WATERING_START = '1';
+        process.env.NOTIFY_ON_WATERING_END = '0';
+        const notifier = createNotifier();
+
+        await notifier('watering-started', { zoneName: 'A' });
+        await notifier('watering-ended', { zoneName: 'A' });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/api/notifications/index.ts
+++ b/api/notifications/index.ts
@@ -1,0 +1,120 @@
+/**
+ * Notification framework. Surfaces watering events and errors through Home
+ * Assistant's `notify` service so HA can fan them out to whatever channels
+ * it has wired up (mobile companion, persistent notification, email, etc.).
+ *
+ * Best-effort by design: the notifier never throws, never retries, and never
+ * blocks the caller's work for long. The alerting channel can be the failing
+ * channel — retrying notifications during an HA outage just makes things
+ * worse.
+ */
+
+/** Coarse event categories the daemon emits. */
+export type NotificationEvent = 'watering-started' | 'watering-ended' | 'error';
+
+/**
+ * Optional context fields included on a notification. Producers fill in
+ * whichever fields are relevant; the message-builder formats them into
+ * human-readable copy.
+ */
+export type NotificationContext = {
+    /** Zone display name. Used in the notification message. */
+    zoneName?: string;
+
+    /** Cycle duration in minutes. Included in `watering-started` messages. */
+    durationMin?: number;
+
+    /** Operation that failed for `error` events (e.g. `open`, `close`, `re-plan`). */
+    operation?: string;
+
+    /** Free-form qualifier (`boot`, `shutdown`, error message, etc.). */
+    reason?: string;
+};
+
+/**
+ * Sends a notification. Resolves whether or not the notification succeeded —
+ * callers should fire-and-forget.
+ */
+export type Notifier = (event: NotificationEvent, context?: NotificationContext) => Promise<void>;
+
+/**
+ * No-op default: resolves immediately, never touches the network. Returned
+ * by `createNotifier` when the env config disables notifications, and used
+ * as the safe daemon default for tests.
+ */
+export const noopNotifier: Notifier = async () => {};
+
+/**
+ * Reads notification config from env at construction time and returns a
+ * `Notifier` closure. If `HA_URL`, `HA_TOKEN`, or `HA_NOTIFY_SERVICE` is
+ * missing, returns `noopNotifier` and logs a single `console.warn` so the
+ * operator knows notifications are off.
+ */
+export function createNotifier(): Notifier {
+    const url = process.env.HA_URL;
+    const token = process.env.HA_TOKEN;
+    const service = process.env.HA_NOTIFY_SERVICE;
+
+    if (!url || !token || !service) {
+        console.warn('notifications: HA_URL, HA_TOKEN, or HA_NOTIFY_SERVICE not set; notifications disabled.');
+        return noopNotifier;
+    }
+
+    const flags = {
+        wateringStarted: parseBoolean(process.env.NOTIFY_ON_WATERING_START, false),
+        wateringEnded: parseBoolean(process.env.NOTIFY_ON_WATERING_END, false),
+        error: parseBoolean(process.env.NOTIFY_ON_ERROR, true),
+    };
+
+    const endpoint = `${url.endsWith('/') ? url.slice(0, -1) : url}/api/services/notify/${service}`;
+
+    return async (event, context) => {
+        if (event === 'watering-started' && !flags.wateringStarted) return;
+        if (event === 'watering-ended' && !flags.wateringEnded) return;
+        if (event === 'error' && !flags.error) return;
+
+        const message = buildMessage(event, context);
+        const body = JSON.stringify({ message, title: 'Irrigo' });
+
+        try {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body,
+            });
+            if (!response.ok) {
+                console.warn(`notifications: HA notify ${event} returned ${response.status} ${response.statusText}.`);
+            }
+        } catch (err) {
+            console.warn(`notifications: HA notify ${event} failed; swallowing.`, err);
+        }
+    };
+}
+
+function buildMessage(event: NotificationEvent, context?: NotificationContext): string {
+    const zone = context?.zoneName ?? 'Zone';
+    if (event === 'watering-started') {
+        const dur = context?.durationMin !== undefined ? ` (~${context.durationMin} min)` : '';
+        if (context?.reason === 'boot') return `${zone} watering started${dur} (recovered after daemon restart).`;
+        return `${zone} watering started${dur}.`;
+    }
+    if (event === 'watering-ended') {
+        if (context?.reason === 'shutdown') return `${zone} watering ended (closed during daemon shutdown).`;
+        return `${zone} watering ended.`;
+    }
+    // error
+    const op = context?.operation ?? 'unknown';
+    const reason = context?.reason ?? 'unknown';
+    return `Irrigo error during ${op} on ${zone}: ${reason}.`;
+}
+
+function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
+    if (raw === undefined) return fallback;
+    const lower = raw.trim().toLowerCase();
+    if (lower === 'true' || lower === '1') return true;
+    if (lower === 'false' || lower === '0' || lower === '') return false;
+    return fallback;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,10 @@ services:
             HA_TOKEN: ${HA_TOKEN:-}
             HA_RETRY_MAX: ${HA_RETRY_MAX:-3}
             HA_RETRY_BASE_MS: ${HA_RETRY_BASE_MS:-1000}
+            HA_NOTIFY_SERVICE: ${HA_NOTIFY_SERVICE:-}
+            NOTIFY_ON_WATERING_START: ${NOTIFY_ON_WATERING_START:-false}
+            NOTIFY_ON_WATERING_END: ${NOTIFY_ON_WATERING_END:-false}
+            NOTIFY_ON_ERROR: ${NOTIFY_ON_ERROR:-true}
         ports:
             - "${PORT:-9753}:9753"
         command: sh -c "bun run start"


### PR DESCRIPTION
## Ticket

[API-12](http://192.168.2.100:7123/irrigo/browse/API-12/) Notification framework via Home Assistant.

## Summary

- Added a notifications module (`api/notifications/index.ts`) exposing `Notifier`, `noopNotifier`, and `createNotifier()`. The factory reads env once at construction, returns the no-op when `HA_URL`/`HA_TOKEN`/`HA_NOTIFY_SERVICE` aren't all set, and otherwise returns a closure that POSTs `{message, title: 'Irrigo'}` to `${HA_URL}/api/services/notify/${HA_NOTIFY_SERVICE}` with the existing bearer-auth pattern.
- Three event types: `watering-started`, `watering-ended`, `error`. Per-event flags (`NOTIFY_ON_WATERING_START`/`NOTIFY_ON_WATERING_END`/`NOTIFY_ON_ERROR`) toggle each. Defaults: start/end opt-in (false), error loud (true).
- **Notifier deliberately skips the retry primitive** — best-effort, fire-and-forget. Fetch rejections and non-2xx responses are swallowed with a warn so the daemon's hot path never throws on a missing alerting channel.
- Wired into the daemon at every meaningful integration point: `runOpen` success/error, `runClose` success/error, `closeAllInFlight` success/error, `rePlan` per-zone catch.
- Boot-recovery vs scheduled distinction: cycles armed at daemon startup pass `armReason: 'boot'`, surfacing as `reason: 'boot'` in the `watering-started` notification (e.g. "Front Lawn watering started (~12 min) (recovered after daemon restart).").
- Shutdown distinction: `closeAllInFlight` emits `watering-ended` with `reason: 'shutdown'` (e.g. "Front Lawn watering ended (closed during daemon shutdown).").
- Plumbed `HA_NOTIFY_SERVICE` and `NOTIFY_ON_*` flags through `.env.example` and `docker-compose.yml`. Documented in `CLAUDE.md`.
- Tests: 15 in the new notifications suite (disabled, defaults, opt-in flags, body/URL/auth shape, message context across boot/shutdown/error variants, fetch failure and non-2xx swallowing). 11 new daemon tests covering the boot-vs-scheduled distinction, runOpen/runClose success+error paths, natural watering-ended, closeAllInFlight shutdown notify + error, and rePlan-error notification. Full api suite: 262 pass / 0 fail.

Out of scope: rate-limiting (the open design question — explicitly deferred), daily summary, channels other than HA notify, DB-stored prefs, API-17 manual zone-fire integration (those endpoints don't exist yet).