### PR TITLE
[API-10] Enforce serial execution across zones

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -26,6 +26,7 @@ import {
 } from './zones';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
 import { noopNotifier, type NotificationContext, type NotificationEvent, type Notifier } from '@/notifications';
+import { WateringSequencer } from './sequencer';
 
 type RecordedNotification = { event: NotificationEvent; context: NotificationContext | undefined };
 
@@ -855,7 +856,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone, closeZone, notifier: noopNotifier });
 
         await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
 
@@ -882,7 +883,7 @@ describe('armCycle', () => {
         const openZone = async () => { throw new Error('HA down'); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone, closeZone, notifier: noopNotifier });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(closes).toEqual([]);
@@ -903,7 +904,7 @@ describe('armCycle', () => {
         const openZone = async () => { /* success */ };
         const closeZone = async () => { throw new Error('close failed'); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone, closeZone, notifier: noopNotifier });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(updates).toHaveLength(1);
@@ -926,7 +927,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async () => { /* success */ };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone, closeZone, notifier: noopNotifier });
         await advanceTo(new Date('2026-05-04T12:05:01.000Z'));
 
         expect(opens).toHaveLength(1);
@@ -941,7 +942,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-N', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 12 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
 
         const started = calls.find(c => c.event === 'watering-started');
@@ -956,7 +957,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T11:00:00.000Z'), durationMin: 12 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, armReason: 'boot' });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, armReason: 'boot' });
         await advanceTo(new Date('2026-05-04T12:00:30.000Z'));
 
         const started = calls.find(c => c.event === 'watering-started');
@@ -972,7 +973,7 @@ describe('armCycle', () => {
         const { notifier, calls } = recordingNotifier();
 
         armCycle({
-            db, clock, registry, zone, cycle,
+            db, clock, registry, sequencer: new WateringSequencer(), zone, cycle,
             openZone: async () => { throw new Error('HA 502'); },
             closeZone: async () => {},
             notifier,
@@ -992,7 +993,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-OK', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
+        armCycle({ db, clock, registry, sequencer: new WateringSequencer(), zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
         await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
 
         const ended = calls.find(c => c.event === 'watering-ended');
@@ -1008,7 +1009,7 @@ describe('armCycle', () => {
         const { notifier, calls } = recordingNotifier();
 
         armCycle({
-            db, clock, registry, zone, cycle,
+            db, clock, registry, sequencer: new WateringSequencer(), zone, cycle,
             openZone: async () => {},
             closeZone: async () => { throw new Error('close failed'); },
             notifier,
@@ -1018,6 +1019,170 @@ describe('armCycle', () => {
         expect(calls.some(c => c.event === 'watering-started')).toBe(true);
         const errorCall = calls.find(c => c.event === 'error');
         expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'close', reason: 'close failed' });
+    });
+});
+
+describe('serial execution (WateringSequencer)', () => {
+    const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+    it('defers a second cycle scheduled at the same start time until the first one closes', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const sequencer = new WateringSequencer();
+        const zoneA = buildZoneModel({ id: 'zone-A', name: 'Zone A' });
+        const zoneB = buildZoneModel({ id: 'zone-B', name: 'Zone B' });
+        const opensInOrder: Array<{ id: string; firedAt: number }> = [];
+        const openZone = async (z: Zone) => { opensInOrder.push({ id: z.id, firedAt: clock.now().getTime() }); };
+        const closeZone = async () => {};
+
+        const cycleA = buildPersistedCycle({ id: 'cycle-A', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 20 });
+        const cycleB = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 15 });
+
+        armCycle({ db, clock, registry, sequencer, zone: zoneA, cycle: cycleA, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer, zone: zoneB, cycle: cycleB, openZone, closeZone, notifier: noopNotifier });
+
+        // After both setTimeouts fire (at 13:00), only A should have opened. B is queued.
+        await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
+        expect(opensInOrder.map(o => o.id)).toEqual(['zone-A']);
+        expect(sequencer.getQueueDepth()).toBe(1);
+
+        // After A's close (20 min later), B should have opened with firedAt = release time, not 13:00.
+        await advanceTo(new Date('2026-05-04T13:20:01.000Z'));
+        expect(opensInOrder.map(o => o.id)).toEqual(['zone-A', 'zone-B']);
+        expect(opensInOrder[1]?.firedAt).toBe(new Date('2026-05-04T13:20:00.000Z').getTime());
+    });
+
+    it('defers a cycle whose start_time falls inside an in-flight cycle', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const sequencer = new WateringSequencer();
+        const zoneA = buildZoneModel({ id: 'zone-A' });
+        const zoneB = buildZoneModel({ id: 'zone-B' });
+        const opensInOrder: Array<{ id: string; firedAt: number }> = [];
+        const openZone = async (z: Zone) => { opensInOrder.push({ id: z.id, firedAt: clock.now().getTime() }); };
+        const closeZone = async () => {};
+
+        // A starts at 13:00, runs 30 min. B is scheduled to start at 13:10 — inside A's window.
+        const cycleA = buildPersistedCycle({ id: 'cycle-A', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 30 });
+        const cycleB = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T13:10:00.000Z'), durationMin: 10 });
+
+        armCycle({ db, clock, registry, sequencer, zone: zoneA, cycle: cycleA, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer, zone: zoneB, cycle: cycleB, openZone, closeZone, notifier: noopNotifier });
+
+        // Advance just past A's open and B's planned start; B should have queued.
+        await advanceTo(new Date('2026-05-04T13:10:30.000Z'));
+        expect(opensInOrder.map(o => o.id)).toEqual(['zone-A']);
+
+        // Past A's close (13:30); B should have fired at A's close time.
+        await advanceTo(new Date('2026-05-04T13:30:30.000Z'));
+        expect(opensInOrder.map(o => o.id)).toEqual(['zone-A', 'zone-B']);
+        expect(opensInOrder[1]?.firedAt).toBe(new Date('2026-05-04T13:30:00.000Z').getTime());
+    });
+
+    it('releases the lock when openZone fails so the next deferred cycle can fire', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const sequencer = new WateringSequencer();
+        const zoneA = buildZoneModel({ id: 'zone-A' });
+        const zoneB = buildZoneModel({ id: 'zone-B' });
+        const opensInOrder: string[] = [];
+        const openZoneFail = async (z: Zone) => {
+            if (z.id === 'zone-A') throw new Error('HA 502');
+            opensInOrder.push(z.id);
+        };
+
+        const cycleA = buildPersistedCycle({ id: 'cycle-A', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 20 });
+        const cycleB = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 10 });
+
+        armCycle({ db, clock, registry, sequencer, zone: zoneA, cycle: cycleA, openZone: openZoneFail, closeZone: async () => {}, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer, zone: zoneB, cycle: cycleB, openZone: openZoneFail, closeZone: async () => {}, notifier: noopNotifier });
+
+        await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
+
+        // A failed to open; B should fire instead of being blocked.
+        expect(opensInOrder).toEqual(['zone-B']);
+        expect(sequencer.isHeld()).toBe(true); // B holds it now.
+    });
+
+    it('releases the lock when closeZone fails so the next deferred cycle can fire', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const sequencer = new WateringSequencer();
+        const zoneA = buildZoneModel({ id: 'zone-A' });
+        const zoneB = buildZoneModel({ id: 'zone-B' });
+        const opensInOrder: string[] = [];
+        const openZone = async (z: Zone) => { opensInOrder.push(z.id); };
+        const closeZoneFail = async (z: Zone) => { if (z.id === 'zone-A') throw new Error('close stuck'); };
+
+        const cycleA = buildPersistedCycle({ id: 'cycle-A', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
+        const cycleB = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
+
+        armCycle({ db, clock, registry, sequencer, zone: zoneA, cycle: cycleA, openZone, closeZone: closeZoneFail, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer, zone: zoneB, cycle: cycleB, openZone, closeZone: closeZoneFail, notifier: noopNotifier });
+
+        // After A's close (5 min) and the close failure, B should fire.
+        await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
+        expect(opensInOrder).toEqual(['zone-A', 'zone-B']);
+    });
+
+    it('fires three queued cycles in armCycle insertion order', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const sequencer = new WateringSequencer();
+        const zoneA = buildZoneModel({ id: 'zone-A' });
+        const zoneB = buildZoneModel({ id: 'zone-B' });
+        const zoneC = buildZoneModel({ id: 'zone-C' });
+        const opensInOrder: string[] = [];
+        const openZone = async (z: Zone) => { opensInOrder.push(z.id); };
+
+        const at = new Date('2026-05-04T13:00:00.000Z');
+        const cycleA = buildPersistedCycle({ id: 'cycle-A', startTime: at, durationMin: 5 });
+        const cycleB = buildPersistedCycle({ id: 'cycle-B', startTime: at, durationMin: 5 });
+        const cycleC = buildPersistedCycle({ id: 'cycle-C', startTime: at, durationMin: 5 });
+
+        armCycle({ db, clock, registry, sequencer, zone: zoneA, cycle: cycleA, openZone, closeZone: async () => {}, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer, zone: zoneB, cycle: cycleB, openZone, closeZone: async () => {}, notifier: noopNotifier });
+        armCycle({ db, clock, registry, sequencer, zone: zoneC, cycle: cycleC, openZone, closeZone: async () => {}, notifier: noopNotifier });
+
+        // Just past all three setTimeouts; A is firing, B+C queued.
+        await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
+        expect(opensInOrder).toEqual(['zone-A']);
+        expect(sequencer.getQueueDepth()).toBe(2);
+
+        // Past A's close: B fires (queue depth 1).
+        await advanceTo(new Date('2026-05-04T13:05:01.000Z'));
+        expect(opensInOrder).toEqual(['zone-A', 'zone-B']);
+        expect(sequencer.getQueueDepth()).toBe(1);
+
+        // Past B's close: C fires.
+        await advanceTo(new Date('2026-05-04T13:10:01.000Z'));
+        expect(opensInOrder).toEqual(['zone-A', 'zone-B', 'zone-C']);
+        expect(sequencer.getQueueDepth()).toBe(0);
+    });
+
+    it('fires a non-overlapping cycle at its planned start time without involving the queue', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const sequencer = new WateringSequencer();
+        const zone = buildZoneModel({ id: 'zone-001' });
+        const opensInOrder: number[] = [];
+        const openZone = async () => { opensInOrder.push(clock.now().getTime()); };
+
+        const cycle = buildPersistedCycle({ id: 'cycle-Solo', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 10 });
+
+        armCycle({ db, clock, registry, sequencer, zone, cycle, openZone, closeZone: async () => {}, notifier: noopNotifier });
+
+        await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
+
+        // Fired at planned start, queue never had to grow.
+        expect(opensInOrder).toEqual([new Date('2026-05-04T13:00:00.000Z').getTime()]);
+        expect(sequencer.getQueueDepth()).toBe(0);
     });
 });
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -8,6 +8,7 @@ import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules'
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { loadFutureCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
 import { armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
+import { WateringSequencer } from './sequencer';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
 import { countZones, loadEnabledZones, type ZoneCountDb, type ZoneLoaderDb } from './zones';
 
@@ -100,6 +101,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const closeZone = options?.closeZone ?? defaultCloseZone;
 
     const registry = new TimerRegistry();
+    const sequencer = new WateringSequencer();
     const notifier = options?.notifier ?? noopNotifier;
     let lastRePlanAt: Date | null = null;
     let started = false;
@@ -110,7 +112,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
 
     const futureCycles = await loadFutureCycles(db, clock.now());
     for (const { cycle, zone } of futureCycles) {
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, armReason: 'boot' });
+        armCycle({ db, clock, registry, sequencer, zone, cycle, openZone, closeZone, notifier, armReason: 'boot' });
     }
 
     const { total, enabled } = await countZones(db);
@@ -144,7 +146,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                 const { entries, projectedNextDepletionMm } = await runPlan(zone);
                 const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm);
                 for (const cycle of cycles) {
-                    armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier });
+                    armCycle({ db, clock, registry, sequencer, zone, cycle, openZone, closeZone, notifier });
                 }
             } catch (err) {
                 console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -3,6 +3,7 @@ import { irrigationCycles } from '@/db/schema';
 import type { Zone } from '@/models';
 import type { Notifier } from '@/notifications';
 import type { PersistedCycle } from './schedules';
+import type { WateringSequencer } from './sequencer';
 
 /**
  * Opaque handle returned by `Clock.setTimeout`. The runtime doesn't introspect
@@ -117,6 +118,7 @@ export type ArmCycleInputs = {
     db: RuntimeDb;
     clock: Clock;
     registry: TimerRegistry;
+    sequencer: WateringSequencer;
     zone: Zone;
     cycle: PersistedCycle;
     openZone: (zone: Zone) => Promise<void>;
@@ -148,21 +150,55 @@ export function armCycle(inputs: ArmCycleInputs): void {
     let openHandle: TimerHandle;
     openHandle = clock.setTimeout(() => {
         registry.consumeOpen(openHandle);
-        runOpen(inputs).catch(err => {
+        attemptOpen(inputs).catch(err => {
             console.error(`daemon: unhandled error in cycle open path for ${cycle.id}.`, err);
         });
     }, openDelay);
     registry.addOpen(openHandle);
 }
 
+/**
+ * Acquires the sequencer lock and runs the cycle if free; otherwise enqueues
+ * the open invocation to fire when the current cycle releases. Either way,
+ * the wall-clock `setTimeout` set in `armCycle` has already fired — we're now
+ * deciding whether the relay can actually open.
+ */
+function attemptOpen(inputs: ArmCycleInputs): Promise<void> {
+    const { sequencer, cycle, zone } = inputs;
+    if (sequencer.tryAcquire()) {
+        return runOpen(inputs);
+    }
+    const queueDepth = sequencer.getQueueDepth() + 1;
+    console.log(`daemon: deferring cycle ${cycle.id} on zone ${zone.id} behind in-flight relay; queue depth: ${queueDepth}.`);
+    sequencer.enqueue(() => runOpen(inputs));
+    return Promise.resolve();
+}
+
+/**
+ * Pops the next deferred runOpen off the sequencer (if any) and invokes it.
+ * Called from every code path that ends a cycle (runOpen failure, runClose
+ * success, runClose failure) — at every release point, the next queued
+ * cycle gets its turn. When the queue is empty, the sequencer's lock is
+ * fully released and the next `tryAcquire` will succeed.
+ */
+function pumpQueue(sequencer: WateringSequencer, cycleId: string): void {
+    const next = sequencer.releaseAndDequeue();
+    if (next === null) return;
+    next().catch(err => {
+        console.error(`daemon: unhandled error in deferred cycle open path after ${cycleId}.`, err);
+    });
+}
+
 async function runOpen(inputs: ArmCycleInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, openZone, closeZone, notifier, armReason } = inputs;
+    const { db, clock, registry, sequencer, zone, cycle, openZone, closeZone, notifier, armReason } = inputs;
 
     try {
         await openZone(zone);
     } catch (err) {
         console.error(`daemon: openZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving fired_at NULL.`, err);
         await notifier('error', { zoneName: zone.name, operation: 'open', reason: errorMessage(err) });
+        // Open failed — release the sequencer so deferred cycles can run.
+        pumpQueue(sequencer, cycle.id);
         return;
     }
 
@@ -177,7 +213,7 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
 
     const closeDelay = cycle.durationMin * 60_000;
     const closeHandle = clock.setTimeout(() => {
-        runClose({ db, clock, registry, zone, cycle, closeZone, notifier }).catch(err => {
+        runClose({ db, clock, registry, sequencer, zone, cycle, closeZone, notifier }).catch(err => {
             console.error(`daemon: unhandled error in cycle close path for ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -188,6 +224,7 @@ type RunCloseInputs = {
     db: RuntimeDb;
     clock: Clock;
     registry: TimerRegistry;
+    sequencer: WateringSequencer;
     zone: Zone;
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
@@ -195,7 +232,7 @@ type RunCloseInputs = {
 };
 
 async function runClose(inputs: RunCloseInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, closeZone, notifier } = inputs;
+    const { db, clock, registry, sequencer, zone, cycle, closeZone, notifier } = inputs;
 
     try {
         await closeZone(zone);
@@ -203,6 +240,8 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
         console.error(`daemon: closeZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving closed_at NULL.`, err);
         registry.clearInFlight(cycle.id);
         await notifier('error', { zoneName: zone.name, operation: 'close', reason: errorMessage(err) });
+        // Close failed — still release the sequencer so the next deferred cycle isn't blocked forever.
+        pumpQueue(sequencer, cycle.id);
         return;
     }
 
@@ -211,6 +250,7 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
     registry.clearInFlight(cycle.id);
     console.log(`daemon: closed zone ${zone.id} for cycle ${cycle.id} at ${closedAt.toISOString()}.`);
     await notifier('watering-ended', { zoneName: zone.name });
+    pumpQueue(sequencer, cycle.id);
 }
 
 /**

--- a/api/daemon/sequencer.test.ts
+++ b/api/daemon/sequencer.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test';
+import { WateringSequencer, type DeferredOpen } from './sequencer';
+
+const noopDeferred: DeferredOpen = async () => {};
+
+describe('WateringSequencer', () => {
+    it('grants the lock to the first acquirer and refuses subsequent ones until released', () => {
+        const sequencer = new WateringSequencer();
+
+        expect(sequencer.tryAcquire()).toBe(true);
+        expect(sequencer.tryAcquire()).toBe(false);
+        expect(sequencer.tryAcquire()).toBe(false);
+    });
+
+    it('releases the lock and returns null when the queue is empty', () => {
+        const sequencer = new WateringSequencer();
+        sequencer.tryAcquire();
+
+        const next = sequencer.releaseAndDequeue();
+
+        expect(next).toBeNull();
+        expect(sequencer.isHeld()).toBe(false);
+        expect(sequencer.tryAcquire()).toBe(true);
+    });
+
+    it('transfers the lock to the next deferred entry without freeing it', () => {
+        const sequencer = new WateringSequencer();
+        sequencer.tryAcquire();
+        const deferred: DeferredOpen = async () => {};
+        sequencer.enqueue(deferred);
+
+        const next = sequencer.releaseAndDequeue();
+
+        expect(next).toBe(deferred);
+        expect(sequencer.isHeld()).toBe(true);
+        expect(sequencer.tryAcquire()).toBe(false);
+    });
+
+    it('preserves FIFO order across multiple deferrals', () => {
+        const sequencer = new WateringSequencer();
+        sequencer.tryAcquire();
+        const calls: string[] = [];
+        const a: DeferredOpen = async () => { calls.push('A'); };
+        const b: DeferredOpen = async () => { calls.push('B'); };
+        const c: DeferredOpen = async () => { calls.push('C'); };
+        sequencer.enqueue(a);
+        sequencer.enqueue(b);
+        sequencer.enqueue(c);
+
+        const first = sequencer.releaseAndDequeue();
+        const second = sequencer.releaseAndDequeue();
+        const third = sequencer.releaseAndDequeue();
+
+        expect(first).toBe(a);
+        expect(second).toBe(b);
+        expect(third).toBe(c);
+    });
+
+    it('reports the queue depth as entries are added and dequeued', () => {
+        const sequencer = new WateringSequencer();
+        sequencer.tryAcquire();
+
+        expect(sequencer.getQueueDepth()).toBe(0);
+        sequencer.enqueue(noopDeferred);
+        expect(sequencer.getQueueDepth()).toBe(1);
+        sequencer.enqueue(noopDeferred);
+        expect(sequencer.getQueueDepth()).toBe(2);
+
+        sequencer.releaseAndDequeue();
+        expect(sequencer.getQueueDepth()).toBe(1);
+        sequencer.releaseAndDequeue();
+        expect(sequencer.getQueueDepth()).toBe(0);
+    });
+
+    it('keeps the lock held after returning the last queued entry, then releases on the next empty dequeue', () => {
+        const sequencer = new WateringSequencer();
+        sequencer.tryAcquire();
+        sequencer.enqueue(noopDeferred);
+
+        // First release transfers ownership to the only queued entry — lock stays held.
+        const first = sequencer.releaseAndDequeue();
+        expect(first).toBe(noopDeferred);
+        expect(sequencer.isHeld()).toBe(true);
+
+        // Next release with no remaining entries frees the lock.
+        const second = sequencer.releaseAndDequeue();
+        expect(second).toBeNull();
+        expect(sequencer.isHeld()).toBe(false);
+    });
+});

--- a/api/daemon/sequencer.ts
+++ b/api/daemon/sequencer.ts
@@ -1,0 +1,72 @@
+/**
+ * Closure form of a deferred runOpen invocation. Wrapping it as `() =>
+ * Promise<void>` keeps the sequencer's internals decoupled from the larger
+ * `ArmCycleInputs` type — it only needs to know how to invoke a deferred
+ * cycle, not its shape.
+ */
+export type DeferredOpen = () => Promise<void>;
+
+/**
+ * Single-slot lock + FIFO queue that serializes zone watering. Acquire the
+ * lock before opening a relay; the lock is held until the close completes
+ * (success or failure). Concurrent attempts to fire while the lock is held
+ * are queued and pumped one at a time after each release.
+ *
+ * The sequencer is purely synchronous over its own state — it doesn't await
+ * anything internally. Callers drive the lifecycle: `tryAcquire` to attempt,
+ * `enqueue` to defer when held, `releaseAndDequeue` after the close finishes
+ * to either transfer the lock to the next deferred entry or free it.
+ */
+export class WateringSequencer {
+    private isLocked = false;
+    private readonly queue: DeferredOpen[] = [];
+
+    /**
+     * Attempts to take the lock. Returns true if it was free and is now held
+     * by the caller; false if it was already held. Callers that get false
+     * should `enqueue` instead.
+     */
+    tryAcquire(): boolean {
+        if (this.isLocked) return false;
+        this.isLocked = true;
+        return true;
+    }
+
+    /**
+     * Adds a deferred runOpen invocation to the FIFO queue. The lock is
+     * assumed to already be held (by whoever's currently watering); the
+     * caller will be invoked when the lock is released and there's nothing
+     * ahead of them.
+     */
+    enqueue(deferred: DeferredOpen): void {
+        this.queue.push(deferred);
+    }
+
+    /**
+     * Atomically transfers the lock to the next queued invocation, if any:
+     * pops the head of the queue and returns it (lock stays held — the
+     * caller is responsible for invoking the returned deferred). When the
+     * queue is empty, releases the lock and returns null.
+     *
+     * Combining release + dequeue in one operation prevents a race where
+     * the lock briefly looks free between dequeue and the next acquire.
+     */
+    releaseAndDequeue(): DeferredOpen | null {
+        const next = this.queue.shift();
+        if (next === undefined) {
+            this.isLocked = false;
+            return null;
+        }
+        return next;
+    }
+
+    /** Whether the lock is currently held. Exposed for tests + log lines. */
+    isHeld(): boolean {
+        return this.isLocked;
+    }
+
+    /** Number of deferred invocations waiting behind the current holder. */
+    getQueueDepth(): number {
+        return this.queue.length;
+    }
+}


### PR DESCRIPTION
## Ticket

[API-10](http://192.168.2.100:7123/irrigo/browse/API-10/) Enforce serial execution across zones.

## Summary

- Added `WateringSequencer` (`api/daemon/sequencer.ts`) — a single-slot lock + FIFO queue. `tryAcquire` / `enqueue` / `releaseAndDequeue` drive a state machine that ensures only one zone has its relay open at any moment.
- Wired the sequencer into `armCycle` via a new `attemptOpen` helper. The wall-clock `setTimeout` still fires at the cycle's planned start; if the lock is free at that moment, the cycle opens immediately. If held, the cycle's `runOpen` invocation is deferred onto the queue. `fired_at` is recorded at actual fire time (not planned start), per ticket requirement #2.
- Lock-release is wired at every cycle-end path: `runOpen` failure (open never succeeded), `runClose` success (natural end), `runClose` failure (HA didn't acknowledge close). `pumpQueue` pulls the next deferred entry and invokes it. Ticket requirement #3 (lock released on HA failure) is covered by both open- and close-failure tests.
- `closeAllInFlight` (shutdown path) untouched — the daemon is dying, sequencer state is irrelevant.
- Tests:
  - 6 unit tests on the sequencer state machine.
  - 6 scenario tests in `serial execution` describe: same-time defer, mid-cycle defer, openZone-failure release, closeZone-failure release, three-cycle FIFO ordering with queue-depth assertions, and a non-overlapping regression guard.
  - All existing direct `armCycle` callers updated to pass a fresh sequencer per test.
  - Full api suite: 274 pass / 0 fail.

## Follow-up

[API-23](http://192.168.2.100:7123/irrigo/browse/API-23/) **Planner: deconflict cycle start times across zones** is filed as a related ticket. Once that lands the runtime sequencer here becomes a defense-in-depth guard rather than a load-bearing safety net (or can be removed entirely).

## Out of scope

Skip-if-late threshold (per the user's design call — defer indefinitely for v1). DB-persistent queue (in-memory only — restart loses queued entries, but `loadFutureCycles` re-arms them). Cross-zone planner deconfliction (API-23).