### PR TITLE
[API-16] Verify DB schema is migrated at startup

### DIFF
--- a/api/db/verify-migrations.test.ts
+++ b/api/db/verify-migrations.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, describe, it, expect } from 'bun:test';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+    MIGRATIONS_TABLE_MISSING,
+    queryLatestMigrationViaDrizzle,
+    readJournalFile,
+    verifyMigrations,
+    type JournalEntry,
+    type LatestMigrationRow,
+    type MigrationsTableMissing,
+} from './verify-migrations';
+
+function buildDeps(overrides: {
+    queryLatestMigration?: () => Promise<LatestMigrationRow | null | MigrationsTableMissing>;
+    journal?: { entries: JournalEntry[] };
+}) {
+    return {
+        queryLatestMigration: overrides.queryLatestMigration ?? (async () => null),
+        readJournal: async () => overrides.journal ?? { entries: [] as JournalEntry[] },
+    };
+}
+
+describe('verifyMigrations', () => {
+    it('returns ok:true when the DB createdAt equals the journal\'s latest when', async () => {
+        const result = await verifyMigrations(buildDeps({
+            queryLatestMigration: async () => ({ hash: 'h2', createdAt: 200 }),
+            journal: { entries: [
+                { idx: 0, tag: '0000_first', when: 100 },
+                { idx: 1, tag: '0001_second', when: 200 },
+            ] },
+        }));
+
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('returns ok:true when the DB createdAt is greater than the journal\'s latest when', async () => {
+        const result = await verifyMigrations(buildDeps({
+            queryLatestMigration: async () => ({ hash: 'h-newer', createdAt: 500 }),
+            journal: { entries: [{ idx: 0, tag: '0000_first', when: 100 }] },
+        }));
+
+        expect(result).toEqual({ ok: true });
+    });
+
+    it('returns ok:false with the not-migrated message when the migrations table is missing', async () => {
+        const result = await verifyMigrations(buildDeps({
+            queryLatestMigration: async () => MIGRATIONS_TABLE_MISSING,
+            journal: { entries: [{ idx: 0, tag: '0000_first', when: 100 }] },
+        }));
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.message).toContain('Database is not migrated');
+            expect(result.message).toContain('bun run db:migrate');
+        }
+    });
+
+    it('returns ok:false with the behind-codebase message when the table exists but has no rows', async () => {
+        const result = await verifyMigrations(buildDeps({
+            queryLatestMigration: async () => null,
+            journal: { entries: [{ idx: 0, tag: '0000_first', when: 100 }] },
+        }));
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.message).toContain('behind the codebase');
+            expect(result.message).toContain('0000_first');
+            expect(result.message).toContain('latest applied: none');
+        }
+    });
+
+    it('returns ok:false naming the latest disk migration when the DB is behind', async () => {
+        const result = await verifyMigrations(buildDeps({
+            queryLatestMigration: async () => ({ hash: 'h0', createdAt: 100 }),
+            journal: { entries: [
+                { idx: 0, tag: '0000_first', when: 100 },
+                { idx: 1, tag: '0001_added_source_column', when: 250 },
+            ] },
+        }));
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.message).toContain('behind the codebase');
+            expect(result.message).toContain('0001_added_source_column');
+            expect(result.message).toContain(new Date(100).toISOString());
+        }
+    });
+
+    it('returns ok:true when both the DB and the journal are empty', async () => {
+        const result = await verifyMigrations(buildDeps({
+            queryLatestMigration: async () => null,
+            journal: { entries: [] },
+        }));
+
+        expect(result).toEqual({ ok: true });
+    });
+});
+
+describe('queryLatestMigrationViaDrizzle', () => {
+    it('returns the mapped row when the executor returns a non-empty result', async () => {
+        const result = await queryLatestMigrationViaDrizzle(async () => ([
+            { hash: 'abc123', created_at: 1_777_945_136_892 },
+        ]));
+
+        expect(result).toEqual({ hash: 'abc123', createdAt: 1_777_945_136_892 });
+    });
+
+    it('coerces a bigint created_at into a number', async () => {
+        const result = await queryLatestMigrationViaDrizzle(async () => ([
+            { hash: 'abc', created_at: 1_777_945_136_892n },
+        ]));
+
+        expect(result).toEqual({ hash: 'abc', createdAt: 1_777_945_136_892 });
+    });
+
+    it('returns null when the executor returns an empty array', async () => {
+        const result = await queryLatestMigrationViaDrizzle(async () => []);
+
+        expect(result).toBeNull();
+    });
+
+    it('also accepts a node-postgres-style { rows } envelope', async () => {
+        const result = await queryLatestMigrationViaDrizzle(async () => ({
+            rows: [{ hash: 'h', created_at: 50 }],
+        }));
+
+        expect(result).toEqual({ hash: 'h', createdAt: 50 });
+    });
+
+    it('returns table-missing when the executor throws with code 42P01 (undefined_table)', async () => {
+        const result = await queryLatestMigrationViaDrizzle(async () => {
+            const err = Object.assign(new Error('relation does not exist'), { code: '42P01' });
+            throw err;
+        });
+
+        expect(result).toBe(MIGRATIONS_TABLE_MISSING);
+    });
+
+    it('returns table-missing when the executor throws with code 3F000 (invalid_schema_name)', async () => {
+        const result = await queryLatestMigrationViaDrizzle(async () => {
+            const err = Object.assign(new Error('schema "drizzle" does not exist'), { code: '3F000' });
+            throw err;
+        });
+
+        expect(result).toBe(MIGRATIONS_TABLE_MISSING);
+    });
+
+    it('propagates errors with other postgres error codes', async () => {
+        await expect(queryLatestMigrationViaDrizzle(async () => {
+            throw Object.assign(new Error('connection refused'), { code: '08006' });
+        })).rejects.toThrow('connection refused');
+    });
+});
+
+describe('readJournalFile', () => {
+    const tmpDir = path.join('/tmp', `irrigo-journal-test-${Date.now()}`);
+
+    beforeAll(async () => {
+        await mkdir(path.join(tmpDir, 'meta'), { recursive: true });
+    });
+
+    afterAll(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('parses the on-disk journal for the api/drizzle directory', async () => {
+        const drizzleDir = path.resolve(import.meta.dir, '..', 'drizzle');
+
+        const journal = await readJournalFile(drizzleDir);
+
+        expect(journal.entries.length).toBeGreaterThan(0);
+        for (const entry of journal.entries) {
+            expect(typeof entry.idx).toBe('number');
+            expect(typeof entry.tag).toBe('string');
+            expect(typeof entry.when).toBe('number');
+        }
+    });
+
+    it('drops malformed entries while keeping well-formed ones', async () => {
+        await writeFile(path.join(tmpDir, 'meta', '_journal.json'), JSON.stringify({
+            version: '7',
+            entries: [
+                { idx: 0, tag: 'good', when: 100 },
+                { idx: 'bad', tag: 'wrong-types', when: 200 },
+                { idx: 1, tag: 'also-good', when: 300 },
+            ],
+        }));
+
+        const journal = await readJournalFile(tmpDir);
+
+        expect(journal.entries.map(e => e.tag)).toEqual(['good', 'also-good']);
+    });
+
+    it('throws when the journal file is missing', async () => {
+        await expect(readJournalFile(path.join(tmpDir, 'does-not-exist'))).rejects.toThrow();
+    });
+});

--- a/api/db/verify-migrations.ts
+++ b/api/db/verify-migrations.ts
@@ -1,0 +1,148 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { sql, type SQL } from 'drizzle-orm';
+
+/**
+ * Outcome of a startup migration check. `ok: false` carries a human-readable
+ * message ready for the caller to log and exit non-zero with.
+ */
+export type VerifyMigrationsResult = { ok: true } | { ok: false; message: string };
+
+/**
+ * Snapshot of the latest applied migration as recorded in
+ * `drizzle.__drizzle_migrations`. `createdAt` is the epoch-ms value that
+ * drizzle-orm wrote at apply time — identical to the journal's `when`.
+ */
+export type LatestMigrationRow = { hash: string; createdAt: number };
+
+/**
+ * One entry in `api/drizzle/meta/_journal.json`. Drizzle-kit writes these in
+ * apply order; `when` is epoch-ms.
+ */
+export type JournalEntry = { idx: number; tag: string; when: number };
+
+/**
+ * Sentinel returned by `queryLatestMigration` when the migrations table or
+ * its enclosing schema is missing — the case the verifier translates into
+ * the "Database is not migrated" failure mode.
+ */
+export const MIGRATIONS_TABLE_MISSING = 'table-missing' as const;
+export type MigrationsTableMissing = typeof MIGRATIONS_TABLE_MISSING;
+
+/**
+ * Collaborators injected at construction so the verifier is fully testable
+ * without touching either Postgres or the file system.
+ */
+export type VerifyMigrationsDeps = {
+    queryLatestMigration: () => Promise<LatestMigrationRow | null | MigrationsTableMissing>;
+    readJournal: () => Promise<{ entries: JournalEntry[] }>;
+};
+
+/**
+ * Compares the latest migration applied in the database against the latest
+ * migration committed to the codebase. Returns `ok: true` when the DB is at
+ * or ahead of the codebase, otherwise an actionable `ok: false` message.
+ *
+ * This function is pure over its deps — see `queryLatestMigrationViaDrizzle`
+ * and `readJournalFile` for the production wiring.
+ */
+export async function verifyMigrations(deps: VerifyMigrationsDeps): Promise<VerifyMigrationsResult> {
+    const latestApplied = await deps.queryLatestMigration();
+    if (latestApplied === MIGRATIONS_TABLE_MISSING) {
+        return {
+            ok: false,
+            message: 'Database is not migrated. Run `bun run db:migrate` before starting the api container.',
+        };
+    }
+
+    const journal = await deps.readJournal();
+    const latestOnDisk = journal.entries.reduce<JournalEntry | null>((max, entry) => {
+        if (max === null || entry.when > max.when) return entry;
+        return max;
+    }, null);
+
+    if (latestOnDisk === null) {
+        return { ok: true };
+    }
+
+    if (latestApplied === null || latestApplied.createdAt < latestOnDisk.when) {
+        const appliedDescription = latestApplied === null
+            ? 'none'
+            : new Date(latestApplied.createdAt).toISOString();
+        return {
+            ok: false,
+            message: `Database schema is behind the codebase (latest applied: ${appliedDescription}; latest on disk: ${latestOnDisk.tag}). Run \`bun run db:migrate\`.`,
+        };
+    }
+
+    return { ok: true };
+}
+
+/**
+ * Executes the migration-table query through a caller-supplied executor and
+ * maps Postgres "table/schema does not exist" errors to the
+ * `'table-missing'` sentinel. The executor abstraction lets the production
+ * wiring use `db.execute` while tests pass deterministic stubs.
+ */
+export async function queryLatestMigrationViaDrizzle(
+    executor: (query: SQL) => Promise<unknown>,
+): Promise<LatestMigrationRow | null | MigrationsTableMissing> {
+    try {
+        const result = await executor(
+            sql`select hash, created_at from drizzle.__drizzle_migrations order by created_at desc limit 1`,
+        );
+        const rows = extractRows(result);
+        const row = rows[0];
+        if (!row) return null;
+        const hash = row['hash'];
+        const createdAt = row['created_at'];
+        if (typeof hash !== 'string') return null;
+        const createdAtNumber = typeof createdAt === 'bigint' ? Number(createdAt) : Number(createdAt);
+        if (!Number.isFinite(createdAtNumber)) return null;
+        return { hash, createdAt: createdAtNumber };
+    } catch (err) {
+        if (isPostgresMissingObjectError(err)) return MIGRATIONS_TABLE_MISSING;
+        throw err;
+    }
+}
+
+/**
+ * Reads `_journal.json` from a drizzle output directory. The file is the
+ * source of truth for what migrations exist on disk.
+ *
+ * @param drizzleDir - Absolute path to the directory containing the `meta/`
+ *   subfolder (i.e. `api/drizzle` in this project).
+ */
+export async function readJournalFile(drizzleDir: string): Promise<{ entries: JournalEntry[] }> {
+    const filePath = path.join(drizzleDir, 'meta', '_journal.json');
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as { entries?: unknown };
+    const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+    return {
+        entries: entries.flatMap((entry): JournalEntry[] => {
+            if (entry === null || typeof entry !== 'object') return [];
+            const e = entry as Record<string, unknown>;
+            const idx = typeof e['idx'] === 'number' ? e['idx'] : null;
+            const tag = typeof e['tag'] === 'string' ? e['tag'] : null;
+            const when = typeof e['when'] === 'number' ? e['when'] : null;
+            if (idx === null || tag === null || when === null) return [];
+            return [{ idx, tag, when }];
+        }),
+    };
+}
+
+function extractRows(result: unknown): ReadonlyArray<Record<string, unknown>> {
+    // postgres-js returns an array-like RowList; node-postgres returns { rows: [] }.
+    if (Array.isArray(result)) return result as ReadonlyArray<Record<string, unknown>>;
+    if (result && typeof result === 'object' && 'rows' in result) {
+        const rows = (result as { rows: unknown }).rows;
+        if (Array.isArray(rows)) return rows as ReadonlyArray<Record<string, unknown>>;
+    }
+    return [];
+}
+
+function isPostgresMissingObjectError(err: unknown): boolean {
+    if (!err || typeof err !== 'object') return false;
+    const code = (err as { code?: unknown }).code;
+    return code === '42P01' || code === '3F000';
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,9 +1,12 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
 import Config from '@/config';
 import { start as daemonStart, type DaemonControl, type DaemonDb, type DaemonStatus } from '@/daemon';
 import { realClock } from '@/daemon/runtime';
 import { loadZoneById } from '@/daemon/zones';
 import { closeZone, openZone } from '@/data/home-assistant';
+import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import { BusyError, createManualController, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
 import { createNotifier } from '@/notifications';
@@ -161,6 +164,17 @@ export async function gracefulShutdown(
 
 if (import.meta.main) {
     const { db } = await import('@/db');
+
+    const verification = await verifyMigrations({
+        queryLatestMigration: () => queryLatestMigrationViaDrizzle(query => db.execute(query)),
+        readJournal: () => readJournalFile(path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'drizzle')),
+    });
+    if (!verification.ok) {
+        console.error(`startup: ${verification.message}`);
+        process.exit(1);
+    }
+    console.log('startup: database schema verified.');
+
     const notifier = createNotifier();
     const daemon = await daemonStart(db as unknown as DaemonDb, { notifier });
     const manual = createManualController({


### PR DESCRIPTION
## Ticket

[API-16](http://192.168.2.100:7123/irrigo/browse/API-16/) — Daemon verifies DB schema is migrated at startup

## Summary

- New `verifyMigrations` in `api/db/verify-migrations.ts` compares the latest migration recorded in `drizzle.__drizzle_migrations` against `api/drizzle/meta/_journal.json`. Returns either `{ ok: true }` or `{ ok: false, message }` with an actionable fix.
- The entrypoint runs the verifier between opening the DB connection and starting the daemon. On failure: log `startup: <message>` and `process.exit(1)` so neither the daemon nor Fastify ever boot against a stale schema. On success: log `startup: database schema verified.` and continue.
- Two failure modes:
  - `drizzle.__drizzle_migrations` (or its enclosing schema) doesn't exist → `Database is not migrated. Run \`bun run db:migrate\` before starting the api container.`
  - Latest disk migration's `when` is newer than the DB's latest `created_at` → `Database schema is behind the codebase (latest applied: ...; latest on disk: <tag>). Run \`bun run db:migrate\`.`
- Per API-4's design call (deferred again here): we do not auto-run migrations at startup. Fail loud, let the user run the migrate step.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 326/326 passing (16 new verifier tests)
- Manual smoke (optional, requires a running stack):
  - Boot the api container against an empty DB (no migrations applied) → logs `startup: Database is not migrated...` and exits non-zero.
  - Run `bun run db:migrate`, restart → logs `startup: database schema verified.`
  - Add a schema change + `bun run db:generate`, restart without migrating → logs `startup: Database schema is behind the codebase...`