### PR TITLE
[API-13] Reconcile cycle and relay state on daemon startup

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -13,3 +13,16 @@ bun run index.ts
 ```
 
 This project was created using `bun init` in bun v1.2.21. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+
+## Safety: HA-side dead-man automation
+
+The api process reconciles cycle and relay state at every startup (see `api/daemon/reconcile.ts`). That covers the case where the daemon comes back. It does **not** cover the case where the daemon stays down — host offline, DB unreachable, container crash-looping, or a network partition between Irrigo and Home Assistant. In any of those scenarios, a relay that was on at the moment of the failure stays on indefinitely, with hours of unintended watering as the worst-case outcome.
+
+To guard against that, configure a Home Assistant automation, **independent of Irrigo**, that force-closes any managed switch that has been on for longer than the longest legitimate cycle. Suggested shape:
+
+- **Trigger**: managed entity in state `on` for longer than `N` minutes — pick a value comfortably above the longest legitimate cycle (60 minutes is a safe default).
+- **Action**: `switch.turn_off` on the offending entity, plus a notification so the operator sees the safety net fire.
+- **Mode**: `single` per entity — don't pile up if the relay refuses to close.
+- **Scope**: one automation per managed zone, **or** a single automation iterating the configured entity list — both are acceptable.
+
+The automation lives entirely in Home Assistant and is not committed to this repo. Confirm it is configured for every managed zone before running unattended; this is the last line of defense against a stuck-on valve.

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1257,10 +1257,27 @@ describe('closeAllInFlight', () => {
 
 type DaemonStubInputs = {
     futureCycles?: FutureCycleJoinedRow[];
+    inFlightCycles?: FutureCycleJoinedRow[];
     enabledZones?: ZoneJoinedRow[];
     zoneCounts?: { total: number; enabled: number };
     siteTimezones?: ReadonlyArray<{ timezone: string }>;
 };
+
+function whereContainsIsNotNull(condition: unknown): boolean {
+    const seen = new WeakSet<object>();
+    function walk(node: unknown): boolean {
+        if (typeof node === 'string') return node.includes('is not null');
+        if (typeof node !== 'object' || node === null) return false;
+        if (seen.has(node)) return false;
+        seen.add(node);
+        if (Array.isArray(node)) return node.some(walk);
+        for (const value of Object.values(node)) {
+            if (walk(value)) return true;
+        }
+        return false;
+    }
+    return walk(condition);
+}
 
 function createDaemonDbStub(inputs?: DaemonStubInputs) {
     const updates: CycleUpdate[] = [];
@@ -1287,9 +1304,23 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
                 return { from: () => Promise.resolve([...siteTimezoneRows]) } as never;
             }
             const isFutureCyclesQuery = 'cycle' in cols;
-            const rows = isFutureCyclesQuery ? (inputs?.futureCycles ?? []) : enabledZoneRows;
-            const whereSink = isFutureCyclesQuery ? whereCallsCycles : whereCallsZone;
-            return { from: () => buildJoinChainStub(whereSink, rows) };
+            if (isFutureCyclesQuery) {
+                // Differentiate loadFutureCycles (where: isNull(firedAt)) from
+                // loadInFlightCycles (where: isNotNull(firedAt)) by inspecting
+                // the where condition. Each call resolves to the right list.
+                const chain: SelectJoinChain<FutureCycleJoinedRow> = {
+                    innerJoin: () => chain,
+                    where: (conditions) => {
+                        whereCallsCycles.push({ conditions });
+                        const rows = whereContainsIsNotNull(conditions)
+                            ? (inputs?.inFlightCycles ?? [])
+                            : (inputs?.futureCycles ?? []);
+                        return Promise.resolve(rows);
+                    },
+                };
+                return { from: () => chain };
+            }
+            return { from: () => buildJoinChainStub(whereCallsZone, enabledZoneRows) };
         },
         delete(table) {
             return {
@@ -1766,6 +1797,7 @@ describe('start', () => {
             runPlan: async () => { throw new Error('forecast unavailable'); },
             openZone: async () => {},
             closeZone: async () => {},
+            getZoneState: async () => 'off',
         });
 
         await control.rePlan();
@@ -1885,6 +1917,110 @@ describe('start', () => {
             // zone-C must see only zone-A's window — not the failed zone's.
             expect(calls[2]?.busyWindows).toHaveLength(1);
             expect(calls[2]?.busyWindows[0]?.start.toISOString()).toBe('2026-05-04T05:00:00.000Z');
+        });
+    });
+
+    describe('startup reconciliation', () => {
+        it('runs reconciliation before arming any future cycles from the boot loop', async () => {
+            const futureRow = buildFutureCycleRow({
+                cycle: {
+                    id: 'cycle-future',
+                    startTime: new Date('2026-05-04T13:00:00.000Z'),
+                    durationMin: 10,
+                    firedAt: null,
+                },
+            });
+            const inFlightRow = buildFutureCycleRow({
+                cycle: {
+                    id: 'cycle-inflight',
+                    startTime: new Date('2026-05-04T11:00:00.000Z'),
+                    durationMin: 90,
+                    firedAt: new Date('2026-05-04T11:00:00.000Z'),
+                    closedAt: null,
+                },
+                zone: { id: 'zone-inflight' },
+            });
+            const { db } = createDaemonDbStub({ futureCycles: [futureRow], inFlightCycles: [inFlightRow] });
+            const { clock } = createFakeClock(NOW);
+            const events: string[] = [];
+
+            await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+                openZone: async () => {},
+                closeZone: async (z) => { events.push(`close:${z.id}`); },
+                getZoneState: async (z) => {
+                    events.push(`state:${z.id}`);
+                    return 'off';
+                },
+            });
+
+            // The first event must be a state query for the in-flight zone (reconcile),
+            // not the future cycle's open. armCycle for future cycles only schedules
+            // a setTimeout, so it doesn't add events here — but the state query proves
+            // reconcile ran first.
+            expect(events[0]).toBe('state:zone-inflight');
+        });
+
+        it('logs the reconcile summary line at startup', async () => {
+            const inFlightRow = buildFutureCycleRow({
+                cycle: {
+                    id: 'cycle-running',
+                    startTime: new Date('2026-05-04T11:00:00.000Z'),
+                    durationMin: 30,
+                    firedAt: new Date('2026-05-04T11:00:00.000Z'),
+                    closedAt: null,
+                },
+                zone: { id: 'zone-running' },
+            });
+            const { db } = createDaemonDbStub({ inFlightCycles: [inFlightRow] });
+            const { clock } = createFakeClock(NOW);
+            const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+            try {
+                await start(db, {
+                    clock,
+                    rePlanHourLocal: 4,
+                    runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+                    openZone: async () => {},
+                    closeZone: async () => {},
+                    getZoneState: async () => 'off',
+                });
+
+                const messages = logSpy.mock.calls.map(args => String((args as unknown[])[0]));
+                expect(messages.some(m => m.startsWith('daemon: reconcile summary'))).toBe(true);
+            } finally {
+                logSpy.mockRestore();
+            }
+        });
+
+        it('propagates a hard reconcile failure (loadInFlightCycles throws) so start() rejects', async () => {
+            const { db: baseDb } = createDaemonDbStub();
+            const erroringDb: DaemonDb = {
+                ...baseDb,
+                select: ((cols: Record<string, unknown>) => {
+                    if ('cycle' in cols) {
+                        return {
+                            from: () => ({
+                                innerJoin: function () { return this; },
+                                where: () => Promise.reject(new Error('db down')),
+                            }),
+                        };
+                    }
+                    return baseDb.select(cols as never);
+                }) as never,
+            };
+            const { clock } = createFakeClock(NOW);
+
+            await expect(start(erroringDb, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            })).rejects.toThrow('db down');
         });
     });
 

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -39,6 +39,7 @@ function recordingNotifier(): { notifier: Notifier; calls: RecordedNotification[
 }
 import {
     loadFutureCycles,
+    loadInFlightCycles,
     replaceZoneSchedule,
     type FutureCycleJoinedRow,
     type FutureCyclesDb,
@@ -46,6 +47,7 @@ import {
     type ScheduleWriterDb,
 } from './schedules';
 import {
+    armCloseOnly,
     armCycle,
     closeAllInFlight,
     TimerRegistry,
@@ -624,6 +626,38 @@ describe('loadFutureCycles', () => {
     });
 });
 
+describe('loadInFlightCycles', () => {
+    it('returns mapped (cycle, zone) pairs for in-flight rows', async () => {
+        const row = buildFutureCycleRow({
+            cycle: { id: 'cycle-running', firedAt: new Date('2026-05-04T11:00:00.000Z'), closedAt: null },
+            zone: { id: 'zone-running' },
+        });
+        const { db } = createFutureCyclesStub([row]);
+
+        const pairs = await loadInFlightCycles(db, NOW_DAEMON);
+
+        expect(pairs).toHaveLength(1);
+        expect(pairs[0]?.cycle.id).toBe('cycle-running');
+        expect(pairs[0]?.zone.id).toBe('zone-running');
+    });
+
+    it('returns an empty array when there are no in-flight rows', async () => {
+        const { db } = createFutureCyclesStub([]);
+
+        const result = await loadInFlightCycles(db, NOW_DAEMON);
+
+        expect(result).toEqual([]);
+    });
+
+    it('issues exactly one .where(...) call per invocation', async () => {
+        const { db, whereCalls } = createFutureCyclesStub([buildFutureCycleRow()]);
+
+        await loadInFlightCycles(db, NOW_DAEMON);
+
+        expect(whereCalls).toHaveLength(1);
+    });
+});
+
 describe('computeNextRePlanAt', () => {
     it('UTC: returns todays hour when the current time is before that hour', () => {
         const now = new Date('2026-05-04T01:30:00.000Z');
@@ -1043,6 +1077,94 @@ describe('armCycle', () => {
     });
 });
 
+describe('armCloseOnly', () => {
+    const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+    it('schedules the close timer for plannedCloseAt - now and registers the cycle as in-flight', async () => {
+        const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-resume' });
+        const cycle = buildPersistedCycle({ id: 'cycle-resume', startTime: new Date('2026-05-04T11:30:00.000Z'), durationMin: 60 });
+        const closes: Zone[] = [];
+        const plannedCloseAt = new Date('2026-05-04T12:30:00.000Z');
+
+        armCloseOnly({
+            db,
+            clock,
+            registry,
+            zone,
+            cycle,
+            closeZone: async (z) => { closes.push(z); },
+            notifier: noopNotifier,
+            plannedCloseAt,
+        });
+
+        // Pre-registered immediately so getStatus.activeZones reflects the resume.
+        expect(registry.snapshotInFlight().map(({ zone }) => zone.id)).toEqual(['zone-resume']);
+        expect(getPendingCount()).toBe(1);
+        expect(closes).toHaveLength(0);
+
+        await advanceTo(new Date('2026-05-04T12:30:30.000Z'));
+
+        expect(closes).toEqual([zone]);
+        expect(updates).toContainEqual({ cycleId: 'cycle-resume', closedAt: plannedCloseAt });
+        expect(registry.snapshotInFlight()).toHaveLength(0);
+    });
+
+    it('clamps a past plannedCloseAt to a 0-ms delay and fires immediately on the next tick', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-late' });
+        const cycle = buildPersistedCycle({ id: 'cycle-late' });
+        const closes: Zone[] = [];
+
+        armCloseOnly({
+            db,
+            clock,
+            registry,
+            zone,
+            cycle,
+            closeZone: async (z) => { closes.push(z); },
+            notifier: noopNotifier,
+            plannedCloseAt: new Date('2026-05-04T11:00:00.000Z'),
+        });
+
+        await advanceTo(NOW);
+
+        expect(closes).toHaveLength(1);
+        expect(updates).toHaveLength(1);
+        expect(updates[0]?.closedAt).toEqual(NOW);
+    });
+
+    it('clears the registry entry and emits an error notification when closeZone rejects', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db, updates } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-fail', name: 'Fail Zone' });
+        const cycle = buildPersistedCycle({ id: 'cycle-fail' });
+        const { notifier, calls } = recordingNotifier();
+
+        armCloseOnly({
+            db,
+            clock,
+            registry,
+            zone,
+            cycle,
+            closeZone: async () => { throw new Error('HA timeout'); },
+            notifier,
+            plannedCloseAt: new Date('2026-05-04T12:30:00.000Z'),
+        });
+
+        await advanceTo(new Date('2026-05-04T12:30:30.000Z'));
+
+        expect(updates).toHaveLength(0);
+        expect(registry.snapshotInFlight()).toHaveLength(0);
+        const errorCall = calls.find(c => c.event === 'error');
+        expect(errorCall?.context).toEqual({ zoneName: 'Fail Zone', operation: 'close', reason: 'HA timeout' });
+    });
+});
 
 describe('closeAllInFlight', () => {
     const NOW = new Date('2026-05-04T12:00:00.000Z');

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -1,13 +1,19 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
-import { closeZone as defaultCloseZone, openZone as defaultOpenZone } from '@/data/home-assistant';
+import {
+    closeZone as defaultCloseZone,
+    getZoneState as defaultGetZoneState,
+    openZone as defaultOpenZone,
+    type ZoneRelayState,
+} from '@/data/home-assistant';
 import type { Zone } from '@/models';
 import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
-import { loadFutureCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
-import { armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
+import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
+import { loadFutureCycles, loadInFlightCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
+import { armCloseOnly, armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
 import { countZones, loadEnabledZones, type ZoneCountDb, type ZoneLoaderDb } from './zones';
 
@@ -39,6 +45,9 @@ export type DaemonOptions = {
 
     /** Override the HA close-relay primitive. */
     closeZone?: (zone: Zone) => Promise<void>;
+
+    /** Override the HA state-query primitive. Used by boot reconciliation. */
+    getZoneState?: (zone: Zone) => Promise<ZoneRelayState>;
 
     /** Override for time/timer access. */
     clock?: Clock;
@@ -98,6 +107,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const runPlan = options?.runPlan ?? ((zone, opts) => runScheduleForZone(zone, opts));
     const openZone = options?.openZone ?? defaultOpenZone;
     const closeZone = options?.closeZone ?? defaultCloseZone;
+    const getZoneState = options?.getZoneState ?? defaultGetZoneState;
 
     const registry = new TimerRegistry();
     const notifier = options?.notifier ?? noopNotifier;
@@ -107,6 +117,20 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const siteTimezone = options?.siteTimezone ?? await loadSiteTimezone(db);
 
     console.log(`daemon: starting (re-plan hour: ${rePlanHourLocal}:00 ${siteTimezone}).`);
+
+    const enabledZonesAtBoot = await loadEnabledZones(db);
+    const reconcileSummary: ReconcileSummary = await reconcileCycleAndRelayState({
+        db,
+        clock,
+        registry,
+        notifier,
+        closeZone,
+        getZoneState,
+        loadInFlightCycles,
+        armCloseOnly,
+        managedZones: enabledZonesAtBoot.filter(z => z.homeAssistantEntityId !== undefined),
+    });
+    console.log(`daemon: reconcile summary — resumed: ${reconcileSummary.resumed}, forcedClosed: ${reconcileSummary.forcedClosed}, missedClose: ${reconcileSummary.missedClose}, orphansClosed: ${reconcileSummary.orphansClosed}, errors: ${reconcileSummary.errors}.`);
 
     const futureCycles = await loadFutureCycles(db, clock.now());
     for (const { cycle, zone } of futureCycles) {

--- a/api/daemon/reconcile.test.ts
+++ b/api/daemon/reconcile.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from 'bun:test';
+import { irrigationCycles } from '@/db/schema';
+import type { ZoneRelayState } from '@/data/home-assistant';
+import type { Zone } from '@/models';
+import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
+import { reconcileCycleAndRelayState, type ReconcileDb, type ReconcileDeps } from './reconcile';
+import type { FutureCyclePair } from './schedules';
+import type { ArmCloseOnlyInputs, Clock, TimerHandle, TimerRegistry } from './runtime';
+
+type RecordedNotification = { event: NotificationEvent; context: NotificationContext | undefined };
+
+const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+function buildZone(overrides?: Partial<Zone>): Zone {
+    return {
+        id: 'zone-001',
+        name: 'Front Lawn',
+        grassType: { name: 'Kentucky Bluegrass', cropCoefficient: 0.85 },
+        soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        flowRateLPerMin: 15,
+        areaM2: 100,
+        precipitationRateMmPerHr: 9,
+        currentDepletionMm: 0,
+        siteTimezone: 'America/Edmonton',
+        isEnabled: true,
+        homeAssistantEntityId: 'switch.zone_001',
+        ...overrides,
+    };
+}
+
+function buildPair(overrides?: {
+    cycleId?: string;
+    startTime?: Date;
+    durationMin?: number;
+    zone?: Partial<Zone>;
+}): FutureCyclePair {
+    return {
+        cycle: {
+            id: overrides?.cycleId ?? 'cycle-001',
+            startTime: overrides?.startTime ?? new Date('2026-05-04T11:30:00.000Z'),
+            durationMin: overrides?.durationMin ?? 60,
+        },
+        zone: buildZone(overrides?.zone),
+    };
+}
+
+function fakeClock(initial: Date): Clock {
+    return {
+        now: () => initial,
+        setTimeout: () => 1 as TimerHandle,
+        clearTimeout: () => {},
+    };
+}
+
+type CycleUpdate = { cycleId: string; closedAt: Date };
+
+function buildDeps(overrides: {
+    inFlight?: FutureCyclePair[];
+    managedZones?: Zone[];
+    state?: (zone: Zone) => Promise<ZoneRelayState> | ZoneRelayState;
+    closeFn?: (zone: Zone) => Promise<void>;
+    armCloseOnly?: (inputs: ArmCloseOnlyInputs) => void;
+    now?: Date;
+}): {
+    deps: ReconcileDeps;
+    closes: Zone[];
+    armCalls: ArmCloseOnlyInputs[];
+    cycleUpdates: CycleUpdate[];
+    notifications: RecordedNotification[];
+} {
+    const closes: Zone[] = [];
+    const armCalls: ArmCloseOnlyInputs[] = [];
+    const cycleUpdates: CycleUpdate[] = [];
+    const notifications: RecordedNotification[] = [];
+    const now = overrides.now ?? NOW;
+
+    const db: ReconcileDb = {
+        select: (() => ({ from: () => ({}) })) as never,
+        update(table) {
+            return {
+                set(values) {
+                    return {
+                        async where(cond) {
+                            if (table !== irrigationCycles) return;
+                            const cycleId = extractIdFromEq(cond);
+                            const closedAt = values['closedAt'];
+                            if (closedAt instanceof Date) {
+                                cycleUpdates.push({ cycleId, closedAt });
+                            }
+                        },
+                    };
+                },
+            };
+        },
+    };
+
+    const registry: TimerRegistry = {
+        addOpen: () => {},
+        consumeOpen: () => {},
+        addInFlight: () => {},
+        clearInFlight: () => {},
+        setRePlanHandle: () => {},
+        cancelOpenTimers: () => {},
+        cancelAllTimers: () => {},
+        snapshotInFlight: () => [],
+    } as unknown as TimerRegistry;
+
+    const notifier: Notifier = async (event, context) => {
+        notifications.push({ event, context });
+    };
+
+    return {
+        closes,
+        armCalls,
+        cycleUpdates,
+        notifications,
+        deps: {
+            db,
+            clock: fakeClock(now),
+            registry,
+            notifier,
+            closeZone: overrides.closeFn ?? (async (zone) => { closes.push(zone); }),
+            getZoneState: async (zone) => {
+                if (!overrides.state) return 'unknown';
+                return overrides.state(zone);
+            },
+            loadInFlightCycles: async () => overrides.inFlight ?? [],
+            armCloseOnly: overrides.armCloseOnly ?? ((inputs) => { armCalls.push(inputs); }),
+            managedZones: overrides.managedZones ?? [],
+        },
+    };
+}
+
+function extractIdFromEq(cond: unknown): string {
+    const seen = new WeakSet<object>();
+    function walk(node: unknown): string | undefined {
+        if (typeof node === 'string') return /^cycle-/.test(node) ? node : undefined;
+        if (typeof node !== 'object' || node === null) return undefined;
+        if (seen.has(node)) return undefined;
+        seen.add(node);
+        if (Array.isArray(node)) {
+            for (const item of node) {
+                const found = walk(item);
+                if (found) return found;
+            }
+            return undefined;
+        }
+        for (const value of Object.values(node)) {
+            const found = walk(value);
+            if (found) return found;
+        }
+        return undefined;
+    }
+    return walk(cond) ?? '';
+}
+
+describe('reconcileCycleAndRelayState — in-flight cycle handling', () => {
+    it(`re-arms the close timer when HA is 'on' and planned close is in the future`, async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-future',
+            startTime: new Date('2026-05-04T11:30:00.000Z'),
+            durationMin: 60, // closes at 12:30, after now=12:00
+        });
+        const sweep = buildZone({ id: 'zone-sweep' });
+        const { deps, armCalls, closes, cycleUpdates } = buildDeps({
+            inFlight: [pair],
+            managedZones: [pair.zone, sweep],
+            state: async (zone): Promise<ZoneRelayState> => zone.id === pair.zone.id ? 'on' : 'off',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ resumed: 1, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 });
+        expect(armCalls).toHaveLength(1);
+        expect(armCalls[0]?.cycle.id).toBe('cycle-future');
+        expect(armCalls[0]?.plannedCloseAt).toEqual(new Date('2026-05-04T12:30:00.000Z'));
+        expect(closes).toHaveLength(0);
+        expect(cycleUpdates).toHaveLength(0);
+    });
+
+    it(`force-closes when HA is 'on' but planned close is in the past`, async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-overrun',
+            startTime: new Date('2026-05-04T10:00:00.000Z'),
+            durationMin: 30, // closes at 10:30, well before now=12:00
+        });
+        const { deps, closes, cycleUpdates, notifications } = buildDeps({
+            inFlight: [pair],
+            state: async (): Promise<ZoneRelayState> => 'on',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ resumed: 0, forcedClosed: 1, missedClose: 0, orphansClosed: 0 });
+        expect(closes).toHaveLength(1);
+        expect(cycleUpdates).toEqual([{ cycleId: 'cycle-overrun', closedAt: NOW }]);
+        const overrunNote = notifications.find(n => n.context?.operation === 'reconcile-overrun');
+        expect(overrunNote).toBeDefined();
+    });
+
+    it(`records closed_at = plannedCloseAt when HA is 'off' and the planned close is earlier than now`, async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-missed',
+            startTime: new Date('2026-05-04T10:00:00.000Z'),
+            durationMin: 30,
+        });
+        const { deps, cycleUpdates, closes } = buildDeps({
+            inFlight: [pair],
+            state: async (): Promise<ZoneRelayState> => 'off',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ missedClose: 1 });
+        expect(cycleUpdates).toEqual([{ cycleId: 'cycle-missed', closedAt: new Date('2026-05-04T10:30:00.000Z') }]);
+        expect(closes).toHaveLength(0);
+    });
+
+    it(`records closed_at = now when HA is 'off' and the planned close is still in the future`, async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-missed-early',
+            startTime: new Date('2026-05-04T11:30:00.000Z'),
+            durationMin: 60, // closes at 12:30, after now=12:00
+        });
+        const { deps, cycleUpdates } = buildDeps({
+            inFlight: [pair],
+            state: async (): Promise<ZoneRelayState> => 'off',
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(cycleUpdates).toEqual([{ cycleId: 'cycle-missed-early', closedAt: NOW }]);
+    });
+
+    it(`leaves the cycle alone when HA returns 'unknown' and does not mark the zone handled`, async () => {
+        const pair = buildPair({ cycleId: 'cycle-unknown' });
+        const { deps, cycleUpdates, closes, armCalls } = buildDeps({
+            inFlight: [pair],
+            managedZones: [pair.zone],
+            state: async (): Promise<ZoneRelayState> => 'unknown',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ resumed: 0, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 });
+        expect(cycleUpdates).toHaveLength(0);
+        expect(closes).toHaveLength(0);
+        expect(armCalls).toHaveLength(0);
+    });
+
+    it('counts an error and skips the cycle when getZoneState throws', async () => {
+        const pair = buildPair({ cycleId: 'cycle-err' });
+        const { deps, cycleUpdates, closes, notifications } = buildDeps({
+            inFlight: [pair],
+            state: async () => { throw new Error('HA timeout'); },
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ errors: 1 });
+        expect(cycleUpdates).toHaveLength(0);
+        expect(closes).toHaveLength(0);
+        const errNote = notifications.find(n => n.context?.operation === 'reconcile-state');
+        expect(errNote?.context?.reason).toBe('HA timeout');
+    });
+});
+
+describe('reconcileCycleAndRelayState — defensive sweep', () => {
+    it(`force-closes a managed zone HA reports 'on' with no in-flight cycle`, async () => {
+        const orphan = buildZone({ id: 'zone-orphan', name: 'Orphan' });
+        const { deps, closes, notifications } = buildDeps({
+            managedZones: [orphan],
+            state: async (): Promise<ZoneRelayState> => 'on',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ orphansClosed: 1 });
+        expect(closes).toEqual([orphan]);
+        const orphanNote = notifications.find(n => n.context?.operation === 'reconcile-orphan-close');
+        expect(orphanNote?.context?.zoneName).toBe('Orphan');
+    });
+
+    it(`takes no action for a managed zone HA reports 'off'`, async () => {
+        const calm = buildZone({ id: 'zone-calm' });
+        const { deps, closes } = buildDeps({
+            managedZones: [calm],
+            state: async (): Promise<ZoneRelayState> => 'off',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ orphansClosed: 0 });
+        expect(closes).toHaveLength(0);
+    });
+
+    it('skips a zone that was already handled as an in-flight cycle', async () => {
+        const zone = buildZone({ id: 'zone-shared' });
+        const pair = buildPair({ cycleId: 'cycle-shared', zone: { id: 'zone-shared' } });
+        const { deps, closes } = buildDeps({
+            inFlight: [pair],
+            managedZones: [zone],
+            // State is 'on' for both — without skipping, we'd call closeZone in the sweep too.
+            state: async (): Promise<ZoneRelayState> => 'off',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        // The cycle path takes care of the missed close; the sweep does NOT then act on it.
+        expect(summary).toMatchObject({ missedClose: 1, orphansClosed: 0 });
+        expect(closes).toHaveLength(0);
+    });
+
+    it('skips a zone with no homeAssistantEntityId', async () => {
+        const noEntity = buildZone({ id: 'zone-noentity', homeAssistantEntityId: undefined });
+        let stateCalls = 0;
+        const { deps, closes } = buildDeps({
+            managedZones: [noEntity],
+            state: async (): Promise<ZoneRelayState> => { stateCalls += 1; return 'on'; },
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ orphansClosed: 0 });
+        expect(stateCalls).toBe(0);
+        expect(closes).toHaveLength(0);
+    });
+
+    it('counts an error when the orphan close itself fails', async () => {
+        const orphan = buildZone({ id: 'zone-bad' });
+        const { deps, notifications } = buildDeps({
+            managedZones: [orphan],
+            state: async (): Promise<ZoneRelayState> => 'on',
+            closeFn: async () => { throw new Error('HA 504'); },
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toMatchObject({ errors: 1, orphansClosed: 0 });
+        const errNote = notifications.find(n => n.context?.operation === 'reconcile-orphan-close' && n.context?.reason === 'HA 504');
+        expect(errNote).toBeDefined();
+    });
+});
+
+describe('reconcileCycleAndRelayState — aggregates', () => {
+    it('returns the right counters for a multi-cycle scenario', async () => {
+        const future = buildPair({
+            cycleId: 'cycle-future',
+            startTime: new Date('2026-05-04T11:30:00.000Z'),
+            durationMin: 60,
+            zone: { id: 'zone-future' },
+        });
+        const overrun = buildPair({
+            cycleId: 'cycle-overrun',
+            startTime: new Date('2026-05-04T09:00:00.000Z'),
+            durationMin: 30,
+            zone: { id: 'zone-overrun' },
+        });
+        const missed = buildPair({
+            cycleId: 'cycle-missed',
+            startTime: new Date('2026-05-04T09:00:00.000Z'),
+            durationMin: 30,
+            zone: { id: 'zone-missed' },
+        });
+        const orphan = buildZone({ id: 'zone-orphan' });
+        const calm = buildZone({ id: 'zone-calm' });
+
+        const stateMap: Record<string, ZoneRelayState> = {
+            'zone-future': 'on',
+            'zone-overrun': 'on',
+            'zone-missed': 'off',
+            'zone-orphan': 'on',
+            'zone-calm': 'off',
+        };
+
+        const { deps } = buildDeps({
+            inFlight: [future, overrun, missed],
+            managedZones: [future.zone, overrun.zone, missed.zone, orphan, calm],
+            state: async (zone) => stateMap[zone.id] ?? 'unknown',
+        });
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toEqual({ resumed: 1, forcedClosed: 1, missedClose: 1, orphansClosed: 1, errors: 0 });
+    });
+
+    it('returns all-zero counters when nothing is in flight and no managed zones provided', async () => {
+        const { deps } = buildDeps({});
+
+        const summary = await reconcileCycleAndRelayState(deps);
+
+        expect(summary).toEqual({ resumed: 0, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 });
+    });
+});

--- a/api/daemon/reconcile.ts
+++ b/api/daemon/reconcile.ts
@@ -1,0 +1,165 @@
+import { eq } from 'drizzle-orm';
+import { irrigationCycles } from '@/db/schema';
+import type { ZoneRelayState } from '@/data/home-assistant';
+import type { Zone } from '@/models';
+import type { Notifier } from '@/notifications';
+import type { FutureCyclePair, FutureCyclesDb } from './schedules';
+import type { ArmCloseOnlyInputs, Clock, RuntimeDb, TimerRegistry } from './runtime';
+
+/**
+ * Counters from a reconciliation pass. The daemon logs these in a single
+ * summary line at startup so operators can tell at a glance whether the
+ * previous shutdown left state behind that needed cleanup.
+ */
+export type ReconcileSummary = {
+    /** In-flight cycles whose close was successfully re-armed for the planned time. */
+    resumed: number;
+    /** In-flight cycles HA still had open past their planned close — closed immediately. */
+    forcedClosed: number;
+    /** In-flight cycles HA had already closed — `closed_at` recorded after the fact. */
+    missedClose: number;
+    /** Managed zones HA had open with no in-flight cycle backing them — force-closed. */
+    orphansClosed: number;
+    /** HA state queries (or close calls) that errored — those zones were skipped. */
+    errors: number;
+};
+
+/**
+ * Db surface needed by the reconciler. The reconciler only updates the
+ * `irrigation_cycles` row's `closed_at`; it never inserts.
+ */
+export type ReconcileDb = FutureCyclesDb & RuntimeDb;
+
+/**
+ * Collaborators injected at construction. Everything external is replaceable
+ * so the orchestrator is fully testable without touching HA, the DB, or the
+ * real clock.
+ */
+export type ReconcileDeps = {
+    db: ReconcileDb;
+    clock: Clock;
+    registry: TimerRegistry;
+    notifier: Notifier;
+    closeZone: (zone: Zone) => Promise<void>;
+    getZoneState: (zone: Zone) => Promise<ZoneRelayState>;
+    loadInFlightCycles: (db: ReconcileDb, now: Date) => Promise<FutureCyclePair[]>;
+    armCloseOnly: (inputs: ArmCloseOnlyInputs) => void;
+
+    /**
+     * Managed zones for the defensive sweep. Caller (the daemon's `start`)
+     * supplies enabled zones with non-null `homeAssistantEntityId`.
+     */
+    managedZones: ReadonlyArray<Zone>;
+};
+
+/**
+ * Resumes or closes any cycle that was in-flight at the previous shutdown,
+ * then defensively force-closes any managed zone that's open with no
+ * in-flight cycle backing it. Runs **before** the daemon arms timers for
+ * future cycles.
+ *
+ * Failures of individual zones are tolerated and counted as `errors` —
+ * reconciliation should make as much progress as it can rather than abort
+ * the whole boot. The caller decides whether to surface a non-zero error
+ * count.
+ *
+ * @param deps - Collaborators and the managed-zone list.
+ * @returns Counters describing what changed.
+ */
+export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<ReconcileSummary> {
+    const { db, clock, registry, notifier, closeZone, getZoneState, loadInFlightCycles, armCloseOnly, managedZones } = deps;
+
+    const summary: ReconcileSummary = { resumed: 0, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 };
+    const handledZoneIds = new Set<string>();
+
+    const inFlight = await loadInFlightCycles(db, clock.now());
+
+    for (const { cycle, zone } of inFlight) {
+        const plannedCloseAt = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);
+        const now = clock.now();
+
+        let state: ZoneRelayState;
+        try {
+            state = await getZoneState(zone);
+        } catch (err) {
+            console.error(`daemon: reconcile getZoneState failed for cycle ${cycle.id} on zone ${zone.id}; skipping.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-state', reason: errorMessage(err) });
+            summary.errors += 1;
+            continue;
+        }
+
+        if (state === 'unknown') {
+            console.warn(`daemon: reconcile got unknown state for cycle ${cycle.id} on zone ${zone.id}; leaving cycle untouched.`);
+            continue;
+        }
+
+        if (state === 'on' && plannedCloseAt.getTime() > now.getTime()) {
+            armCloseOnly({ db, clock, registry, zone, cycle, closeZone, notifier, plannedCloseAt });
+            handledZoneIds.add(zone.id);
+            summary.resumed += 1;
+            console.log(`daemon: reconcile resumed cycle ${cycle.id} on zone ${zone.id} (closes at ${plannedCloseAt.toISOString()}).`);
+            continue;
+        }
+
+        if (state === 'on') {
+            try {
+                await closeZone(zone);
+            } catch (err) {
+                console.error(`daemon: reconcile force-close failed for cycle ${cycle.id} on zone ${zone.id}.`, err);
+                await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun-close', reason: errorMessage(err) });
+                summary.errors += 1;
+                continue;
+            }
+            const closedAt = clock.now();
+            await db.update(irrigationCycles).set({ closedAt }).where(eq(irrigationCycles.id, cycle.id));
+            handledZoneIds.add(zone.id);
+            summary.forcedClosed += 1;
+            console.warn(`daemon: reconcile force-closed cycle ${cycle.id} on zone ${zone.id} — relay was open past planned close ${plannedCloseAt.toISOString()}.`);
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun', reason: `relay still open past planned close ${plannedCloseAt.toISOString()}` });
+            continue;
+        }
+
+        // state === 'off'
+        const closedAt = plannedCloseAt.getTime() < now.getTime() ? plannedCloseAt : now;
+        await db.update(irrigationCycles).set({ closedAt }).where(eq(irrigationCycles.id, cycle.id));
+        handledZoneIds.add(zone.id);
+        summary.missedClose += 1;
+        console.log(`daemon: reconcile recorded missed close for cycle ${cycle.id} on zone ${zone.id} (set closed_at=${closedAt.toISOString()}).`);
+    }
+
+    for (const zone of managedZones) {
+        if (handledZoneIds.has(zone.id)) continue;
+        if (!zone.homeAssistantEntityId) continue;
+
+        let state: ZoneRelayState;
+        try {
+            state = await getZoneState(zone);
+        } catch (err) {
+            console.error(`daemon: reconcile getZoneState failed during defensive sweep for zone ${zone.id}; skipping.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-sweep-state', reason: errorMessage(err) });
+            summary.errors += 1;
+            continue;
+        }
+
+        if (state !== 'on') continue;
+
+        try {
+            await closeZone(zone);
+        } catch (err) {
+            console.error(`daemon: reconcile orphan-close failed for zone ${zone.id}.`, err);
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason: errorMessage(err) });
+            summary.errors += 1;
+            continue;
+        }
+        summary.orphansClosed += 1;
+        console.warn(`daemon: reconcile force-closed unmanaged-open zone ${zone.id} (${zone.homeAssistantEntityId}); no in-flight cycle backed it.`);
+        await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason: `relay was on at boot with no in-flight cycle` });
+    }
+
+    return summary;
+}
+
+function errorMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    return String(err);
+}

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -184,6 +184,47 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
     registry.addInFlight(cycle.id, zone, closeHandle);
 }
 
+/**
+ * Inputs to `armCloseOnly` — the boot-time reconciliation path that
+ * re-arms a close timer for a cycle that was already running when the
+ * previous daemon process died. There is no open phase: HA already has
+ * the relay energised, the DB already has `firedAt`, and we just need to
+ * land the close at the planned time (or immediately if it's past).
+ */
+export type ArmCloseOnlyInputs = {
+    db: RuntimeDb;
+    clock: Clock;
+    registry: TimerRegistry;
+    zone: Zone;
+    cycle: PersistedCycle;
+    closeZone: (zone: Zone) => Promise<void>;
+    notifier: Notifier;
+
+    /** Wall-clock time at which the close should fire. Past times fire immediately. */
+    plannedCloseAt: Date;
+};
+
+/**
+ * Schedules the close half of a cycle's lifecycle without re-running the
+ * open. Pre-registers the cycle as in-flight so `getStatus().activeZones`
+ * reflects the resumed zone before the timer fires; the close path itself
+ * reuses `runClose` so success/failure semantics match a normally-armed
+ * cycle exactly.
+ *
+ * @param inputs - Collaborators and the cycle/zone whose close is being re-armed.
+ */
+export function armCloseOnly(inputs: ArmCloseOnlyInputs): void {
+    const { db, clock, registry, zone, cycle, closeZone, notifier, plannedCloseAt } = inputs;
+    const closeDelay = Math.max(0, plannedCloseAt.getTime() - clock.now().getTime());
+
+    const closeHandle = clock.setTimeout(() => {
+        runClose({ db, clock, registry, zone, cycle, closeZone, notifier }).catch(err => {
+            console.error(`daemon: unhandled error in close-only path for cycle ${cycle.id}.`, err);
+        });
+    }, closeDelay);
+    registry.addInFlight(cycle.id, zone, closeHandle);
+}
+
 type RunCloseInputs = {
     db: RuntimeDb;
     clock: Clock;

--- a/api/daemon/schedules.ts
+++ b/api/daemon/schedules.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, gte, isNull } from 'drizzle-orm';
+import { and, eq, gt, gte, isNotNull, isNull } from 'drizzle-orm';
 import {
     grassTypes,
     irrigationCycles,
@@ -205,6 +205,46 @@ export async function loadFutureCycles(db: FutureCyclesDb, now: Date): Promise<F
 
     const pairs = rows.map(row => mapFutureCycleRow(row));
     console.log(`daemon: loaded ${pairs.length} future cycle(s).`);
+    return pairs;
+}
+
+/**
+ * Reads every cycle that is in flight at boot time — `firedAt` is set but
+ * `closedAt` is still null — paired with the fully-formed zone it belongs
+ * to. Used by the startup reconciliation pass to decide whether to resume,
+ * force-close, or record a missed close for each cycle.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param now - Reference time (unused for filtering; reserved so callers
+ *   can plumb their `Clock`-supplied `now` symmetrically with
+ *   `loadFutureCycles`).
+ * @returns Pairs of (cycle, zone) the daemon needs to reconcile.
+ */
+export async function loadInFlightCycles(db: FutureCyclesDb, _now: Date): Promise<FutureCyclePair[]> {
+    const rows = await db
+        .select({
+            cycle: irrigationCycles,
+            scheduleEntry: scheduleEntries,
+            zone: zones,
+            grassType: grassTypes,
+            soilType: soilTypes,
+            site: sites,
+        })
+        .from(irrigationCycles)
+        .innerJoin(scheduleEntries, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+        .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+        .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
+        .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
+        .innerJoin(sites, eq(zones.siteId, sites.id))
+        .where(
+            and(
+                isNotNull(irrigationCycles.firedAt),
+                isNull(irrigationCycles.closedAt),
+            ),
+        );
+
+    const pairs = rows.map(row => mapFutureCycleRow(row));
+    console.log(`daemon: loaded ${pairs.length} in-flight cycle(s).`);
     return pairs;
 }
 

--- a/api/data/home-assistant/.test.ts
+++ b/api/data/home-assistant/.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { createTestZone } from '@/mock/zone';
-import { closeZone, openZone } from '.';
+import { closeZone, getZoneState, openZone } from '.';
 import { HttpResponseError, computeBackoffMs, retry } from './retry';
 
 const mockFetch = mock(() => Promise.resolve({} as Response));
@@ -237,6 +237,89 @@ describe('Home Assistant client', () => {
 
             await expect(openZone(zone)).rejects.toThrow(/turn_on on switch\.sonoff_4chpro_relay_1 failed: 502 Bad Gateway/);
             expect(mockFetch).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('getZoneState', () => {
+        const stateResponse = (state: string) => ({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({ entity_id: ENTITY_ID, state }),
+        }) as unknown as Response;
+
+        it(`returns 'on' when HA reports state='on'`, async () => {
+            mockFetch.mockResolvedValueOnce(stateResponse('on'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const state = await getZoneState(zone);
+
+            expect(state).toBe('on');
+        });
+
+        it(`returns 'off' when HA reports state='off'`, async () => {
+            mockFetch.mockResolvedValueOnce(stateResponse('off'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const state = await getZoneState(zone);
+
+            expect(state).toBe('off');
+        });
+
+        it(`returns 'unknown' for any other state string`, async () => {
+            mockFetch.mockResolvedValueOnce(stateResponse('unavailable'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const state = await getZoneState(zone);
+
+            expect(state).toBe('unknown');
+        });
+
+        it(`returns 'unknown' when HA returns 404`, async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: 'Not Found',
+            } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const state = await getZoneState(zone);
+
+            expect(state).toBe('unknown');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it(`returns 'unknown' when the zone has no homeAssistantEntityId and does not call fetch`, async () => {
+            const zone = createTestZone({ homeAssistantEntityId: undefined });
+
+            const state = await getZoneState(zone);
+
+            expect(state).toBe('unknown');
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('throws after retry exhaustion when HA returns 500', async () => {
+            mockFetch.mockResolvedValue({
+                ok: false,
+                status: 500,
+                statusText: 'Internal Server Error',
+            } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(getZoneState(zone)).rejects.toThrow(/get_state on switch\.sonoff_4chpro_relay_1 failed: 500/);
+        });
+
+        it('GETs /api/states/<entity_id> with the bearer token and no body', async () => {
+            mockFetch.mockResolvedValueOnce(stateResponse('off'));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await getZoneState(zone);
+
+            const [calledUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+            expect(calledUrl).toBe(`${HA_URL}/api/states/${encodeURIComponent(ENTITY_ID)}`);
+            expect(init.method).toBe('GET');
+            expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${HA_TOKEN}`);
+            expect(init.body).toBeUndefined();
         });
     });
 });

--- a/api/data/home-assistant/index.ts
+++ b/api/data/home-assistant/index.ts
@@ -17,6 +17,14 @@ const DEFAULT_RETRY_MAX = 3;
 const DEFAULT_RETRY_BASE_MS = 1000;
 
 /**
+ * Resolved switch state for a zone's relay. `'unknown'` covers the cases
+ * where HA can answer at all but doesn't know the entity (404) or reports
+ * a transient state like `unavailable` — the caller should treat it as
+ * "don't touch" rather than as a definitive on/off signal.
+ */
+export type ZoneRelayState = 'on' | 'off' | 'unknown';
+
+/**
  * Opens (energizes) the relay for the given zone via Home Assistant's
  * `switch.turn_on` service. Throws if the zone has no Home Assistant entity
  * configured, if the HA env vars are missing, or if the service call fails
@@ -40,6 +48,73 @@ export async function openZone(zone: Zone): Promise<void> {
  */
 export async function closeZone(zone: Zone): Promise<void> {
     return callService(zone, 'turn_off');
+}
+
+/**
+ * Reads the current on/off state of a zone's relay from Home Assistant via
+ * `GET /api/states/<entity_id>`. Returns `'unknown'` rather than throwing
+ * for the soft-failure cases (zone not configured, entity missing in HA,
+ * unrecognized state string) so callers like the boot-time reconciler can
+ * treat them as "don't touch" without a try/catch. Network or 5xx errors
+ * propagate after the read-side retry budget is exhausted.
+ *
+ * @param zone - Zone whose relay state should be queried.
+ * @throws Error when the HA env vars are missing or HA returns a 5xx
+ *   response after retry exhaustion.
+ */
+export async function getZoneState(zone: Zone): Promise<ZoneRelayState> {
+    if (!zone.homeAssistantEntityId) {
+        console.warn(`home-assistant: zone ${zone.id} (${zone.name}) has no homeAssistantEntityId; cannot read state.`);
+        return 'unknown';
+    }
+
+    const { url, token } = readConfig();
+    const entityId = zone.homeAssistantEntityId;
+    const endpoint = buildStateUrl(url, entityId);
+
+    console.log(`home-assistant: reading state for zone ${zone.id} (${zone.name}) via ${entityId}.`);
+
+    const retryConfig = readRetryConfig();
+    return retry(
+        () => sendStateRequest(endpoint, token, entityId),
+        {
+            maxAttempts: retryConfig.maxAttempts,
+            baseMs: retryConfig.baseMs,
+            operation: 'get_state',
+            entityId,
+        },
+    );
+}
+
+async function sendStateRequest(endpoint: string, token: string, entityId: string): Promise<ZoneRelayState> {
+    let response: Response;
+    try {
+        response = await fetch(endpoint, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+    } catch (err) {
+        console.error(`home-assistant: fetch failed while reading state of ${entityId}.`, err);
+        throw err;
+    }
+
+    if (response.status === 404) {
+        console.warn(`home-assistant: entity ${entityId} returned 404; treating as unknown.`);
+        return 'unknown';
+    }
+
+    if (!response.ok) {
+        const message = `home-assistant: get_state on ${entityId} failed: ${response.status} ${response.statusText}`;
+        console.error(message);
+        throw new HttpResponseError(response.status, response.statusText, message);
+    }
+
+    const body = await response.json() as { state?: unknown };
+    if (body.state === 'on') return 'on';
+    if (body.state === 'off') return 'off';
+    return 'unknown';
 }
 
 async function callService(zone: Zone, service: SwitchService): Promise<void> {
@@ -120,4 +195,9 @@ function parseNonNegativeInt(raw: string | undefined, fallback: number): number 
 function buildServiceUrl(baseUrl: string, service: SwitchService): string {
     const trimmed = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
     return `${trimmed}/api/services/switch/${service}`;
+}
+
+function buildStateUrl(baseUrl: string, entityId: string): string {
+    const trimmed = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    return `${trimmed}/api/states/${encodeURIComponent(entityId)}`;
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -5,7 +5,7 @@ import Config from '@/config';
 import { start as daemonStart, type DaemonControl, type DaemonDb, type DaemonStatus } from '@/daemon';
 import { realClock } from '@/daemon/runtime';
 import { loadZoneById } from '@/daemon/zones';
-import { closeZone, openZone } from '@/data/home-assistant';
+import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import { BusyError, createManualController, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
@@ -176,7 +176,7 @@ if (import.meta.main) {
     console.log('startup: database schema verified.');
 
     const notifier = createNotifier();
-    const daemon = await daemonStart(db as unknown as DaemonDb, { notifier });
+    const daemon = await daemonStart(db as unknown as DaemonDb, { notifier, getZoneState });
     const manual = createManualController({
         db: db as unknown as Parameters<typeof createManualController>[0]['db'],
         clock: realClock,


### PR DESCRIPTION
## Ticket

[API-13](http://192.168.2.100:7123/irrigo/browse/API-13/) — Reconcile cycle and relay state on daemon startup

## Summary

- New `getZoneState(zone)` HA primitive returns `'on'` / `'off'` / `'unknown'`. `'unknown'` covers 404, missing entity ID, and unrecognized state strings; 5xx propagates after retry exhaustion.
- New `loadInFlightCycles(db, now)` returns `irrigation_cycles` rows with `firedAt IS NOT NULL AND closedAt IS NULL`, joined with their zone.
- New `armCloseOnly(inputs)` schedules just the close half of a cycle's lifecycle. Pre-registers the cycle as in-flight so `getStatus().activeZones` reflects the resumed zone immediately; on fire it reuses the existing `runClose` path.
- New `reconcileCycleAndRelayState(deps)` runs at daemon startup before any timers are armed:
  - For each in-flight cycle: HA `'on'` + future planned close → `armCloseOnly`; HA `'on'` + past planned close → close immediately, write `closed_at = now`, warn + notify; HA `'off'` → write `closed_at = LEAST(plannedClose, now)`, log; HA `'unknown'` → leave the cycle alone.
  - Defensive sweep: any managed zone HA reports `'on'` with no in-flight cycle gets force-closed and a loud `console.warn`. Per ticket: lean force-close for safety.
  - Returns a `{ resumed, forcedClosed, missedClose, orphansClosed, errors }` summary; daemon logs it on a single line at boot.
- Hard reconcile failures (DB unreachable) propagate so `start()` rejects and the api process exits — the safety net being broken is worth crashing for.
- `api/README.md` documents the HA-side dead-man automation that catches the case where the daemon never comes back. The YAML lives in HA, not in this repo.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 355/355 passing (7 new HA tests, 6 new schedule/runtime tests, 13 new reconcile tests, 3 new daemon-start tests)
- Manual smoke (optional, requires a running stack):
  - Cycle row with `fired_at` set + `closed_at` null + HA still reports `on`: restart api → daemon logs the resume + arms the close timer; the close fires at the planned time.
  - Same setup but HA reports `off`: restart api → daemon writes `closed_at` and logs the discrepancy.
  - Managed zone open at boot with no in-flight row: restart api → daemon force-closes and logs `reconcile force-closed unmanaged-open zone ...`.