### PR TITLE
[API-17] Manual zone fire and close HTTP endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ Available scripts (run from `api/`):
 - `bun run db:push` — push the schema directly to the database (dev only; bypasses migrations)
 - `bun run db:studio` — launch Drizzle Studio against `DATABASE_URL`
 
+## Security
+
+The api container exposes manual zone-control endpoints (`POST /zones/:id/open`, `/close`, `/run`) with **no authentication** — they assume a trusted LAN. Bind the api port to LAN-only or run it behind a VPN. **Never expose the api container's port to the public internet.**
+
 ## Tickets
 
 Tickets are tracked in **Plane**, in the `api` project (`API-XXX` keys). Categorization is via labels, not work-item types — every ticket gets exactly one of Epic / Feature / Bug.

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,12 +1,48 @@
 import { describe, it, expect } from 'bun:test';
 import { buildApp, gracefulShutdown } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
+import { BusyError, type ManualController } from '@/manual';
+import type { Zone } from '@/models';
 
 function buildStatus(overrides?: Partial<DaemonStatus>): DaemonStatus {
     return {
         alive: true,
         lastRePlanAt: null,
         activeZones: [],
+        ...overrides,
+    };
+}
+
+function buildZone(overrides?: Partial<Zone>): Zone {
+    return {
+        id: 'zone-001',
+        name: 'Front Lawn',
+        grassType: { name: 'Kentucky Bluegrass', cropCoefficient: 0.85 },
+        soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        flowRateLPerMin: 15,
+        areaM2: 100,
+        precipitationRateMmPerHr: 9,
+        currentDepletionMm: 12,
+        siteTimezone: 'America/Edmonton',
+        isEnabled: true,
+        homeAssistantEntityId: 'switch.zone_001',
+        ...overrides,
+    };
+}
+
+function buildManual(overrides?: Partial<ManualController>): ManualController {
+    return {
+        open: async () => ({ since: new Date('2026-05-04T15:00:00.000Z') }),
+        close: async () => ({ closed: true }),
+        run: async () => ({
+            since: new Date('2026-05-04T15:00:00.000Z'),
+            willCloseAt: new Date('2026-05-04T15:15:00.000Z'),
+        }),
+        getActiveZone: () => null,
+        shutdown: async () => {},
         ...overrides,
     };
 }
@@ -91,5 +127,241 @@ describe('gracefulShutdown', () => {
         await gracefulShutdown(app, daemon);
 
         expect(callOrder).toEqual(['daemon', 'fastify']);
+    });
+
+    it('shuts down the manual controller before the daemon when one is provided', async () => {
+        const callOrder: string[] = [];
+        const daemon = buildFakeDaemon(callOrder);
+        const manual = buildManual({ shutdown: async () => { callOrder.push('manual'); } });
+        const app = buildApp({ getStatus: daemon.getStatus });
+        const originalClose = app.close.bind(app);
+        app.close = (async () => {
+            callOrder.push('fastify');
+            await originalClose();
+        }) as typeof app.close;
+
+        await gracefulShutdown(app, daemon, manual);
+
+        expect(callOrder).toEqual(['manual', 'daemon', 'fastify']);
+    });
+});
+
+describe('buildApp manual zone routes', () => {
+    function buildAppWithManual(opts?: {
+        manual?: ManualController;
+        zoneById?: (zoneId: string) => Promise<Zone | null>;
+    }) {
+        return buildApp({
+            getStatus: () => buildStatus(),
+            manual: opts?.manual ?? buildManual(),
+            zoneById: opts?.zoneById ?? (async (id) => id === 'zone-001' ? buildZone() : null),
+        });
+    }
+
+    describe('POST /zones/:id/open', () => {
+        it('returns 200 with the open timestamp on success', async () => {
+            const app = buildAppWithManual();
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/open' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ status: 'open', since: '2026-05-04T15:00:00.000Z' });
+            await app.close();
+        });
+
+        it('returns 404 when the zone is not found', async () => {
+            const app = buildAppWithManual();
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-missing/open' });
+
+            expect(res.statusCode).toBe(404);
+            expect(res.json()).toMatchObject({ error: 'not-found' });
+            await app.close();
+        });
+
+        it('returns 409 when the controller throws BusyError', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ open: async () => { throw new BusyError('busy'); } }),
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/open' });
+
+            expect(res.statusCode).toBe(409);
+            expect(res.json()).toMatchObject({ error: 'busy' });
+            await app.close();
+        });
+
+        it('returns 502 when the controller throws a non-busy error (HA failure)', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ open: async () => { throw new Error('HA 502'); } }),
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/open' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'home-assistant', message: 'HA 502' });
+            await app.close();
+        });
+    });
+
+    describe('POST /zones/:id/close', () => {
+        it('returns 200 on success (controller is idempotent)', async () => {
+            const app = buildAppWithManual();
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/close' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ status: 'closed' });
+            await app.close();
+        });
+
+        it('returns 404 when the zone is not found', async () => {
+            const app = buildAppWithManual();
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-missing/close' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+
+        it('returns 502 when the controller throws a non-busy error', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ close: async () => { throw new Error('HA 504'); } }),
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/close' });
+
+            expect(res.statusCode).toBe(502);
+            await app.close();
+        });
+    });
+
+    describe('POST /zones/:id/run', () => {
+        it('returns 200 with since and willCloseAt for a valid duration', async () => {
+            const app = buildAppWithManual();
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-001/run',
+                payload: { durationMin: 15 },
+                headers: { 'content-type': 'application/json' },
+            });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({
+                status: 'open',
+                since: '2026-05-04T15:00:00.000Z',
+                willCloseAt: '2026-05-04T15:15:00.000Z',
+            });
+            await app.close();
+        });
+
+        it('returns 400 when the body is missing or has no durationMin', async () => {
+            const app = buildAppWithManual();
+
+            const noBody = await app.inject({ method: 'POST', url: '/zones/zone-001/run' });
+            expect(noBody.statusCode).toBe(400);
+
+            const emptyBody = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-001/run',
+                payload: {},
+                headers: { 'content-type': 'application/json' },
+            });
+            expect(emptyBody.statusCode).toBe(400);
+            await app.close();
+        });
+
+        it('returns 400 when durationMin is non-numeric, zero, or negative', async () => {
+            const app = buildAppWithManual();
+
+            for (const bad of [{ durationMin: 'fifteen' }, { durationMin: 0 }, { durationMin: -5 }]) {
+                const res = await app.inject({
+                    method: 'POST',
+                    url: '/zones/zone-001/run',
+                    payload: bad,
+                    headers: { 'content-type': 'application/json' },
+                });
+                expect(res.statusCode).toBe(400);
+            }
+            await app.close();
+        });
+
+        it('returns 400 when durationMin exceeds the controller cap', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({
+                    run: async () => { throw new Error('manual: durationMin 999 exceeds maximum 60.'); },
+                }),
+            });
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-001/run',
+                payload: { durationMin: 999 },
+                headers: { 'content-type': 'application/json' },
+            });
+
+            expect(res.statusCode).toBe(400);
+            expect(res.json()).toMatchObject({ error: 'bad-request' });
+            await app.close();
+        });
+
+        it('returns 409 when the controller throws BusyError', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ run: async () => { throw new BusyError('busy'); } }),
+            });
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-001/run',
+                payload: { durationMin: 5 },
+                headers: { 'content-type': 'application/json' },
+            });
+
+            expect(res.statusCode).toBe(409);
+            await app.close();
+        });
+
+        it('returns 502 when the controller throws a non-validation, non-busy error', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ run: async () => { throw new Error('HA 504'); } }),
+            });
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-001/run',
+                payload: { durationMin: 5 },
+                headers: { 'content-type': 'application/json' },
+            });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'home-assistant', message: 'HA 504' });
+            await app.close();
+        });
+
+        it('returns 404 when the zone is not found', async () => {
+            const app = buildAppWithManual();
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-missing/run',
+                payload: { durationMin: 5 },
+                headers: { 'content-type': 'application/json' },
+            });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+    });
+
+    describe('without a manual controller', () => {
+        it('does not register the manual routes when manual or zoneById is missing', async () => {
+            const app = buildApp({ getStatus: () => buildStatus() });
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/open' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
     });
 });

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -18,6 +18,7 @@ import { computeNextRePlanAt, start, type DaemonDb } from '.';
 import {
     countZones,
     loadEnabledZones,
+    loadZoneById,
     mapJoinedRowsToZones,
     type SelectJoinChain,
     type ZoneCountDb,
@@ -300,6 +301,27 @@ describe('loadEnabledZones', () => {
         const result = await loadEnabledZones(db);
 
         expect(result).toEqual([]);
+    });
+});
+
+describe('loadZoneById', () => {
+    it('returns the mapped Zone when a row matches the id', async () => {
+        const row = buildJoinedRow({ zone: { id: 'zone-target', name: 'Target Zone' } });
+        const { db } = createZoneLoaderStub([row]);
+
+        const result = await loadZoneById(db, 'zone-target');
+
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe('zone-target');
+        expect(result?.name).toBe('Target Zone');
+    });
+
+    it('returns null when no row matches the id', async () => {
+        const { db } = createZoneLoaderStub([]);
+
+        const result = await loadZoneById(db, 'zone-missing');
+
+        expect(result).toBeNull();
     });
 });
 

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -102,6 +102,30 @@ export async function loadEnabledZones(db: ZoneLoaderDb): Promise<Zone[]> {
 }
 
 /**
+ * Loads a single zone by id, joined with its grass/soil/site reference rows.
+ * Returns `null` if no zone exists with that id. Disabled zones are still
+ * returned — callers (e.g. the manual-fire HTTP routes) decide whether to
+ * refuse based on `zone.isEnabled`.
+ *
+ * @param db - Drizzle client (or a compatible stub).
+ * @param zoneId - The zone's UUID.
+ * @returns The mapped Zone or null.
+ */
+export async function loadZoneById(db: ZoneLoaderDb, zoneId: string): Promise<Zone | null> {
+    const rows = await db
+        .select({ zone: zones, grassType: grassTypes, soilType: soilTypes, site: sites })
+        .from(zones)
+        .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
+        .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
+        .innerJoin(sites, eq(zones.siteId, sites.id))
+        .where(eq(zones.id, zoneId));
+
+    const row = rows[0];
+    if (!row) return null;
+    return joinedRowToZone(row);
+}
+
+/**
  * Pure mapping function: filters disabled rows and turns each joined row into
  * a fully-formed `Zone` with embedded grass type, soil type, and resolved
  * location. Tested directly to keep coverage tight without involving Drizzle.

--- a/api/db/schema/schedule-entries.ts
+++ b/api/db/schema/schedule-entries.ts
@@ -1,4 +1,4 @@
-import { date, pgTable, real, uuid } from 'drizzle-orm/pg-core';
+import { date, pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
 import { zones } from './zones';
 
@@ -9,5 +9,6 @@ export const scheduleEntries = pgTable('schedule_entries', {
     appliedDepthMm: real('applied_depth_mm').notNull(),
     depletionBeforeMm: real('depletion_before_mm').notNull(),
     depletionAfterMm: real('depletion_after_mm').notNull(),
+    source: text('source').notNull().default('scheduled'),
     ...auditColumns,
 });

--- a/api/drizzle/0002_lovely_lady_vermin.sql
+++ b/api/drizzle/0002_lovely_lady_vermin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schedule_entries" ADD COLUMN "source" text DEFAULT 'scheduled' NOT NULL;

--- a/api/drizzle/meta/0002_snapshot.json
+++ b/api/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,566 @@
+{
+  "id": "06294bdf-a813-46ad-90df-1fbf20ceb6a8",
+  "prevId": "bcb67bef-049e-437b-9f87-1a27d8692090",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777945136892,
       "tag": "0001_robust_jigsaw",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1778180644537,
+      "tag": "0002_lovely_lady_vermin",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -29,10 +29,19 @@ export type BuildAppOptions = {
 export function buildApp(opts: BuildAppOptions): FastifyInstance {
     const app = Fastify();
 
+    /**
+     * `GET /` — placeholder root-of-host probe. Always 200; useful for
+     * confirming the api process is up before pointing tooling at it.
+     */
     app.get('/', async () => {
         return { message: 'Hello, world!' };
     });
 
+    /**
+     * `GET /health` — daemon liveness snapshot for ops surfaces. Re-evaluates
+     * `getStatus()` per request so a long-lived monitor sees state changes
+     * (re-plan timestamp updates, in-flight zones changing) without restarts.
+     */
     app.get('/health', async () => {
         return opts.getStatus();
     });
@@ -49,6 +58,12 @@ function registerManualRoutes(
     manual: ManualController,
     zoneById: (zoneId: string) => Promise<Zone | null>,
 ): void {
+    /**
+     * `POST /zones/:id/open` — opens the zone's relay via Home Assistant.
+     * Returns 200 with the open timestamp on success, 404 if the zone id is
+     * unknown, 409 if another fire (manual or scheduled) is already in
+     * flight, or 502 if HA itself rejected the call.
+     */
     app.post('/zones/:id/open', async (req, reply) => {
         const { id } = req.params as { id: string };
         const zone = await zoneById(id);
@@ -62,6 +77,12 @@ function registerManualRoutes(
         }
     });
 
+    /**
+     * `POST /zones/:id/close` — closes the zone's relay. Idempotent: closing
+     * a relay that the controller doesn't track still issues HA's `turn_off`
+     * (itself idempotent) and returns 200. 404 only when the zone id is
+     * unknown; 502 when HA rejects.
+     */
     app.post('/zones/:id/close', async (req, reply) => {
         const { id } = req.params as { id: string };
         const zone = await zoneById(id);
@@ -75,6 +96,13 @@ function registerManualRoutes(
         }
     });
 
+    /**
+     * `POST /zones/:id/run` — opens the zone now and schedules an automatic
+     * close after `durationMin` minutes. Body must contain a positive finite
+     * `durationMin`; the controller additionally caps it at
+     * `MAX_RUN_DURATION_MIN`. Maps controller errors: `BusyError` → 409,
+     * duration out-of-range → 400, anything else (HA failure) → 502.
+     */
     app.post('/zones/:id/run', async (req, reply) => {
         const { id } = req.params as { id: string };
         const body = req.body as Record<string, unknown> | undefined;
@@ -94,8 +122,8 @@ function registerManualRoutes(
                 willCloseAt: willCloseAt.toISOString(),
             });
         } catch (err) {
-            // Validation errors thrown by `run` (durationMin out of range) → 400.
-            // Concurrency rejections → 409. HA / IO errors → 502.
+            // Map controller-side durationMin validation (e.g. "exceeds maximum") back to 400
+            // so the client sees the same status class as the route's own pre-check above.
             if (err instanceof Error && /durationMin/.test(err.message)) {
                 return reply.code(400).send({ error: 'bad-request', message: err.message });
             }

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,15 +1,32 @@
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
 import Config from '@/config';
 import { start as daemonStart, type DaemonControl, type DaemonDb, type DaemonStatus } from '@/daemon';
+import { realClock } from '@/daemon/runtime';
+import { loadZoneById } from '@/daemon/zones';
+import { closeZone, openZone } from '@/data/home-assistant';
+import { BusyError, createManualController, type ManualController } from '@/manual';
+import type { Zone } from '@/models';
 import { createNotifier } from '@/notifications';
 
 const shutdownStarted = new WeakSet<FastifyInstance>();
 
 /**
- * Builds the Fastify instance with the routes Irrigo exposes today. The status
- * getter is injected so tests can pass a stub without a running daemon.
+ * Build-time options for the Fastify app. `manual` and `zoneById` are
+ * optional so tests that only care about `/` and `/health` don't have to
+ * stub the manual surface.
  */
-export function buildApp(opts: { getStatus: () => DaemonStatus }): FastifyInstance {
+export type BuildAppOptions = {
+    getStatus: () => DaemonStatus;
+    manual?: ManualController;
+    zoneById?: (zoneId: string) => Promise<Zone | null>;
+};
+
+/**
+ * Builds the Fastify instance with the routes Irrigo exposes today. Status
+ * and the manual-fire controller are injected so tests can substitute stubs
+ * without a running daemon or DB.
+ */
+export function buildApp(opts: BuildAppOptions): FastifyInstance {
     const app = Fastify();
 
     app.get('/', async () => {
@@ -20,17 +37,95 @@ export function buildApp(opts: { getStatus: () => DaemonStatus }): FastifyInstan
         return opts.getStatus();
     });
 
+    if (opts.manual && opts.zoneById) {
+        registerManualRoutes(app, opts.manual, opts.zoneById);
+    }
+
     return app;
 }
 
+function registerManualRoutes(
+    app: FastifyInstance,
+    manual: ManualController,
+    zoneById: (zoneId: string) => Promise<Zone | null>,
+): void {
+    app.post('/zones/:id/open', async (req, reply) => {
+        const { id } = req.params as { id: string };
+        const zone = await zoneById(id);
+        if (!zone) return reply.code(404).send({ error: 'not-found', message: `Zone ${id} not found.` });
+
+        try {
+            const { since } = await manual.open(zone);
+            return reply.code(200).send({ status: 'open', since: since.toISOString() });
+        } catch (err) {
+            return sendControllerError(reply, err);
+        }
+    });
+
+    app.post('/zones/:id/close', async (req, reply) => {
+        const { id } = req.params as { id: string };
+        const zone = await zoneById(id);
+        if (!zone) return reply.code(404).send({ error: 'not-found', message: `Zone ${id} not found.` });
+
+        try {
+            await manual.close(zone);
+            return reply.code(200).send({ status: 'closed' });
+        } catch (err) {
+            return sendControllerError(reply, err);
+        }
+    });
+
+    app.post('/zones/:id/run', async (req, reply) => {
+        const { id } = req.params as { id: string };
+        const body = req.body as Record<string, unknown> | undefined;
+        const durationMin = body?.['durationMin'];
+        if (typeof durationMin !== 'number' || !Number.isFinite(durationMin) || durationMin <= 0) {
+            return reply.code(400).send({ error: 'bad-request', message: 'durationMin must be a positive number.' });
+        }
+
+        const zone = await zoneById(id);
+        if (!zone) return reply.code(404).send({ error: 'not-found', message: `Zone ${id} not found.` });
+
+        try {
+            const { since, willCloseAt } = await manual.run(zone, durationMin);
+            return reply.code(200).send({
+                status: 'open',
+                since: since.toISOString(),
+                willCloseAt: willCloseAt.toISOString(),
+            });
+        } catch (err) {
+            // Validation errors thrown by `run` (durationMin out of range) → 400.
+            // Concurrency rejections → 409. HA / IO errors → 502.
+            if (err instanceof Error && /durationMin/.test(err.message)) {
+                return reply.code(400).send({ error: 'bad-request', message: err.message });
+            }
+            return sendControllerError(reply, err);
+        }
+    });
+}
+
+function sendControllerError(reply: FastifyReply, err: unknown): FastifyReply {
+    if (err instanceof BusyError) {
+        return reply.code(409).send({ error: 'busy', message: err.message });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return reply.code(502).send({ error: 'home-assistant', message });
+}
+
 /**
- * Closes the daemon (relays first) before the HTTP server. Idempotent per app
- * so the SIGINT/SIGTERM handlers can both fire without double-closing.
+ * Closes the manual relay (if any), then the daemon, then the HTTP server.
+ * Idempotent per app so the SIGINT/SIGTERM handlers can both fire without
+ * double-closing.
  */
-export async function gracefulShutdown(app: FastifyInstance, daemon: DaemonControl): Promise<void> {
+export async function gracefulShutdown(
+    app: FastifyInstance,
+    daemon: DaemonControl,
+    manual?: ManualController,
+): Promise<void> {
     if (shutdownStarted.has(app)) return;
     shutdownStarted.add(app);
-    console.log('shutdown: starting; closing daemon before HTTP.');
+    console.log('shutdown: starting; closing manual relay (if any) and daemon before HTTP.');
+    if (manual) await manual.shutdown();
     await daemon.shutdown();
     await app.close();
     console.log('shutdown: complete.');
@@ -40,11 +135,23 @@ if (import.meta.main) {
     const { db } = await import('@/db');
     const notifier = createNotifier();
     const daemon = await daemonStart(db as unknown as DaemonDb, { notifier });
-    const app = buildApp({ getStatus: daemon.getStatus });
+    const manual = createManualController({
+        db: db as unknown as Parameters<typeof createManualController>[0]['db'],
+        clock: realClock,
+        openZone,
+        closeZone,
+        notifier,
+        isAnyScheduledInFlight: () => daemon.getStatus().activeZones.length > 0,
+    });
+    const app = buildApp({
+        getStatus: daemon.getStatus,
+        manual,
+        zoneById: zoneId => loadZoneById(db as unknown as Parameters<typeof loadZoneById>[0], zoneId),
+    });
 
     const onSignal = (signal: NodeJS.Signals): void => {
         console.log(`process: received ${signal}; shutting down.`);
-        gracefulShutdown(app, daemon)
+        gracefulShutdown(app, daemon, manual)
             .then(() => process.exit(0))
             .catch(err => {
                 console.error('shutdown: failed.', err);

--- a/api/manual/.test.ts
+++ b/api/manual/.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect } from 'bun:test';
+import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import type { Clock, TimerHandle } from '@/daemon/runtime';
+import type { Zone } from '@/models';
+import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
+import {
+    BusyError,
+    createManualController,
+    MAX_RUN_DURATION_MIN,
+    type ManualControllerDb,
+} from '.';
+
+type RecordedNotification = { event: NotificationEvent; context: NotificationContext | undefined };
+
+function recordingNotifier(): { notifier: Notifier; calls: RecordedNotification[] } {
+    const calls: RecordedNotification[] = [];
+    const notifier: Notifier = async (event, context) => {
+        calls.push({ event, context });
+    };
+    return { notifier, calls };
+}
+
+type ScheduledTimer = { handle: number; fireAt: number; cb: () => void };
+
+function createFakeClock(initial: Date) {
+    let currentMs = initial.getTime();
+    let nextHandle = 1;
+    const timers = new Map<number, ScheduledTimer>();
+
+    const clock: Clock = {
+        now: () => new Date(currentMs),
+        setTimeout(cb, ms) {
+            const handle = nextHandle++;
+            timers.set(handle, { handle, fireAt: currentMs + ms, cb });
+            return handle as TimerHandle;
+        },
+        clearTimeout(h) {
+            timers.delete(h as number);
+        },
+    };
+
+    async function flushMicrotasks(): Promise<void> {
+        for (let i = 0; i < 50; i += 1) await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    async function advanceTo(target: Date): Promise<void> {
+        const targetMs = target.getTime();
+        while (true) {
+            let earliest: ScheduledTimer | undefined;
+            for (const t of timers.values()) {
+                if (t.fireAt > targetMs) continue;
+                if (!earliest || t.fireAt < earliest.fireAt) earliest = t;
+            }
+            if (!earliest) break;
+            timers.delete(earliest.handle);
+            currentMs = earliest.fireAt;
+            earliest.cb();
+            await flushMicrotasks();
+        }
+        currentMs = targetMs;
+    }
+
+    return { clock, advanceTo, getPendingCount: () => timers.size };
+}
+
+type InsertCall = { table: unknown; rows: ReadonlyArray<Record<string, unknown>> };
+type UpdateCall = { table: unknown; values: Record<string, unknown> };
+
+function createDbStub() {
+    const inserts: InsertCall[] = [];
+    const updates: UpdateCall[] = [];
+    let nextEntryId = 1;
+    let nextCycleId = 1;
+
+    const db: ManualControllerDb = {
+        insert(table) {
+            return {
+                values(rows) {
+                    return {
+                        returning() {
+                            inserts.push({ table, rows });
+                            if (table === scheduleEntries) {
+                                return Promise.resolve(rows.map(() => ({ id: `entry-${nextEntryId++}` })));
+                            }
+                            if (table === irrigationCycles) {
+                                return Promise.resolve(rows.map(() => ({ id: `cycle-${nextCycleId++}` })));
+                            }
+                            return Promise.resolve([]);
+                        },
+                    };
+                },
+            };
+        },
+        update(table) {
+            return {
+                set(values) {
+                    return {
+                        where() {
+                            updates.push({ table, values });
+                            return Promise.resolve(undefined);
+                        },
+                    };
+                },
+            };
+        },
+    };
+
+    return { db, inserts, updates };
+}
+
+function buildZone(overrides?: Partial<Zone>): Zone {
+    return {
+        id: 'zone-001',
+        name: 'Front Lawn',
+        grassType: { name: 'Kentucky Bluegrass', cropCoefficient: 0.85 },
+        soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        flowRateLPerMin: 15,
+        areaM2: 100,
+        precipitationRateMmPerHr: 9,
+        currentDepletionMm: 12,
+        siteTimezone: 'America/Edmonton',
+        isEnabled: true,
+        homeAssistantEntityId: 'switch.zone_001',
+        ...overrides,
+    };
+}
+
+const NOW = new Date('2026-05-04T15:00:00.000Z');
+
+describe('manual controller — open', () => {
+    it('opens the relay, records active state, returns the open timestamp', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const opens: Zone[] = [];
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async (z) => { opens.push(z); },
+            closeZone: async () => {},
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+
+        const result = await controller.open(zone);
+
+        expect(opens).toHaveLength(1);
+        expect(opens[0]?.id).toBe('zone-001');
+        expect(result.since.getTime()).toBe(NOW.getTime());
+        expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-001', zoneName: 'Front Lawn', since: NOW });
+        const started = calls.find(c => c.event === 'watering-started');
+        expect(started?.context).toEqual({ zoneName: 'Front Lawn', reason: 'manual' });
+    });
+
+    it('rejects with BusyError when a scheduled cycle is in flight', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        let openCalls = 0;
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => { openCalls += 1; },
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => true,
+        });
+
+        await expect(controller.open(buildZone())).rejects.toBeInstanceOf(BusyError);
+        expect(openCalls).toBe(0);
+    });
+
+    it('rejects with BusyError when another manual fire is already active', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+        await controller.open(buildZone());
+
+        await expect(controller.open(buildZone({ id: 'zone-002', name: 'Back' }))).rejects.toBeInstanceOf(BusyError);
+    });
+
+    it('does not retain state and emits an error notification when openZone throws', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => { throw new Error('HA 502'); },
+            closeZone: async () => {},
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+
+        await expect(controller.open(buildZone())).rejects.toThrow('HA 502');
+        expect(controller.getActiveZone()).toBeNull();
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
+    });
+});
+
+describe('manual controller — close', () => {
+    it('closes the active zone, inserts schedule_entries with source=manual, updates depletion, clears state', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, inserts, updates } = createDbStub();
+        const closes: Zone[] = [];
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async (z) => { closes.push(z); },
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+        await controller.open(zone);
+        await advanceTo(new Date('2026-05-04T15:06:00.000Z'));
+
+        await controller.close(zone);
+
+        expect(closes).toHaveLength(1);
+        const scheduleInserts = inserts.filter(c => c.table === scheduleEntries);
+        expect(scheduleInserts).toHaveLength(1);
+        expect(scheduleInserts[0]?.rows[0]).toMatchObject({
+            zoneId: 'zone-001',
+            date: '2026-05-04',
+            source: 'manual',
+        });
+        expect(scheduleInserts[0]?.rows[0]?.['appliedDepthMm']).toBeCloseTo(0.9, 1);
+        expect(scheduleInserts[0]?.rows[0]?.['depletionBeforeMm']).toBeCloseTo(12, 1);
+        const cycleInserts = inserts.filter(c => c.table === irrigationCycles);
+        expect(cycleInserts).toHaveLength(1);
+        expect(cycleInserts[0]?.rows[0]).toMatchObject({
+            scheduleEntryId: 'entry-1',
+            firedAt: NOW,
+        });
+        const zoneUpdate = updates.find(u => u.table === zones);
+        expect(zoneUpdate?.values['currentDepletionMm']).toBeCloseTo(11.3, 1);
+        expect(controller.getActiveZone()).toBeNull();
+        expect(calls.some(c => c.event === 'watering-ended')).toBe(true);
+    });
+
+    it('records duration as elapsed time between open and close', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, inserts } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+        await controller.open(zone);
+        await advanceTo(new Date('2026-05-04T15:10:00.000Z'));
+
+        await controller.close(zone);
+
+        const cycleInsert = inserts.find(c => c.table === irrigationCycles);
+        expect(cycleInsert?.rows[0]?.['durationMin']).toBe(10);
+    });
+
+    it('is a no-op success that defensively closes when no manual fire is active', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, inserts } = createDbStub();
+        const closes: Zone[] = [];
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async (z) => { closes.push(z); },
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+
+        const result = await controller.close(zone);
+
+        expect(result).toEqual({ closed: true });
+        expect(closes).toHaveLength(1);
+        expect(inserts).toHaveLength(0);
+    });
+
+    it('clears state even when closeZone rejects so subsequent calls do not see phantom state', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => { throw new Error('HA timeout'); },
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+        await controller.open(zone);
+
+        await expect(controller.close(zone)).rejects.toThrow('HA timeout');
+
+        expect(controller.getActiveZone()).toBeNull();
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context?.operation).toBe('close');
+    });
+});
+
+describe('manual controller — run', () => {
+    it('rejects with BusyError when another fire is active', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+        await controller.open(buildZone());
+
+        await expect(controller.run(buildZone({ id: 'zone-002' }), 5)).rejects.toBeInstanceOf(BusyError);
+    });
+
+    it('rejects when durationMin is zero, negative, or NaN', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+
+        await expect(controller.run(buildZone(), 0)).rejects.toThrow(/> 0/);
+        await expect(controller.run(buildZone(), -5)).rejects.toThrow(/> 0/);
+        await expect(controller.run(buildZone(), Number.NaN)).rejects.toThrow(/> 0/);
+    });
+
+    it(`rejects when durationMin exceeds the cap of ${MAX_RUN_DURATION_MIN}`, async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+
+        await expect(controller.run(buildZone(), MAX_RUN_DURATION_MIN + 1)).rejects.toThrow(/exceeds maximum/);
+    });
+
+    it('opens, records DB rows synchronously, and schedules the auto-close', async () => {
+        const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
+        const { db, inserts, updates } = createDbStub();
+        const closes: Zone[] = [];
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async (z) => { closes.push(z); },
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+
+        const result = await controller.run(zone, 15);
+
+        expect(result.since).toEqual(NOW);
+        expect(result.willCloseAt).toEqual(new Date('2026-05-04T15:15:00.000Z'));
+        // DB rows written upfront with the planned duration.
+        const cycleInsert = inserts.find(c => c.table === irrigationCycles);
+        expect(cycleInsert?.rows[0]?.['durationMin']).toBe(15);
+        expect(cycleInsert?.rows[0]?.['firedAt']).toEqual(NOW);
+        expect(cycleInsert?.rows[0]?.['closedAt']).toBeNull();
+        expect(updates.some(u => u.table === zones)).toBe(true);
+        const started = calls.find(c => c.event === 'watering-started');
+        expect(started?.context).toEqual({ zoneName: 'Front Lawn', durationMin: 15, reason: 'manual' });
+        expect(getPendingCount()).toBe(1);
+
+        await advanceTo(new Date('2026-05-04T15:15:30.000Z'));
+
+        expect(closes).toHaveLength(1);
+        const closedAtUpdate = updates.find(u => u.table === irrigationCycles && u.values['closedAt'] instanceof Date);
+        expect(closedAtUpdate?.values['closedAt']).toEqual(new Date('2026-05-04T15:15:00.000Z'));
+        expect(controller.getActiveZone()).toBeNull();
+        expect(calls.some(c => c.event === 'watering-ended')).toBe(true);
+    });
+
+    it('clears state and emits an error when the auto-close fires but closeZone rejects', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => { throw new Error('HA 504'); },
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+
+        await controller.run(zone, 5);
+        await advanceTo(new Date('2026-05-04T15:05:30.000Z'));
+
+        expect(controller.getActiveZone()).toBeNull();
+        const errorCall = calls.find(c => c.event === 'error' && c.context?.operation === 'close');
+        expect(errorCall?.context?.reason).toBe('HA 504');
+    });
+
+    it('falls back to the flow-rate / area precipitation rate when the zone has no precipitationRateMmPerHr', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, inserts } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+        // flowRate 15 L/min, area 100 m² → 60*(15/100) = 9 mm/hr. Same as the explicit 9 default.
+        const zone = buildZone({ precipitationRateMmPerHr: undefined });
+
+        await controller.run(zone, 10);
+
+        const scheduleInsert = inserts.find(c => c.table === scheduleEntries);
+        // 10/60 * 9 = 1.5 mm.
+        expect(scheduleInsert?.rows[0]?.['appliedDepthMm']).toBeCloseTo(1.5, 1);
+    });
+
+    it('clamps depletionAfter at zero rather than going negative', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, inserts } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+        // Tiny existing depletion + a long fire that would otherwise overshoot.
+        const zone = buildZone({ currentDepletionMm: 0.5 });
+
+        await controller.run(zone, 60);
+
+        const scheduleInsert = inserts.find(c => c.table === scheduleEntries);
+        expect(scheduleInsert?.rows[0]?.['depletionAfterMm']).toBe(0);
+    });
+});
+
+describe('manual controller — getActiveZone and shutdown', () => {
+    it('getActiveZone returns null when nothing is active and the snapshot when active', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+
+        expect(controller.getActiveZone()).toBeNull();
+
+        await controller.open(buildZone({ id: 'zone-007', name: 'Side Strip' }));
+
+        expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-007', zoneName: 'Side Strip', since: NOW });
+    });
+
+    it('shutdown closes any active manual zone and cancels the close timer', async () => {
+        const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
+        const { db, updates } = createDbStub();
+        const closes: Zone[] = [];
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async (z) => { closes.push(z); },
+            notifier,
+            isAnyScheduledInFlight: () => false,
+        });
+        const zone = buildZone();
+        await controller.run(zone, 10);
+        expect(getPendingCount()).toBe(1);
+
+        await controller.shutdown();
+
+        expect(closes).toHaveLength(1);
+        expect(getPendingCount()).toBe(0);
+        expect(controller.getActiveZone()).toBeNull();
+        const ended = calls.find(c => c.event === 'watering-ended');
+        expect(ended?.context).toEqual({ zoneName: 'Front Lawn', reason: 'shutdown' });
+        expect(updates.some(u => u.table === irrigationCycles && u.values['closedAt'] instanceof Date)).toBe(true);
+
+        // Advancing time past the canceled timer must not re-fire the close.
+        await advanceTo(new Date('2026-05-04T15:30:00.000Z'));
+        expect(closes).toHaveLength(1);
+    });
+
+    it('shutdown is a no-op when nothing is active', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        const closes: Zone[] = [];
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async (z) => { closes.push(z); },
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+        });
+
+        await controller.shutdown();
+
+        expect(closes).toHaveLength(0);
+    });
+});

--- a/api/manual/index.ts
+++ b/api/manual/index.ts
@@ -1,0 +1,346 @@
+import dayjs from 'dayjs';
+import { eq } from 'drizzle-orm';
+import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import type { Clock, TimerHandle } from '@/daemon/runtime';
+import type { Zone } from '@/models';
+import type { Notifier } from '@/notifications';
+
+/**
+ * Hard cap on `/run` duration. Manual fires are for testing and one-off
+ * "water now" use cases — anything longer should be a planned cycle.
+ */
+export const MAX_RUN_DURATION_MIN = 60;
+
+/**
+ * Sentinel error thrown by `open` and `run` when the controller refuses
+ * because something else is currently watering. The HTTP layer maps this
+ * to a 409.
+ */
+export class BusyError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BusyError';
+    }
+}
+
+/**
+ * Minimal db interface needed by the manual controller. Mirrors the chained
+ * Drizzle `insert/update` shapes the recording test stub already supports.
+ */
+export type ManualControllerDb = {
+    insert: (table: typeof scheduleEntries | typeof irrigationCycles) => {
+        values: (rows: ReadonlyArray<Record<string, unknown>>) => {
+            returning: (cols: Record<string, unknown>) => Promise<Array<Record<string, unknown>>>;
+        };
+    };
+    update: (table: typeof zones | typeof irrigationCycles) => {
+        set: (values: Record<string, unknown>) => {
+            where: (cond: unknown) => Promise<unknown>;
+        };
+    };
+};
+
+/**
+ * Collaborators injected at construction time so tests can substitute
+ * deterministic stubs.
+ */
+export type ManualControllerDeps = {
+    db: ManualControllerDb;
+    clock: Clock;
+    openZone: (zone: Zone) => Promise<void>;
+    closeZone: (zone: Zone) => Promise<void>;
+    notifier: Notifier;
+
+    /**
+     * Returns true if a scheduled cycle is currently in-flight. The controller
+     * uses this to refuse manual fires while the daemon owns the relay.
+     */
+    isAnyScheduledInFlight: () => boolean;
+};
+
+export type ActiveManualSnapshot = {
+    zoneId: string;
+    zoneName: string;
+    since: Date;
+};
+
+/**
+ * Public surface of the manual fire controller. Wired into HTTP routes.
+ */
+export type ManualController = {
+    /** Opens the zone's relay. Returns when HA acknowledges the turn_on. */
+    open: (zone: Zone) => Promise<{ since: Date }>;
+
+    /**
+     * Closes the zone's relay. Idempotent: if the controller has no record
+     * of this zone being open, it still issues HA's `turn_off` (which is
+     * itself idempotent) and returns success.
+     */
+    close: (zone: Zone) => Promise<{ closed: boolean }>;
+
+    /**
+     * Opens the relay and schedules an automatic close after `durationMin`
+     * minutes. Equivalent to `open` followed by a deferred `close`, but
+     * records the planned duration in the irrigation_cycles row up front.
+     */
+    run: (zone: Zone, durationMin: number) => Promise<{ since: Date; willCloseAt: Date }>;
+
+    /** Snapshot of the active manual fire (if any). Drives the HTTP status. */
+    getActiveZone: () => ActiveManualSnapshot | null;
+
+    /** Closes the open relay (best-effort) and cancels any pending close timer. */
+    shutdown: () => Promise<void>;
+};
+
+type ActiveManualFire = {
+    zone: Zone;
+    openedAt: Date;
+    closeHandle?: TimerHandle;
+    cycleId?: string;
+    runDurationMin?: number;
+};
+
+/**
+ * Builds a manual fire controller. The controller is a small in-process
+ * single-slot lock plus the side effects required to keep zone state and
+ * irrigation history coherent: it calls HA's open/close primitives, writes
+ * matching `schedule_entries` (`source = 'manual'`) and `irrigation_cycles`
+ * rows, and updates `zones.current_depletion_mm` so the planner's next
+ * re-plan starts from the post-fire soil-moisture state.
+ *
+ * @param deps - Collaborators and config.
+ * @returns Wired controller ready to back the `/zones/:id/...` routes.
+ */
+export function createManualController(deps: ManualControllerDeps): ManualController {
+    const { db, clock, openZone, closeZone, notifier, isAnyScheduledInFlight } = deps;
+    let current: ActiveManualFire | null = null;
+
+    const ensureFree = (action: string, zone: Zone): void => {
+        if (current !== null) {
+            throw new BusyError(`manual: cannot ${action} zone ${zone.id} — manual fire already active for zone ${current.zone.id}.`);
+        }
+        if (isAnyScheduledInFlight()) {
+            throw new BusyError(`manual: cannot ${action} zone ${zone.id} — a scheduled cycle is currently in flight.`);
+        }
+    };
+
+    const writeManualRecord = async (
+        zone: Zone,
+        openedAt: Date,
+        closedAt: Date | null,
+        durationMin: number,
+    ): Promise<string | null> => {
+        const today = dayjs(openedAt).format('YYYY-MM-DD');
+        const precipRate = zone.precipitationRateMmPerHr ?? (60 * (zone.flowRateLPerMin / zone.areaM2));
+        const appliedDepth = (durationMin / 60) * precipRate;
+        const netDepth = appliedDepth * zone.irrigationEfficiency;
+        const depletionBefore = zone.currentDepletionMm;
+        const depletionAfter = Math.max(0, depletionBefore - netDepth);
+
+        const insertedEntry = await db
+            .insert(scheduleEntries)
+            .values([
+                {
+                    zoneId: zone.id,
+                    date: today,
+                    appliedDepthMm: roundTo1Decimal(appliedDepth),
+                    depletionBeforeMm: roundTo1Decimal(depletionBefore),
+                    depletionAfterMm: roundTo1Decimal(depletionAfter),
+                    source: 'manual',
+                },
+            ])
+            .returning({ id: scheduleEntries.id });
+
+        const entryId = (insertedEntry[0] as { id: string } | undefined)?.id;
+        if (!entryId) {
+            console.warn(`manual: schedule_entries insert returned no id for zone ${zone.id}; skipping cycle row.`);
+            return null;
+        }
+
+        const insertedCycle = await db
+            .insert(irrigationCycles)
+            .values([
+                {
+                    scheduleEntryId: entryId,
+                    startTime: openedAt,
+                    durationMin,
+                    firedAt: openedAt,
+                    closedAt,
+                },
+            ])
+            .returning({ id: irrigationCycles.id });
+
+        const cycleId = (insertedCycle[0] as { id: string } | undefined)?.id ?? null;
+
+        await db
+            .update(zones)
+            .set({ currentDepletionMm: depletionAfter })
+            .where(eq(zones.id, zone.id));
+
+        return cycleId;
+    };
+
+    const updateCycleClosedAt = async (cycleId: string, closedAt: Date): Promise<void> => {
+        await db
+            .update(irrigationCycles)
+            .set({ closedAt })
+            .where(eq(irrigationCycles.id, cycleId));
+    };
+
+    const open: ManualController['open'] = async (zone) => {
+        ensureFree('open', zone);
+
+        try {
+            await openZone(zone);
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            console.error(`manual: openZone failed for zone ${zone.id}.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'open', reason });
+            throw err;
+        }
+
+        const openedAt = clock.now();
+        current = { zone, openedAt };
+        console.log(`manual: opened zone ${zone.id} at ${openedAt.toISOString()}.`);
+        await notifier('watering-started', { zoneName: zone.name, reason: 'manual' });
+
+        return { since: openedAt };
+    };
+
+    const close: ManualController['close'] = async (zone) => {
+        const active = current?.zone.id === zone.id ? current : null;
+
+        if (active === null) {
+            try {
+                await closeZone(zone);
+            } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                console.error(`manual: defensive closeZone failed for zone ${zone.id}.`, err);
+                await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+                throw err;
+            }
+            console.log(`manual: defensive close for zone ${zone.id} (no active manual fire).`);
+            return { closed: true };
+        }
+
+        if (active.closeHandle !== undefined) {
+            clock.clearTimeout(active.closeHandle);
+        }
+        const { openedAt, cycleId, runDurationMin } = active;
+        current = null;
+
+        try {
+            await closeZone(zone);
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            console.error(`manual: closeZone failed for zone ${zone.id}.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+            throw err;
+        }
+
+        const closedAt = clock.now();
+
+        if (runDurationMin !== undefined && cycleId !== undefined) {
+            await updateCycleClosedAt(cycleId, closedAt);
+        } else {
+            const elapsedMin = (closedAt.getTime() - openedAt.getTime()) / 60_000;
+            await writeManualRecord(zone, openedAt, closedAt, elapsedMin);
+        }
+
+        console.log(`manual: closed zone ${zone.id} at ${closedAt.toISOString()}.`);
+        await notifier('watering-ended', { zoneName: zone.name, reason: 'manual' });
+        return { closed: true };
+    };
+
+    const onScheduledCloseFire = async (zone: Zone, cycleId: string | null): Promise<void> => {
+        if (current?.zone.id !== zone.id) return;
+        current = null;
+
+        try {
+            await closeZone(zone);
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            console.error(`manual: scheduled close failed for zone ${zone.id}.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+            return;
+        }
+
+        const closedAt = clock.now();
+        if (cycleId !== null) {
+            await updateCycleClosedAt(cycleId, closedAt);
+        }
+
+        console.log(`manual: scheduled close for zone ${zone.id} at ${closedAt.toISOString()}.`);
+        await notifier('watering-ended', { zoneName: zone.name, reason: 'manual' });
+    };
+
+    const run: ManualController['run'] = async (zone, durationMin) => {
+        if (!Number.isFinite(durationMin) || durationMin <= 0) {
+            throw new Error(`manual: durationMin must be > 0 (got ${durationMin}).`);
+        }
+        if (durationMin > MAX_RUN_DURATION_MIN) {
+            throw new Error(`manual: durationMin ${durationMin} exceeds maximum ${MAX_RUN_DURATION_MIN}.`);
+        }
+        ensureFree('run', zone);
+
+        try {
+            await openZone(zone);
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            console.error(`manual: openZone failed for zone ${zone.id}.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'open', reason });
+            throw err;
+        }
+
+        const openedAt = clock.now();
+        const willCloseAt = new Date(openedAt.getTime() + durationMin * 60_000);
+        const cycleId = await writeManualRecord(zone, openedAt, null, durationMin);
+
+        const closeHandle = clock.setTimeout(() => {
+            onScheduledCloseFire(zone, cycleId).catch(err => {
+                console.error(`manual: unhandled error in scheduled close path for zone ${zone.id}.`, err);
+            });
+        }, durationMin * 60_000);
+
+        current = { zone, openedAt, closeHandle, cycleId: cycleId ?? undefined, runDurationMin: durationMin };
+        console.log(`manual: opened zone ${zone.id} at ${openedAt.toISOString()} for ${durationMin} min (auto-close).`);
+        await notifier('watering-started', { zoneName: zone.name, durationMin, reason: 'manual' });
+
+        return { since: openedAt, willCloseAt };
+    };
+
+    const getActiveZone: ManualController['getActiveZone'] = () => {
+        if (current === null) return null;
+        return { zoneId: current.zone.id, zoneName: current.zone.name, since: current.openedAt };
+    };
+
+    const shutdown: ManualController['shutdown'] = async () => {
+        if (current === null) return;
+        const active = current;
+        current = null;
+
+        if (active.closeHandle !== undefined) {
+            clock.clearTimeout(active.closeHandle);
+        }
+
+        try {
+            await closeZone(active.zone);
+            const closedAt = clock.now();
+            console.log(`manual: closed zone ${active.zone.id} on shutdown.`);
+            if (active.cycleId !== undefined) {
+                await updateCycleClosedAt(active.cycleId, closedAt);
+            }
+            await notifier('watering-ended', { zoneName: active.zone.name, reason: 'shutdown' });
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            console.error(`manual: shutdown closeZone failed for zone ${active.zone.id}.`, err);
+            await notifier('error', { zoneName: active.zone.name, operation: 'shutdown-close', reason });
+        }
+    };
+
+    return { open, close, run, getActiveZone, shutdown };
+}
+
+function roundTo1Decimal(value: number): number {
+    return Math.round(value * 10) / 10;
+}


### PR DESCRIPTION
## Ticket

[API-17](http://192.168.2.100:7123/irrigo/browse/API-17/) — Manual zone fire and close HTTP endpoints

## Summary

- New `POST /zones/:id/open`, `POST /zones/:id/close`, `POST /zones/:id/run` Fastify routes for ad-hoc zone control.
- `api/manual` controller serializes manual fires through a single in-process slot. `/open` and `/run` return **409** when (a) a scheduled cycle is in flight or (b) another manual fire is active. `/close` is idempotent (defensively calls HA `turn_off` even when no manual fire is tracked).
- Manual fires are recorded into `schedule_entries` (with a new `source` column — `'scheduled'` | `'manual'`) and `irrigation_cycles`. `zones.current_depletion_mm` is updated so the planner's next re-plan starts from honest soil-moisture state.
- `/run` validates `durationMin` is `1..60`. Body shape: `{ "durationMin": 15 }`.
- `gracefulShutdown` now closes any active manual relay before the daemon's shutdown.
- CLAUDE.md note: api endpoints are unauthenticated; bind LAN-only.

The original ticket text referenced API-10's serial lock; that lock was removed in API-23, so concurrency is now enforced via the in-process manual slot + the daemon's `getStatus().activeZones` snapshot. Scheduled cycles do **not** check for an active manual fire — the planner generally schedules predawn while manual is daytime ad-hoc; deferred to a follow-up if it becomes a real problem.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 310/310 passing (18 manual controller, 19 route tests, 2 `loadZoneById`, plus the existing suite)
- Manual smoke (optional, requires a running stack with seeded zones):
  - `curl -X POST http://localhost:3000/zones/<id>/open`
  - `curl -X POST http://localhost:3000/zones/<id>/close`
  - `curl -X POST http://localhost:3000/zones/<id>/run -H 'content-type: application/json' -d '{"durationMin":2}'`