### PR TITLE
[API-24] Named schedules per site with enable/disable surface

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -26,6 +26,7 @@ function buildZone(overrides?: Partial<Zone>): Zone {
         areaM2: 100,
         precipitationRateMmPerHr: 9,
         currentDepletionMm: 12,
+        siteId: 'site-A',
         siteTimezone: 'America/Edmonton',
         isEnabled: true,
         homeAssistantEntityId: 'switch.zone_001',

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -365,3 +365,93 @@ describe('buildApp manual zone routes', () => {
         });
     });
 });
+
+describe('buildApp schedule routes', () => {
+    const NOW = new Date('2026-05-08T12:00:00.000Z');
+    const buildSchedule = (overrides?: Partial<{ slug: string; name: string; siteId: string; isActive: boolean }>) => ({
+        id: 'sched-1',
+        siteId: 'site-A',
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    });
+
+    describe('POST /schedule/enable/:slug', () => {
+        it('returns 200 with the schedule payload on success', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async slug => buildSchedule({ slug, name: 'Maintenance', siteId: 'site-A', isActive: true }),
+                    disable: async () => null,
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/enable/maintenance' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({
+                status: 'enabled',
+                schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-A' },
+            });
+            await app.close();
+        });
+
+        it('returns 404 when the controller returns null', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: { enable: async () => null, disable: async () => null },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/enable/no-such' });
+
+            expect(res.statusCode).toBe(404);
+            expect(res.json()).toMatchObject({ error: 'not-found' });
+            await app.close();
+        });
+    });
+
+    describe('POST /schedule/disable/:slug', () => {
+        it('returns 200 with the schedule payload on success', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async () => null,
+                    disable: async slug => buildSchedule({ slug, isActive: false }),
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/disable/maintenance' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toMatchObject({
+                status: 'disabled',
+                schedule: { slug: 'maintenance' },
+            });
+            await app.close();
+        });
+
+        it('returns 404 when the controller returns null', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: { enable: async () => null, disable: async () => null },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/disable/no-such' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+    });
+
+    it('does not register schedule routes when the option is absent', async () => {
+        const app = buildApp({ getStatus: () => buildStatus() });
+
+        const res = await app.inject({ method: 'POST', url: '/schedule/enable/maintenance' });
+
+        expect(res.statusCode).toBe(404);
+        await app.close();
+    });
+});

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -407,11 +407,27 @@ describe('replaceZoneSchedule', () => {
         const { db, deleteCalls, insertCalls } = createScheduleWriterStub();
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
 
-        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0);
+        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
 
         expect(deleteCalls).toHaveLength(1);
         expect(deleteCalls[0]?.table).toBe(scheduleEntries);
         expect(insertCalls.length).toBeGreaterThan(0);
+    });
+
+    it('stamps the supplied scheduleId on each inserted schedule_entries row', async () => {
+        const { db, insertCalls } = createScheduleWriterStub({ entries: ['entry-A', 'entry-B'] });
+        const entries = [
+            buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]),
+            buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
+        ];
+
+        await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04', 0, 'sched-overseed');
+
+        const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
+        expect(entryInserts).toHaveLength(2);
+        for (const call of entryInserts) {
+            expect(call.rows[0]?.['scheduleId']).toBe('sched-overseed');
+        }
     });
 
     it('inserts one schedule_entries row per planner entry with the right zoneId, date, and depletion fields', async () => {
@@ -421,7 +437,7 @@ describe('replaceZoneSchedule', () => {
             buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
         ];
 
-        await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04', 0);
+        await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04', 0, 'sched-default');
 
         const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
         expect(entryInserts).toHaveLength(2);
@@ -442,7 +458,7 @@ describe('replaceZoneSchedule', () => {
             { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
         ]);
 
-        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0);
+        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
 
         const cycleInserts = insertCalls.filter(c => c.table === irrigationCycles);
         expect(cycleInserts).toHaveLength(1);
@@ -464,7 +480,7 @@ describe('replaceZoneSchedule', () => {
             { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
         ]);
 
-        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0);
+        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
 
         expect(result.cycles).toHaveLength(2);
         expect(result.cycles[0]?.id).toBe('cycle-A1');
@@ -476,7 +492,7 @@ describe('replaceZoneSchedule', () => {
     it('still issues the delete and inserts no rows when given an empty entries array', async () => {
         const { db, deleteCalls, insertCalls } = createScheduleWriterStub();
 
-        const result = await replaceZoneSchedule(db, 'zone-001', [], '2026-05-04', 0);
+        const result = await replaceZoneSchedule(db, 'zone-001', [], '2026-05-04', 0, 'sched-default');
 
         expect(deleteCalls).toHaveLength(1);
         expect(insertCalls).toHaveLength(0);
@@ -487,7 +503,7 @@ describe('replaceZoneSchedule', () => {
         const { db, insertCalls } = createScheduleWriterStub({ entries: ['entry-A'] });
         const entry = buildEntry('2026-05-04', []);
 
-        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0);
+        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
 
         expect(insertCalls.filter(c => c.table === scheduleEntries)).toHaveLength(1);
         expect(insertCalls.filter(c => c.table === irrigationCycles)).toHaveLength(0);
@@ -498,7 +514,7 @@ describe('replaceZoneSchedule', () => {
         const { db, updateCalls } = createScheduleWriterStub();
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
 
-        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 7.5);
+        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 7.5, 'sched-default');
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.table).toBe(zones);
@@ -508,7 +524,7 @@ describe('replaceZoneSchedule', () => {
     it('writes the depletion update even when the entries array is empty', async () => {
         const { db, updateCalls } = createScheduleWriterStub();
 
-        await replaceZoneSchedule(db, 'zone-002', [], '2026-05-04', 12.3);
+        await replaceZoneSchedule(db, 'zone-002', [], '2026-05-04', 12.3, 'sched-default');
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 12.3 });
@@ -886,6 +902,8 @@ function buildZoneModel(overrides?: Partial<Zone>): Zone {
         areaM2: 100,
         precipitationRateMmPerHr: 9,
         currentDepletionMm: 0,
+        siteId: 'site-A',
+        siteTimezone: 'America/Edmonton',
         isEnabled: true,
         location: { lat: 51.0447, lon: -114.0719 },
         homeAssistantEntityId: 'switch.zone_1',
@@ -1261,6 +1279,7 @@ type DaemonStubInputs = {
     enabledZones?: ZoneJoinedRow[];
     zoneCounts?: { total: number; enabled: number };
     siteTimezones?: ReadonlyArray<{ timezone: string }>;
+    activeSchedules?: ReadonlyArray<{ schedule: { id: string; siteId: string; slug: string; name: string; isActive: boolean; createdAt: Date; updatedAt: Date } }>;
 };
 
 function whereContainsIsNotNull(condition: unknown): boolean {
@@ -1293,6 +1312,22 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
 
     const siteTimezoneRows = inputs?.siteTimezones ?? [{ timezone: 'America/Edmonton' }];
 
+    // Default: one active schedule for site-A (matches the default `siteId`
+    // on `buildJoinedRow` / `buildZoneModel`). Tests that need different
+    // configurations override.
+    const NOW_FOR_SCHEDULES = new Date('2026-05-04T12:00:00.000Z');
+    const activeScheduleRows = inputs?.activeSchedules ?? [{
+        schedule: {
+            id: 'sched-default',
+            siteId: 'site-001',
+            slug: 'maintenance',
+            name: 'Maintenance',
+            isActive: true,
+            createdAt: NOW_FOR_SCHEDULES,
+            updatedAt: NOW_FOR_SCHEDULES,
+        },
+    }];
+
     const db: DaemonDb = {
         select(columns) {
             const cols = columns as Record<string, unknown>;
@@ -1302,6 +1337,14 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             // SiteTimezoneDb shape: a single `timezone` column, no other keys.
             if ('timezone' in cols && Object.keys(cols).length === 1) {
                 return { from: () => Promise.resolve([...siteTimezoneRows]) } as never;
+            }
+            // Schedule manager shape: a single `schedule` column.
+            if ('schedule' in cols && Object.keys(cols).length === 1) {
+                return {
+                    from: () => ({
+                        where: () => Promise.resolve([...activeScheduleRows]),
+                    }),
+                } as never;
             }
             const isFutureCyclesQuery = 'cycle' in cols;
             if (isFutureCyclesQuery) {
@@ -1917,6 +1960,113 @@ describe('start', () => {
             // zone-C must see only zone-A's window — not the failed zone's.
             expect(calls[2]?.busyWindows).toHaveLength(1);
             expect(calls[2]?.busyWindows[0]?.start.toISOString()).toBe('2026-05-04T05:00:00.000Z');
+        });
+    });
+
+    describe('schedule integration', () => {
+        it('stamps the active schedule id on each schedule_entries insert during rePlan', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded', siteId: 'site-A' } });
+            const { db, inserts } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-active', siteId: 'site-A', slug: 'maintenance', name: 'Maintenance',
+                        isActive: true, createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planned = buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 20 }]);
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [planned], projectedNextDepletionMm: 0 }),
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            const entryInserts = inserts.filter(c => c.table === scheduleEntries);
+            expect(entryInserts).toHaveLength(1);
+            expect(entryInserts[0]?.rows[0]?.['scheduleId']).toBe('sched-active');
+        });
+
+        it('skips a zone whose site has no active schedule and logs a warning', async () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                const enabledRow = buildJoinedRow({ zone: { id: 'zone-orphan', siteId: 'site-no-schedule' } });
+                const { db, inserts } = createDaemonDbStub({
+                    enabledZones: [enabledRow],
+                    activeSchedules: [], // no active schedules anywhere
+                });
+                const { clock } = createFakeClock(NOW);
+                const planCalls: string[] = [];
+
+                const control = await start(db, {
+                    clock,
+                    rePlanHourLocal: 4,
+                    runPlan: async (z) => {
+                        planCalls.push(z.id);
+                        return { entries: [], projectedNextDepletionMm: 0 };
+                    },
+                    openZone: async () => {},
+                    closeZone: async () => {},
+                    getZoneState: async () => 'off',
+                });
+
+                await control.rePlan();
+
+                expect(planCalls).toEqual([]);
+                expect(inserts.filter(c => c.table === scheduleEntries)).toHaveLength(0);
+                const messages = warnSpy.mock.calls.map(args => String((args as unknown[])[0]));
+                expect(messages.some(m => m.includes('no active schedule for site site-no-schedule'))).toBe(true);
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        it('plans the zones whose sites have an active schedule even when other zones are skipped', async () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                const planned = buildJoinedRow({ zone: { id: 'zone-planned', siteId: 'site-active' } });
+                const skipped = buildJoinedRow({ zone: { id: 'zone-skipped', siteId: 'site-empty' } });
+                const { db, inserts } = createDaemonDbStub({
+                    enabledZones: [skipped, planned],
+                    activeSchedules: [{
+                        schedule: {
+                            id: 'sched-A', siteId: 'site-active', slug: 'maintenance', name: 'Maintenance',
+                            isActive: true, createdAt: NOW, updatedAt: NOW,
+                        },
+                    }],
+                });
+                const { clock } = createFakeClock(NOW);
+                const planCalls: string[] = [];
+                const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 10 }]);
+
+                const control = await start(db, {
+                    clock,
+                    rePlanHourLocal: 4,
+                    runPlan: async (z) => {
+                        planCalls.push(z.id);
+                        return { entries: [entry], projectedNextDepletionMm: 0 };
+                    },
+                    openZone: async () => {},
+                    closeZone: async () => {},
+                    getZoneState: async () => 'off',
+                });
+
+                await control.rePlan();
+
+                expect(planCalls).toEqual(['zone-planned']);
+                const entryInserts = inserts.filter(c => c.table === scheduleEntries);
+                expect(entryInserts).toHaveLength(1);
+                expect(entryInserts[0]?.rows[0]?.['scheduleId']).toBe('sched-A');
+            } finally {
+                warnSpy.mockRestore();
+            }
         });
     });
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -12,6 +12,7 @@ import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
+import { loadActiveSchedulesBySite, type Schedule, type ScheduleManagerDb } from './schedule-manager';
 import { loadFutureCycles, loadInFlightCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
 import { armCloseOnly, armCycle, closeAllInFlight, realClock, TimerRegistry, type Clock, type RuntimeDb } from './runtime';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
@@ -27,7 +28,7 @@ const DEFAULT_REPLAN_HOUR_LOCAL = 4;
  * pass the eager `db` export from `@/db`; tests pass a recording stub that
  * implements the union of the smaller per-helper interfaces.
  */
-export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb;
+export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb & ScheduleManagerDb;
 
 /**
  * Caller-overridable hooks. Defaults wire to the real planning function and
@@ -161,13 +162,20 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         registry.cancelOpenTimers(clock);
 
         const enabledZones = await loadEnabledZones(db);
+        const activeSchedulesBySite: Map<string, Schedule> = await loadActiveSchedulesBySite(db);
         const today = dayjs(clock.now()).format('YYYY-MM-DD');
         const busyWindows: Array<{ start: Date; end: Date }> = [];
 
         for (const zone of enabledZones) {
+            const activeSchedule = activeSchedulesBySite.get(zone.siteId);
+            if (!activeSchedule) {
+                console.warn(`daemon: no active schedule for site ${zone.siteId} — skipping zone ${zone.id} (${zone.name}).`);
+                continue;
+            }
+
             try {
                 const { entries, projectedNextDepletionMm } = await runPlan(zone, { busyWindows });
-                const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm);
+                const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm, activeSchedule.id);
                 for (const cycle of cycles) {
                     armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier });
                     busyWindows.push({

--- a/api/daemon/reconcile.test.ts
+++ b/api/daemon/reconcile.test.ts
@@ -24,6 +24,7 @@ function buildZone(overrides?: Partial<Zone>): Zone {
         areaM2: 100,
         precipitationRateMmPerHr: 9,
         currentDepletionMm: 0,
+        siteId: 'site-A',
         siteTimezone: 'America/Edmonton',
         isEnabled: true,
         homeAssistantEntityId: 'switch.zone_001',

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'bun:test';
+import { schedules } from '@/db/schema';
+import {
+    disableSchedule,
+    enableSchedule,
+    loadActiveSchedulesBySite,
+    loadScheduleBySlug,
+    type Schedule,
+    type ScheduleManagerDb,
+} from './schedule-manager';
+
+type SelectCall = { where?: unknown };
+type UpdateCall = { values: Partial<Schedule>; where: unknown };
+
+const NOW = new Date('2026-05-08T12:00:00.000Z');
+
+function buildSchedule(overrides?: Partial<Schedule>): Schedule {
+    return {
+        id: 'sched-001',
+        siteId: 'site-A',
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+function createStub(rowsByPredicate: Schedule[]) {
+    const selectCalls: SelectCall[] = [];
+    const updateCalls: UpdateCall[] = [];
+    let rows: Schedule[] = [...rowsByPredicate];
+
+    const db: ScheduleManagerDb = {
+        select() {
+            return {
+                from() {
+                    return {
+                        where(cond: unknown) {
+                            selectCalls.push({ where: cond });
+                            const params = extractParamValues(cond);
+                            // No params: probably an `eq(isActive, true)` filter (boolean param
+                            // is encoded differently and not picked up as a string Param value).
+                            // The real call site is loadActiveSchedulesBySite, which wants only
+                            // active rows. Otherwise treat the param as a slug.
+                            if (params.length === 0) {
+                                return Promise.resolve(rows.filter(r => r.isActive).map(s => ({ schedule: s })));
+                            }
+                            const slug = params[0]!;
+                            return Promise.resolve(rows.filter(r => r.slug === slug).map(s => ({ schedule: s })));
+                        },
+                    };
+                },
+            } as unknown as ReturnType<ScheduleManagerDb['select']>;
+        },
+        update() {
+            return {
+                set(values) {
+                    return {
+                        async where(cond) {
+                            updateCalls.push({ values, where: cond });
+                            // Apply mutation in-place so subsequent reads see it. We match
+                            // by inspecting the bound Param values; the conditions targeting
+                            // a single row carry the row id as a Param. The "deactivate
+                            // siblings" condition uses (siteId == X AND id != target.id) — we
+                            // detect it by the presence of two params, treating the second
+                            // as the *exclude* id.
+                            const params = extractParamValues(cond);
+                            for (const row of rows) {
+                                if (params.length === 1 && params[0] === row.id) {
+                                    Object.assign(row, values);
+                                } else if (params.length === 2) {
+                                    const [siteId, excludeId] = params;
+                                    if (row.siteId === siteId && row.id !== excludeId) {
+                                        Object.assign(row, values);
+                                    }
+                                }
+                            }
+                            return Promise.resolve(undefined);
+                        },
+                    };
+                },
+            };
+        },
+        async transaction(cb) {
+            return cb(db);
+        },
+    };
+
+    return { db, selectCalls, updateCalls, getRows: () => [...rows] };
+}
+
+function extractParamValues(cond: unknown): string[] {
+    // Drizzle's eq/ne/and conditions are SQL objects whose `queryChunks` array
+    // contains `Param` instances; each Param exposes the bound value via `.value`
+    // alongside an `encoder` property. We collect every Param's string value.
+    const seen = new WeakSet<object>();
+    const values: string[] = [];
+    function walk(node: unknown): void {
+        if (typeof node !== 'object' || node === null) return;
+        if (seen.has(node)) return;
+        seen.add(node);
+        const obj = node as Record<string, unknown>;
+        if ('encoder' in obj && 'value' in obj && typeof obj['value'] === 'string') {
+            values.push(obj['value'] as string);
+            return;
+        }
+        if (Array.isArray(node)) { for (const item of node) walk(item); return; }
+        for (const value of Object.values(obj)) walk(value);
+    }
+    walk(cond);
+    return values;
+}
+
+describe('loadActiveSchedulesBySite', () => {
+    it('returns a Map<siteId, Schedule> for every active row', async () => {
+        const a = buildSchedule({ id: 'sched-A', siteId: 'site-A', isActive: true });
+        const b = buildSchedule({ id: 'sched-B', siteId: 'site-B', isActive: true });
+        const inactive = buildSchedule({ id: 'sched-C', siteId: 'site-C', isActive: false });
+        const { db } = createStub([a, b, inactive]);
+
+        const result = await loadActiveSchedulesBySite(db);
+
+        expect(result.size).toBe(2);
+        expect(result.get('site-A')?.id).toBe('sched-A');
+        expect(result.get('site-B')?.id).toBe('sched-B');
+        expect(result.has('site-C')).toBe(false);
+    });
+
+    it('returns an empty map when no active rows exist', async () => {
+        const { db } = createStub([buildSchedule({ isActive: false })]);
+
+        const result = await loadActiveSchedulesBySite(db);
+
+        expect(result.size).toBe(0);
+    });
+});
+
+describe('loadScheduleBySlug', () => {
+    it('returns the schedule matching the slug', async () => {
+        const target = buildSchedule({ slug: 'overseeding' });
+        const { db } = createStub([buildSchedule({ slug: 'maintenance' }), target]);
+
+        const result = await loadScheduleBySlug(db, 'overseeding');
+
+        expect(result?.slug).toBe('overseeding');
+    });
+
+    it('returns null when no schedule matches the slug', async () => {
+        const { db } = createStub([buildSchedule({ slug: 'maintenance' })]);
+
+        const result = await loadScheduleBySlug(db, 'no-such');
+
+        expect(result).toBeNull();
+    });
+});
+
+describe('enableSchedule', () => {
+    it('returns null without writing when the slug is unknown', async () => {
+        const { db, updateCalls } = createStub([buildSchedule({ slug: 'maintenance' })]);
+
+        const result = await enableSchedule(db, 'unknown');
+
+        expect(result).toBeNull();
+        expect(updateCalls).toHaveLength(0);
+    });
+
+    it('deactivates siblings on the same site, then activates the target — both inside the transaction', async () => {
+        const previouslyActive = buildSchedule({ id: 'sched-prev', siteId: 'site-A', slug: 'overseeding', isActive: true });
+        const target = buildSchedule({ id: 'sched-target', siteId: 'site-A', slug: 'maintenance', isActive: false });
+        const otherSite = buildSchedule({ id: 'sched-other', siteId: 'site-B', slug: 'maintenance', isActive: true });
+        const { db, updateCalls, getRows } = createStub([previouslyActive, target, otherSite]);
+
+        const result = await enableSchedule(db, 'maintenance');
+
+        expect(result?.id).toBe('sched-target');
+        expect(result?.isActive).toBe(true);
+        // Two updates: deactivate siblings on the same site, then activate the target.
+        expect(updateCalls).toHaveLength(2);
+        expect(updateCalls[0]?.values).toEqual({ isActive: false });
+        expect(updateCalls[1]?.values).toEqual({ isActive: true });
+        // Final state: the previous sibling is now inactive, target is active.
+        const rows = getRows();
+        expect(rows.find(r => r.id === 'sched-prev')?.isActive).toBe(false);
+        expect(rows.find(r => r.id === 'sched-target')?.isActive).toBe(true);
+        // The other site's row was not touched by either update — its sibling-deactivate
+        // condition required `siteId = site-A`.
+        expect(rows.find(r => r.id === 'sched-other')?.isActive).toBe(true);
+    });
+});
+
+describe('disableSchedule', () => {
+    it(`writes isActive = false for the matching slug and returns the row`, async () => {
+        const target = buildSchedule({ id: 'sched-1', slug: 'maintenance', isActive: true });
+        const { db, updateCalls } = createStub([target]);
+
+        const result = await disableSchedule(db, 'maintenance');
+
+        expect(result?.id).toBe('sched-1');
+        expect(result?.isActive).toBe(false);
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0]?.values).toEqual({ isActive: false });
+    });
+
+    it('returns null without writing when the slug is unknown', async () => {
+        const { db, updateCalls } = createStub([]);
+
+        const result = await disableSchedule(db, 'no-such');
+
+        expect(result).toBeNull();
+        expect(updateCalls).toHaveLength(0);
+    });
+});
+
+// Use schedules import so the test file compiles even if Drizzle doesn't tree-shake.
+void schedules;

--- a/api/daemon/schedule-manager.ts
+++ b/api/daemon/schedule-manager.ts
@@ -1,0 +1,119 @@
+import { and, eq, ne } from 'drizzle-orm';
+import { schedules } from '@/db/schema';
+
+/**
+ * Single-row representation of a `schedules` row, derived from Drizzle's
+ * inferred row type. Used as the return shape across the manager API.
+ */
+export type Schedule = typeof schedules.$inferSelect;
+
+/**
+ * Minimal Drizzle surface the schedule manager needs. The transaction shape
+ * is the subset of `db.transaction(cb)` semantics we exercise: the callback
+ * receives a tx with `select` + `update`. Tests pass a recording stub.
+ */
+export type ScheduleManagerDb = {
+    select: (columns: { schedule: typeof schedules }) => {
+        from: (table: typeof schedules) => {
+            where: (cond: unknown) => Promise<Array<{ schedule: Schedule }>>;
+        };
+    } & {
+        // Allow the `from` chain to also resolve directly when no `where` is supplied.
+        from: (table: typeof schedules) => Promise<Array<{ schedule: Schedule }>>;
+    };
+    update: (table: typeof schedules) => {
+        set: (values: Partial<Schedule>) => {
+            where: (cond: unknown) => Promise<unknown>;
+        };
+    };
+    transaction: <T>(callback: (tx: ScheduleManagerDb) => Promise<T>) => Promise<T>;
+};
+
+/**
+ * Returns a `Map<siteId, Schedule>` of every active schedule. The partial
+ * unique index `schedules_one_active_per_site` guarantees at most one row
+ * per site, so the map is always unambiguous.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ */
+export async function loadActiveSchedulesBySite(db: ScheduleManagerDb): Promise<Map<string, Schedule>> {
+    const rows = await db
+        .select({ schedule: schedules })
+        .from(schedules)
+        .where(eq(schedules.isActive, true));
+
+    const map = new Map<string, Schedule>();
+    for (const row of rows) {
+        map.set(row.schedule.siteId, row.schedule);
+    }
+    return map;
+}
+
+/**
+ * Returns the schedule with the given slug, or `null` if no such row exists.
+ * Slugs are unique within a site (enforced by the composite index), but the
+ * caller doesn't supply a `siteId` — slugs across sites can collide. For now
+ * the system has one site, so this is unambiguous; callers that need to be
+ * site-specific should filter the result.
+ */
+export async function loadScheduleBySlug(db: ScheduleManagerDb, slug: string): Promise<Schedule | null> {
+    const rows = await db
+        .select({ schedule: schedules })
+        .from(schedules)
+        .where(eq(schedules.slug, slug));
+
+    const row = rows[0];
+    return row ? row.schedule : null;
+}
+
+/**
+ * Atomically activates the schedule with the given slug, deactivating any
+ * sibling that's currently active on the same site. Wrapped in a single
+ * transaction so the partial unique index never fires mid-flight.
+ *
+ * @returns The (now-active) schedule row, or `null` if no schedule with
+ *   the given slug exists.
+ */
+export async function enableSchedule(db: ScheduleManagerDb, slug: string): Promise<Schedule | null> {
+    return db.transaction(async tx => {
+        const target = await loadScheduleBySlug(tx, slug);
+        if (target === null) {
+            console.warn(`schedule-manager: enable failed — no schedule with slug '${slug}'.`);
+            return null;
+        }
+
+        await tx
+            .update(schedules)
+            .set({ isActive: false })
+            .where(and(eq(schedules.siteId, target.siteId), ne(schedules.id, target.id)));
+
+        await tx
+            .update(schedules)
+            .set({ isActive: true })
+            .where(eq(schedules.id, target.id));
+
+        console.log(`schedule-manager: enabled schedule ${target.id} (${slug}) on site ${target.siteId}.`);
+        return { ...target, isActive: true };
+    });
+}
+
+/**
+ * Deactivates the schedule with the given slug. Idempotent: deactivating an
+ * already-inactive schedule is a no-op success. Returns the row (with
+ * `isActive: false`) or `null` if the slug is unknown.
+ */
+export async function disableSchedule(db: ScheduleManagerDb, slug: string): Promise<Schedule | null> {
+    const target = await loadScheduleBySlug(db, slug);
+    if (target === null) {
+        console.warn(`schedule-manager: disable failed — no schedule with slug '${slug}'.`);
+        return null;
+    }
+
+    await db
+        .update(schedules)
+        .set({ isActive: false })
+        .where(eq(schedules.id, target.id));
+
+    console.log(`schedule-manager: disabled schedule ${target.id} (${slug}) on site ${target.siteId}.`);
+    return { ...target, isActive: false };
+}

--- a/api/daemon/schedules.ts
+++ b/api/daemon/schedules.ts
@@ -63,6 +63,9 @@ export type ScheduleWriterDb = {
  *   later are deleted before re-insert.
  * @param projectedNextDepletionMm - Depletion value to write to
  *   `zones.current_depletion_mm` (per-zone atomic with the schedule write).
+ * @param scheduleId - The active schedule's id stamped on each inserted
+ *   `schedule_entries` row so downstream consumers can group entries by
+ *   the schedule they came from.
  * @returns The inserted cycles in input order, ready for arming.
  */
 export async function replaceZoneSchedule(
@@ -71,6 +74,7 @@ export async function replaceZoneSchedule(
     entries: ReadonlyArray<IrrigationScheduleEntry>,
     today: string,
     projectedNextDepletionMm: number,
+    scheduleId: string,
 ): Promise<PersistedScheduleResult> {
     console.log(`daemon: replacing schedule for zone ${zoneId} from ${today} (${entries.length} entry/entries).`);
 
@@ -86,6 +90,7 @@ export async function replaceZoneSchedule(
             .values([
                 {
                     zoneId,
+                    scheduleId,
                     date: entry.date.format('YYYY-MM-DD'),
                     appliedDepthMm: entry.appliedDepthMm,
                     depletionBeforeMm: entry.depletionBeforeMm,

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -168,6 +168,7 @@ export function joinedRowToZone(row: ZoneJoinedRow): Zone {
         areaM2: row.zone.areaM2,
         precipitationRateMmPerHr: row.zone.precipitationRateMmPerHr ?? undefined,
         currentDepletionMm: row.zone.currentDepletionMm,
+        siteId: row.zone.siteId,
         siteTimezone: row.site.timezone,
         isEnabled: row.zone.isEnabled,
         location: { lat, lon },

--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -1,6 +1,7 @@
 export { grassTypes } from './grass-types';
 export { irrigationCycles } from './irrigation-cycles';
 export { scheduleEntries } from './schedule-entries';
+export { schedules } from './schedules';
 export { sites } from './sites';
 export { soilTypes } from './soil-types';
 export { zones } from './zones';

--- a/api/db/schema/schedule-entries.ts
+++ b/api/db/schema/schedule-entries.ts
@@ -1,10 +1,12 @@
 import { date, pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
+import { schedules } from './schedules';
 import { zones } from './zones';
 
 export const scheduleEntries = pgTable('schedule_entries', {
     id: uuid('id').primaryKey().defaultRandom(),
     zoneId: uuid('zone_id').notNull().references(() => zones.id),
+    scheduleId: uuid('schedule_id').references(() => schedules.id),
     date: date('date').notNull(),
     appliedDepthMm: real('applied_depth_mm').notNull(),
     depletionBeforeMm: real('depletion_before_mm').notNull(),

--- a/api/db/schema/schedules.ts
+++ b/api/db/schema/schedules.ts
@@ -1,0 +1,22 @@
+import { sql } from 'drizzle-orm';
+import { boolean, pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+import { sites } from './sites';
+
+/**
+ * Named irrigation schedules (e.g. `Maintenance`, `Overseeding`). Each site
+ * has at most one active schedule at a time — enforced by the partial unique
+ * index `schedules_one_active_per_site`. The active schedule's id is stamped
+ * onto every `schedule_entries` row the planner writes.
+ */
+export const schedules = pgTable('schedules', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    siteId: uuid('site_id').notNull().references(() => sites.id),
+    slug: text('slug').notNull(),
+    name: text('name').notNull(),
+    isActive: boolean('is_active').notNull().default(false),
+    ...auditColumns,
+}, table => [
+    uniqueIndex('schedules_site_slug_idx').on(table.siteId, table.slug),
+    uniqueIndex('schedules_one_active_per_site').on(table.siteId).where(sql`${table.isActive}`),
+]);

--- a/api/drizzle/0003_bizarre_banshee.sql
+++ b/api/drizzle/0003_bizarre_banshee.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "schedules" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"site_id" uuid NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"is_active" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "schedule_entries" ADD COLUMN "schedule_id" uuid;--> statement-breakpoint
+ALTER TABLE "schedules" ADD CONSTRAINT "schedules_site_id_sites_id_fk" FOREIGN KEY ("site_id") REFERENCES "public"."sites"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "schedules_site_slug_idx" ON "schedules" USING btree ("site_id","slug");--> statement-breakpoint
+CREATE UNIQUE INDEX "schedules_one_active_per_site" ON "schedules" USING btree ("site_id") WHERE "schedules"."is_active";--> statement-breakpoint
+ALTER TABLE "schedule_entries" ADD CONSTRAINT "schedule_entries_schedule_id_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."schedules"("id") ON DELETE no action ON UPDATE no action;

--- a/api/drizzle/meta/0003_snapshot.json
+++ b/api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,696 @@
+{
+  "id": "aa08d545-d224-4ffd-a936-7506bdaad7c2",
+  "prevId": "06294bdf-a813-46ad-90df-1fbf20ceb6a8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778180644537,
       "tag": "0002_lovely_lady_vermin",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778261132642,
+      "tag": "0003_bizarre_banshee",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -10,6 +10,7 @@ import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } fro
 import { BusyError, createManualController, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
 import { createNotifier } from '@/notifications';
+import { disableSchedule as defaultDisableSchedule, enableSchedule as defaultEnableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/schedule-manager';
 
 const shutdownStarted = new WeakSet<FastifyInstance>();
 
@@ -18,10 +19,21 @@ const shutdownStarted = new WeakSet<FastifyInstance>();
  * optional so tests that only care about `/` and `/health` don't have to
  * stub the manual surface.
  */
+/**
+ * Subset of the `ScheduleManager` API exposed to HTTP. Both methods return
+ * the post-update `Schedule` row, or `null` if the slug is unknown so the
+ * route handler can map that to a 404.
+ */
+export type ScheduleApi = {
+    enable: (slug: string) => Promise<Schedule | null>;
+    disable: (slug: string) => Promise<Schedule | null>;
+};
+
 export type BuildAppOptions = {
     getStatus: () => DaemonStatus;
     manual?: ManualController;
     zoneById?: (zoneId: string) => Promise<Zone | null>;
+    schedule?: ScheduleApi;
 };
 
 /**
@@ -53,7 +65,47 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerManualRoutes(app, opts.manual, opts.zoneById);
     }
 
+    if (opts.schedule) {
+        registerScheduleRoutes(app, opts.schedule);
+    }
+
     return app;
+}
+
+function registerScheduleRoutes(app: FastifyInstance, schedule: ScheduleApi): void {
+    /**
+     * `POST /schedule/enable/:slug` — atomically activates the named schedule
+     * and deactivates any other schedule that's currently active on the same
+     * site. 200 with the schedule on success; 404 when the slug is unknown.
+     */
+    app.post('/schedule/enable/:slug', async (req, reply) => {
+        const { slug } = req.params as { slug: string };
+        const result = await schedule.enable(slug);
+        if (result === null) {
+            return reply.code(404).send({ error: 'not-found', message: `Schedule '${slug}' not found.` });
+        }
+        return reply.code(200).send({
+            status: 'enabled',
+            schedule: { slug: result.slug, name: result.name, siteId: result.siteId },
+        });
+    });
+
+    /**
+     * `POST /schedule/disable/:slug` — deactivates the named schedule.
+     * Idempotent at the data layer (already-inactive returns success). 404
+     * when the slug is unknown.
+     */
+    app.post('/schedule/disable/:slug', async (req, reply) => {
+        const { slug } = req.params as { slug: string };
+        const result = await schedule.disable(slug);
+        if (result === null) {
+            return reply.code(404).send({ error: 'not-found', message: `Schedule '${slug}' not found.` });
+        }
+        return reply.code(200).send({
+            status: 'disabled',
+            schedule: { slug: result.slug, name: result.name, siteId: result.siteId },
+        });
+    });
 }
 
 function registerManualRoutes(
@@ -185,10 +237,15 @@ if (import.meta.main) {
         notifier,
         isAnyScheduledInFlight: () => daemon.getStatus().activeZones.length > 0,
     });
+    const scheduleDb = db as unknown as ScheduleManagerDb;
     const app = buildApp({
         getStatus: daemon.getStatus,
         manual,
         zoneById: zoneId => loadZoneById(db as unknown as Parameters<typeof loadZoneById>[0], zoneId),
+        schedule: {
+            enable: slug => defaultEnableSchedule(scheduleDb, slug),
+            disable: slug => defaultDisableSchedule(scheduleDb, slug),
+        },
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/manual/.test.ts
+++ b/api/manual/.test.ts
@@ -121,6 +121,7 @@ function buildZone(overrides?: Partial<Zone>): Zone {
         areaM2: 100,
         precipitationRateMmPerHr: 9,
         currentDepletionMm: 12,
+        siteId: 'site-A',
         siteTimezone: 'America/Edmonton',
         isEnabled: true,
         homeAssistantEntityId: 'switch.zone_001',

--- a/api/manual/.test.ts
+++ b/api/manual/.test.ts
@@ -234,6 +234,7 @@ describe('manual controller — close', () => {
         expect(scheduleInserts).toHaveLength(1);
         expect(scheduleInserts[0]?.rows[0]).toMatchObject({
             zoneId: 'zone-001',
+            scheduleId: null,
             date: '2026-05-04',
             source: 'manual',
         });

--- a/api/manual/index.ts
+++ b/api/manual/index.ts
@@ -142,6 +142,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
             .values([
                 {
                     zoneId: zone.id,
+                    scheduleId: null,
                     date: today,
                     appliedDepthMm: roundTo1Decimal(appliedDepth),
                     depletionBeforeMm: roundTo1Decimal(depletionBefore),

--- a/api/mock/zone.ts
+++ b/api/mock/zone.ts
@@ -27,6 +27,7 @@ export function createTestZone(overrides?: Partial<Zone>): Zone {
         areaM2: 100,
         precipitationRateMmPerHr: 9,
         currentDepletionMm: 0,
+        siteId: 'test-site-001',
         siteTimezone: 'America/Edmonton',
         isEnabled: true,
         location: {

--- a/api/models.ts
+++ b/api/models.ts
@@ -87,6 +87,9 @@ export type Zone = {
     /** Required. The current soil moisture deficit (0 = full). */
     currentDepletionMm: number;
 
+    /** Required. The ID of the site this zone belongs to. */
+    siteId: string;
+
     /** Required. The IANA timezone of the site this zone belongs to. */
     siteTimezone: string;
 

--- a/api/package.json
+++ b/api/package.json
@@ -9,6 +9,8 @@
     "test": "bun test",
     "type-check": "tsc --noEmit",
     "seed": "bun scripts/seed.ts",
+    "enable-schedule": "bun scripts/enable-schedule.ts",
+    "disable-schedule": "bun scripts/disable-schedule.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/api/scripts/.test.ts
+++ b/api/scripts/.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
+import { grassTypes, schedules, sites, soilTypes, zones } from '@/db/schema';
 import { seed, type SeedDb } from './seed';
 
 type InsertCall = {
@@ -89,7 +89,7 @@ describe('seed orchestrator', () => {
 
         await seed({ db, dataDir });
 
-        expect(calls.map(c => c.table)).toEqual([grassTypes, soilTypes, sites, zones]);
+        expect(calls.map(c => c.table)).toEqual([grassTypes, soilTypes, sites, zones, schedules]);
     });
 
     it('resolves zone slug references to FK ids using maps from prior upserts', async () => {
@@ -166,7 +166,7 @@ describe('seed orchestrator', () => {
         const summary = await seed({ db, dataDir });
 
         expect(calls).toHaveLength(0);
-        expect(summary).toEqual({ grassTypes: 0, soilTypes: 0, sites: 0, zones: 0 });
+        expect(summary).toEqual({ grassTypes: 0, soilTypes: 0, sites: 0, zones: 0, schedules: 0 });
     });
 
     it('reads from the dataDir argument rather than the default location', async () => {
@@ -264,7 +264,7 @@ describe('seed orchestrator', () => {
 
         const summary = await seed({ db, dataDir });
 
-        expect(summary).toEqual({ grassTypes: 2, soilTypes: 1, sites: 3, zones: 0 });
+        expect(summary).toEqual({ grassTypes: 2, soilTypes: 1, sites: 3, zones: 0, schedules: 3 });
     });
 
     it('throws a clear error when a seed file is missing from dataDir', async () => {
@@ -275,6 +275,60 @@ describe('seed orchestrator', () => {
         const { db } = createStubDb();
 
         await expect(seed({ db, dataDir })).rejects.toThrow(/missing seed file .+zones\.json/);
+    });
+
+    it('upserts a Maintenance/maintenance schedule for every seeded site with isActive=true', async () => {
+        await writeJson(dataDir, 'grass-types.json', []);
+        await writeJson(dataDir, 'soil-types.json', []);
+        await writeJson(dataDir, 'sites.json', [
+            { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
+            { slug: 'cabin', name: 'Cabin', timezone: 'America/Edmonton', latitude: 52.0, longitude: -114.0 },
+        ]);
+        await writeJson(dataDir, 'zones.json', []);
+        const { db, calls } = createStubDb();
+
+        const summary = await seed({ db, dataDir });
+
+        expect(summary.schedules).toBe(2);
+        const scheduleCall = calls.find(c => c.table === schedules);
+        expect(scheduleCall).toBeDefined();
+        expect(scheduleCall!.rows).toHaveLength(2);
+        for (const row of scheduleCall!.rows) {
+            expect(row['slug']).toBe('maintenance');
+            expect(row['name']).toBe('Maintenance');
+            expect(row['isActive']).toBe(true);
+            expect(typeof row['siteId']).toBe('string');
+        }
+    });
+
+    it('omits isActive from the conflict-update set so re-seeding does not flip a deactivated schedule', async () => {
+        await writeJson(dataDir, 'grass-types.json', []);
+        await writeJson(dataDir, 'soil-types.json', []);
+        await writeJson(dataDir, 'sites.json', [
+            { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
+        ]);
+        await writeJson(dataDir, 'zones.json', []);
+        const { db, calls } = createStubDb();
+
+        await seed({ db, dataDir });
+
+        const scheduleCall = calls.find(c => c.table === schedules);
+        expect(scheduleCall).toBeDefined();
+        expect(Object.keys(scheduleCall!.conflictSet)).toEqual(['name']);
+        expect('isActive' in scheduleCall!.conflictSet).toBe(false);
+    });
+
+    it('skips schedules upsert when no sites are seeded', async () => {
+        await writeJson(dataDir, 'grass-types.json', []);
+        await writeJson(dataDir, 'soil-types.json', []);
+        await writeJson(dataDir, 'sites.json', []);
+        await writeJson(dataDir, 'zones.json', []);
+        const { db, calls } = createStubDb();
+
+        const summary = await seed({ db, dataDir });
+
+        expect(summary.schedules).toBe(0);
+        expect(calls.find(c => c.table === schedules)).toBeUndefined();
     });
 });
 

--- a/api/scripts/disable-schedule.test.ts
+++ b/api/scripts/disable-schedule.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'bun:test';
+import { disableScheduleCli, type DisableScheduleCliDeps } from './disable-schedule';
+import type { Schedule, ScheduleManagerDb } from '@/daemon/schedule-manager';
+
+const NOW = new Date('2026-05-08T12:00:00.000Z');
+
+function buildSchedule(overrides?: Partial<Schedule>): Schedule {
+    return {
+        id: 'sched-1',
+        siteId: 'site-A',
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+function recordingDeps(overrides: Partial<DisableScheduleCliDeps>): {
+    deps: DisableScheduleCliDeps;
+    logs: string[];
+    errors: string[];
+} {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const deps: DisableScheduleCliDeps = {
+        disableSchedule: async () => null,
+        loadDb: async () => ({} as ScheduleManagerDb),
+        log: m => logs.push(m),
+        error: m => errors.push(m),
+        ...overrides,
+    };
+    return { deps, logs, errors };
+}
+
+describe('disableScheduleCli', () => {
+    it('returns 0 and logs the deactivated schedule on success', async () => {
+        const { deps, logs, errors } = recordingDeps({
+            disableSchedule: async (_db, slug) => buildSchedule({ slug }),
+        });
+
+        const code = await disableScheduleCli(['bun', 'disable-schedule.ts', 'maintenance'], deps);
+
+        expect(code).toBe(0);
+        expect(logs[0]).toContain(`disabled 'maintenance'`);
+        expect(errors).toEqual([]);
+    });
+
+    it('returns 1 with a usage error when the slug is missing from argv', async () => {
+        let called = 0;
+        const { deps, errors } = recordingDeps({
+            disableSchedule: async () => { called += 1; return null; },
+        });
+
+        const code = await disableScheduleCli(['bun', 'disable-schedule.ts'], deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('usage');
+        expect(called).toBe(0);
+    });
+
+    it('returns 1 with a clear error when the underlying call returns null', async () => {
+        const { deps, errors } = recordingDeps({
+            disableSchedule: async () => null,
+        });
+
+        const code = await disableScheduleCli(['bun', 'disable-schedule.ts', 'no-such'], deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain(`no schedule with slug 'no-such'`);
+    });
+});

--- a/api/scripts/disable-schedule.ts
+++ b/api/scripts/disable-schedule.ts
@@ -1,0 +1,52 @@
+import { disableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/schedule-manager';
+
+/**
+ * Dependencies the CLI entry point pulls from production wiring; the test
+ * file injects deterministic stubs.
+ */
+export type DisableScheduleCliDeps = {
+    disableSchedule: (db: ScheduleManagerDb, slug: string) => Promise<Schedule | null>;
+    loadDb: () => Promise<ScheduleManagerDb>;
+    log: (message: string) => void;
+    error: (message: string) => void;
+};
+
+/**
+ * CLI body for `bun run disable-schedule <slug>`. Exits non-zero when the
+ * slug is missing from argv, when the slug is unknown, or when the
+ * underlying disable call rejects.
+ *
+ * @param argv - Process argv (or test fixture). Slug is read from index 2.
+ * @param deps - Injectable wiring; production passes the real DB + logger.
+ * @returns The exit code (0 or 1).
+ */
+export async function disableScheduleCli(argv: ReadonlyArray<string>, deps: DisableScheduleCliDeps): Promise<0 | 1> {
+    const slug = argv[2];
+    if (!slug) {
+        deps.error('disable-schedule: usage: bun run disable-schedule <slug>');
+        return 1;
+    }
+
+    const db = await deps.loadDb();
+    const result = await deps.disableSchedule(db, slug);
+    if (result === null) {
+        deps.error(`disable-schedule: no schedule with slug '${slug}'.`);
+        return 1;
+    }
+
+    deps.log(`disable-schedule: disabled '${result.slug}' (${result.name}) on site ${result.siteId}.`);
+    return 0;
+}
+
+if (import.meta.main) {
+    const deps: DisableScheduleCliDeps = {
+        disableSchedule,
+        loadDb: async () => {
+            const { db } = await import('@/db');
+            return db as unknown as ScheduleManagerDb;
+        },
+        log: (m) => console.log(m),
+        error: (m) => console.error(m),
+    };
+    disableScheduleCli(process.argv, deps).then(code => process.exit(code));
+}

--- a/api/scripts/enable-schedule.test.ts
+++ b/api/scripts/enable-schedule.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'bun:test';
+import { enableScheduleCli, type EnableScheduleCliDeps } from './enable-schedule';
+import type { Schedule, ScheduleManagerDb } from '@/daemon/schedule-manager';
+
+const NOW = new Date('2026-05-08T12:00:00.000Z');
+
+function buildSchedule(overrides?: Partial<Schedule>): Schedule {
+    return {
+        id: 'sched-1',
+        siteId: 'site-A',
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+function recordingDeps(overrides: Partial<EnableScheduleCliDeps>): {
+    deps: EnableScheduleCliDeps;
+    logs: string[];
+    errors: string[];
+} {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const deps: EnableScheduleCliDeps = {
+        enableSchedule: async () => null,
+        loadDb: async () => ({} as ScheduleManagerDb),
+        log: m => logs.push(m),
+        error: m => errors.push(m),
+        ...overrides,
+    };
+    return { deps, logs, errors };
+}
+
+describe('enableScheduleCli', () => {
+    it('returns 0 and logs the activated schedule on success', async () => {
+        const { deps, logs, errors } = recordingDeps({
+            enableSchedule: async (_db, slug) => buildSchedule({ slug, isActive: true }),
+        });
+
+        const code = await enableScheduleCli(['bun', 'enable-schedule.ts', 'maintenance'], deps);
+
+        expect(code).toBe(0);
+        expect(logs[0]).toContain(`enabled 'maintenance'`);
+        expect(errors).toEqual([]);
+    });
+
+    it('returns 1 with a usage error when the slug is missing from argv', async () => {
+        let called = 0;
+        const { deps, errors } = recordingDeps({
+            enableSchedule: async () => { called += 1; return null; },
+        });
+
+        const code = await enableScheduleCli(['bun', 'enable-schedule.ts'], deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('usage');
+        expect(called).toBe(0);
+    });
+
+    it('returns 1 with a clear error when the underlying call returns null', async () => {
+        const { deps, errors } = recordingDeps({
+            enableSchedule: async () => null,
+        });
+
+        const code = await enableScheduleCli(['bun', 'enable-schedule.ts', 'no-such'], deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain(`no schedule with slug 'no-such'`);
+    });
+});

--- a/api/scripts/enable-schedule.ts
+++ b/api/scripts/enable-schedule.ts
@@ -1,0 +1,52 @@
+import { enableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/schedule-manager';
+
+/**
+ * Dependencies the CLI entry point pulls from production wiring; the test
+ * file injects deterministic stubs.
+ */
+export type EnableScheduleCliDeps = {
+    enableSchedule: (db: ScheduleManagerDb, slug: string) => Promise<Schedule | null>;
+    loadDb: () => Promise<ScheduleManagerDb>;
+    log: (message: string) => void;
+    error: (message: string) => void;
+};
+
+/**
+ * CLI body for `bun run enable-schedule <slug>`. Exits non-zero when the
+ * slug is missing from argv, when the slug is unknown, or when the
+ * underlying enable call rejects.
+ *
+ * @param argv - Process argv (or test fixture). Slug is read from index 2.
+ * @param deps - Injectable wiring; production passes the real DB + logger.
+ * @returns The exit code (0 or 1).
+ */
+export async function enableScheduleCli(argv: ReadonlyArray<string>, deps: EnableScheduleCliDeps): Promise<0 | 1> {
+    const slug = argv[2];
+    if (!slug) {
+        deps.error('enable-schedule: usage: bun run enable-schedule <slug>');
+        return 1;
+    }
+
+    const db = await deps.loadDb();
+    const result = await deps.enableSchedule(db, slug);
+    if (result === null) {
+        deps.error(`enable-schedule: no schedule with slug '${slug}'.`);
+        return 1;
+    }
+
+    deps.log(`enable-schedule: enabled '${result.slug}' (${result.name}) on site ${result.siteId}.`);
+    return 0;
+}
+
+if (import.meta.main) {
+    const deps: EnableScheduleCliDeps = {
+        enableSchedule,
+        loadDb: async () => {
+            const { db } = await import('@/db');
+            return db as unknown as ScheduleManagerDb;
+        },
+        log: (m) => console.log(m),
+        error: (m) => console.error(m),
+    };
+    enableScheduleCli(process.argv, deps).then(code => process.exit(code));
+}

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { sql } from 'drizzle-orm';
-import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
+import { grassTypes, schedules, sites, soilTypes, zones } from '@/db/schema';
 import {
     parseGrassTypes,
     parseSites,
@@ -25,7 +25,8 @@ type SeedTable =
     | typeof grassTypes
     | typeof soilTypes
     | typeof sites
-    | typeof zones;
+    | typeof zones
+    | typeof schedules;
 
 type SeedInsertBuilder = {
     values: (rows: ReadonlyArray<Record<string, unknown>>) => SeedConflictBuilder;
@@ -55,6 +56,7 @@ export type SeedSummary = {
     soilTypes: number;
     sites: number;
     zones: number;
+    schedules: number;
 };
 
 const DEFAULT_DATA_DIR = path.resolve(import.meta.dir, '../data/seeds');
@@ -91,6 +93,7 @@ export async function seed(options?: SeedOptions): Promise<SeedSummary> {
     const soilMap = await upsertSoilTypes(db, soilRows);
     const siteMap = await upsertSites(db, siteRows);
     await upsertZones(db, zoneRows, { grassMap, soilMap, siteMap });
+    const scheduleCount = await upsertDefaultSchedules(db, siteMap);
 
     console.log('seed: complete.');
 
@@ -99,6 +102,7 @@ export async function seed(options?: SeedOptions): Promise<SeedSummary> {
         soilTypes: soilRows.length,
         sites: siteRows.length,
         zones: zoneRows.length,
+        schedules: scheduleCount,
     };
 }
 
@@ -216,6 +220,32 @@ async function upsertZones(db: SeedDb, rows: ZoneSeed[], lookups: ZoneLookups): 
             },
         })
         .returning({ id: zones.id, slug: zones.slug });
+}
+
+async function upsertDefaultSchedules(db: SeedDb, siteMap: Map<string, string>): Promise<number> {
+    if (siteMap.size === 0) return 0;
+
+    const valueRows = [...siteMap.values()].map(siteId => ({
+        siteId,
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: true,
+    }));
+
+    // Conflict target: composite (siteId, slug). On conflict only refresh `name` —
+    // leave `isActive` alone so re-seeding doesn't clobber a runtime activation.
+    await db
+        .insert(schedules)
+        .values(valueRows)
+        .onConflictDoUpdate({
+            target: [schedules.siteId, schedules.slug],
+            set: {
+                name: sql`excluded.name`,
+            },
+        })
+        .returning({ id: schedules.id, slug: schedules.slug });
+
+    return valueRows.length;
 }
 
 function resolveZone(row: ZoneSeed, lookups: ZoneLookups) {


### PR DESCRIPTION
## Ticket

[API-24](http://192.168.2.100:7123/irrigo/browse/API-24/) — Add named schedules per site with enable/disable endpoints and scripts

## Summary

- New `schedules` table: `siteId`, `slug`, `name`, `isActive`, audit columns. Composite unique index on `(siteId, slug)` plus a partial unique index on `siteId WHERE is_active` enforces at-most-one-active-per-site.
- Migration `0003_bizarre_banshee.sql` creates the table + indexes and adds a nullable `scheduleId` FK to `schedule_entries`.
- Seed (`bun run seed`) now upserts a default `Maintenance` (`maintenance`) schedule per site with `isActive: true`. Re-seeding does not flip an operator's runtime activation (the conflict-update set excludes `is_active`).
- Schedule manager (`api/daemon/schedule-manager.ts`):
  - `loadActiveSchedulesBySite(db)` returns `Map<siteId, Schedule>`.
  - `enableSchedule(db, slug)` runs in a transaction — deactivates same-site siblings, then activates the target. Returns `null` for unknown slug.
  - `disableSchedule(db, slug)` flips the target's `isActive` to false. Idempotent.
- HTTP: `POST /schedule/enable/:slug` and `POST /schedule/disable/:slug`. 200 with the schedule on success; 404 when slug is unknown. Routes are gated on `BuildAppOptions.schedule` so existing tests that don't supply it remain isolated.
- CLI: `bun run enable-schedule <slug>` and `bun run disable-schedule <slug>` exit non-zero with a clear error on missing argv or unknown slug.
- Daemon planner integration: `rePlan` loads the active schedule per site once at the top of the loop. Each zone is skipped (with a single warn) when its site has no active schedule; otherwise the active schedule's id is stamped on every `schedule_entries` row written by `replaceZoneSchedule`.
- Manual fires (`POST /zones/:id/run`, etc.) explicitly write `scheduleId: NULL` on their `schedule_entries` row — manual writes are an explicit exception to the "always populated" invariant.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 381/381 passing (8 new manager tests, 5 new route tests, 6 new CLI tests, 4 new seed tests, 4 new daemon-rePlan tests + assorted regression updates)
- Manual smoke (optional, requires a running stack):
  - `bun --cwd api run db:migrate` then `bun --cwd api run seed` — each site has an active `maintenance` schedule.
  - `curl -X POST http://localhost:3000/schedule/disable/maintenance` → 200; next re-plan logs `no active schedule for site …` and skips that site.
  - `bun --cwd api run enable-schedule maintenance` → schedule re-enabled and the next re-plan resumes writing entries with `scheduleId` stamped.

## Out of scope

- Water-restriction days config (separate ticket).
- Per-schedule planner-parameter overrides (separate ticket).
- Auth on the schedule endpoints (LAN-only posture, documented in CLAUDE.md alongside the manual endpoints).
- Stamping `scheduleId` on manual-fire rows — left NULL by design.