### PR TITLE
[API-25] Honor per-schedule water-restriction days and time windows

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1279,7 +1279,17 @@ type DaemonStubInputs = {
     enabledZones?: ZoneJoinedRow[];
     zoneCounts?: { total: number; enabled: number };
     siteTimezones?: ReadonlyArray<{ timezone: string }>;
-    activeSchedules?: ReadonlyArray<{ schedule: { id: string; siteId: string; slug: string; name: string; isActive: boolean; createdAt: Date; updatedAt: Date } }>;
+    activeSchedules?: ReadonlyArray<{ schedule: {
+        id: string;
+        siteId: string;
+        slug: string;
+        name: string;
+        isActive: boolean;
+        allowedDays: number[] | null;
+        allowedTimeWindows: Array<{ start: string; end: string }> | null;
+        createdAt: Date;
+        updatedAt: Date;
+    } }>;
 };
 
 function whereContainsIsNotNull(condition: unknown): boolean {
@@ -1323,6 +1333,8 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             slug: 'maintenance',
             name: 'Maintenance',
             isActive: true,
+            allowedDays: null,
+            allowedTimeWindows: null,
             createdAt: NOW_FOR_SCHEDULES,
             updatedAt: NOW_FOR_SCHEDULES,
         },
@@ -1964,6 +1976,51 @@ describe('start', () => {
     });
 
     describe('schedule integration', () => {
+        it('forwards the active schedule\'s allowedDays and allowedTimeWindows to runPlan', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-r', siteId: 'site-R' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-r', siteId: 'site-R', slug: 'maintenance', name: 'Maintenance',
+                        isActive: true,
+                        allowedDays: [3, 5, 7],
+                        allowedTimeWindows: [
+                            { start: '00:00', end: '10:00' },
+                            { start: '19:00', end: '23:59' },
+                        ],
+                        createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: Array<{ allowedDays: number[] | null | undefined; allowedTimeWindows: unknown }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    planCalls.push({
+                        allowedDays: opts?.restrictions?.allowedDays,
+                        allowedTimeWindows: opts?.restrictions?.allowedTimeWindows,
+                    });
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toHaveLength(1);
+            expect(planCalls[0]?.allowedDays).toEqual([3, 5, 7]);
+            expect(planCalls[0]?.allowedTimeWindows).toEqual([
+                { start: '00:00', end: '10:00' },
+                { start: '19:00', end: '23:59' },
+            ]);
+        });
+
         it('stamps the active schedule id on each schedule_entries insert during rePlan', async () => {
             const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded', siteId: 'site-A' } });
             const { db, inserts } = createDaemonDbStub({
@@ -1971,7 +2028,7 @@ describe('start', () => {
                 activeSchedules: [{
                     schedule: {
                         id: 'sched-active', siteId: 'site-A', slug: 'maintenance', name: 'Maintenance',
-                        isActive: true, createdAt: NOW, updatedAt: NOW,
+                        isActive: true, allowedDays: null, allowedTimeWindows: null, createdAt: NOW, updatedAt: NOW,
                     },
                 }],
             });
@@ -2038,7 +2095,7 @@ describe('start', () => {
                     activeSchedules: [{
                         schedule: {
                             id: 'sched-A', siteId: 'site-active', slug: 'maintenance', name: 'Maintenance',
-                            isActive: true, createdAt: NOW, updatedAt: NOW,
+                            isActive: true, allowedDays: null, allowedTimeWindows: null, createdAt: NOW, updatedAt: NOW,
                         },
                     }],
                 });

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -174,7 +174,11 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
             }
 
             try {
-                const { entries, projectedNextDepletionMm } = await runPlan(zone, { busyWindows });
+                const restrictions = {
+                    allowedDays: activeSchedule.allowedDays,
+                    allowedTimeWindows: activeSchedule.allowedTimeWindows,
+                };
+                const { entries, projectedNextDepletionMm } = await runPlan(zone, { busyWindows, restrictions });
                 const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm, activeSchedule.id);
                 for (const cycle of cycles) {
                     armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier });

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -21,6 +21,8 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         slug: 'maintenance',
         name: 'Maintenance',
         isActive: true,
+        allowedDays: null,
+        allowedTimeWindows: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/db/schema/schedules.ts
+++ b/api/db/schema/schedules.ts
@@ -1,13 +1,27 @@
 import { sql } from 'drizzle-orm';
-import { boolean, pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { boolean, integer, jsonb, pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
 import { sites } from './sites';
+
+/**
+ * One allowed irrigation window within a day. Hours and minutes in the
+ * site's local timezone. Windows do not wrap past midnight — represent
+ * overnight allowances as two windows on consecutive days.
+ */
+export type ScheduleTimeWindow = {
+    start: string;
+    end: string;
+};
 
 /**
  * Named irrigation schedules (e.g. `Maintenance`, `Overseeding`). Each site
  * has at most one active schedule at a time — enforced by the partial unique
  * index `schedules_one_active_per_site`. The active schedule's id is stamped
  * onto every `schedule_entries` row the planner writes.
+ *
+ * `allowedDays` and `allowedTimeWindows` express municipal water-restriction
+ * compliance: nullable so existing rows behave as "no restriction" until an
+ * operator opts in. `allowedDays` uses ISO weekday numbers (1=Mon..7=Sun).
  */
 export const schedules = pgTable('schedules', {
     id: uuid('id').primaryKey().defaultRandom(),
@@ -15,6 +29,8 @@ export const schedules = pgTable('schedules', {
     slug: text('slug').notNull(),
     name: text('name').notNull(),
     isActive: boolean('is_active').notNull().default(false),
+    allowedDays: integer('allowed_days').array(),
+    allowedTimeWindows: jsonb('allowed_time_windows').$type<ScheduleTimeWindow[]>(),
     ...auditColumns,
 }, table => [
     uniqueIndex('schedules_site_slug_idx').on(table.siteId, table.slug),

--- a/api/drizzle/0004_living_joshua_kane.sql
+++ b/api/drizzle/0004_living_joshua_kane.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "schedules" ADD COLUMN "allowed_days" integer[];--> statement-breakpoint
+ALTER TABLE "schedules" ADD COLUMN "allowed_time_windows" jsonb;

--- a/api/drizzle/meta/0004_snapshot.json
+++ b/api/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,708 @@
+{
+  "id": "08b7c40f-f4b6-4956-805f-7b951c5efaf5",
+  "prevId": "aa08d545-d224-4ffd-a936-7506bdaad7c2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778261132642,
       "tag": "0003_bizarre_banshee",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778510901466,
+      "tag": "0004_living_joshua_kane",
+      "breakpoints": true
     }
   ]
 }

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -132,6 +132,28 @@ describe('runScheduleForZone', () => {
         expect(shifted.startTime.toDate().getTime()).toBe(busyEnd.getTime());
     });
 
+    it('forwards schedule restrictions to the planner so disallowed days drop their cycles', async () => {
+        stubSuccess();
+        const zone = createTestZone({
+            currentDepletionMm: 22,
+            soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+            precipitationRateMmPerHr: 50,
+            location: { lat: 51.0447, lon: -114.0719 },
+        });
+
+        // The weather stub has dates 2025-10-20 / 21 / 22 (Mon / Tue / Wed).
+        // Allow only Wednesday (isoWeekday 3) — Mon and Tue should produce no entries.
+        const result = await runScheduleForZone(zone, {
+            restrictions: { allowedDays: [3], allowedTimeWindows: null },
+        });
+
+        for (const entry of result.entries) {
+            expect(entry.date.isoWeekday()).toBe(3);
+        }
+        expect(result.entries.some(e => e.date.format('YYYY-MM-DD') === '2025-10-22')).toBe(true);
+        expect(result.entries.some(e => e.date.format('YYYY-MM-DD') === '2025-10-20')).toBe(false);
+    });
+
     it('returns an empty schedule when the weather API returns no days', async () => {
         mockFetch.mockResolvedValueOnce({
             ok: true,

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1151,4 +1151,231 @@ describe('planZoneSchedule', () => {
             }
         });
     });
+
+    describe('schedule restrictions', () => {
+        // Single-cycle scenario reused from the busy-window tests: high
+        // infiltration + matching precip keeps totalRunTime ≤ maxCycle.
+        const singleCycleZone = () => createTestZone({
+            currentDepletionMm: 22,
+            soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+            precipitationRateMmPerHr: 50,
+        });
+
+        function weatherFromDates(startDate: string, days: number, sunriseHour = 6) {
+            return createWeatherDays(
+                Array.from({ length: days }, () => ({ evapotranspirationMmPerDay: 1.0, rainfallMm: 0 })),
+                dayjs(startDate),
+            ).map((day, idx) => ({
+                ...day,
+                sunrise: dayjs(startDate).add(idx, 'day').hour(sunriseHour).minute(0).second(0).millisecond(0),
+            }));
+        }
+
+        it('treats both columns null as no restriction — output identical to today (regression)', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-04', 1); // Monday
+
+            const baseline = planZoneSchedule(zone, weather);
+            const withNoRestrictions = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+            });
+
+            expect(withNoRestrictions.entries).toHaveLength(baseline.entries.length);
+            expect(withNoRestrictions.entries[0]?.cycles[0]?.startTime.isSame(baseline.entries[0]?.cycles[0]?.startTime)).toBe(true);
+            expect(withNoRestrictions.projectedNextDepletionMm).toBeCloseTo(baseline.projectedNextDepletionMm, 5);
+        });
+
+        it('treats empty arrays the same as null', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-04', 1);
+
+            const empty = planZoneSchedule(zone, weather, [], {
+                allowedDays: [],
+                allowedTimeWindows: [],
+            });
+            const nulls = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+            });
+
+            expect(empty.entries).toHaveLength(nulls.entries.length);
+            const a = empty.entries[0]?.cycles[0]!;
+            const b = nulls.entries[0]?.cycles[0]!;
+            expect(a.startTime.isSame(b.startTime)).toBe(true);
+        });
+
+        it('skips a disallowed weekday and lets depletion accumulate into the next allowed day', () => {
+            // Monday 2026-05-04 → isoWeekday 1 (disallowed for Wed/Fri/Sun).
+            // Wednesday 2026-05-06 → isoWeekday 3 (allowed).
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-04', 3); // Mon, Tue, Wed
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: [3, 5, 7],
+                allowedTimeWindows: null,
+            });
+
+            // No entries for Monday or Tuesday (the only disallowed days that
+            // would have otherwise triggered).
+            expect(result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04')).toBeUndefined();
+            expect(result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-05')).toBeUndefined();
+            // Wednesday — depletion has accumulated more than the no-restriction case.
+            const wedEntry = result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-06');
+            expect(wedEntry).toBeDefined();
+            // The Monday depletion (22.85 mm) + Tue/Wed net ET (~0.95 each)
+            // accumulates into Wednesday's irrigation pre-depletion. Sanity:
+            // depletionBeforeMm must be greater than the single-day case.
+            expect(wedEntry?.depletionBeforeMm).toBeGreaterThan(22.85);
+        });
+
+        it('keeps short pre-sunrise cycles inside the morning window when sunrise is 06:00', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-06', 1, 6); // Wed at 06:00
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            });
+
+            const cycle = result.entries[0]?.cycles[0];
+            expect(cycle).toBeDefined();
+            const start = cycle!.startTime;
+            const end = start.add(cycle!.durationMin, 'minute');
+            expect(start.hour()).toBeGreaterThanOrEqual(0);
+            expect(end.isBefore(start.startOf('day').hour(10))).toBe(true);
+        });
+
+        it('re-anchors a cycle into the morning window when sunrise falls in the disallowed gap', () => {
+            const zone = singleCycleZone();
+            // Sunrise 12:00 — falls inside the forbidden 10:00–19:00 gap.
+            const weather = weatherFromDates('2026-05-06', 1, 12);
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            });
+
+            const cycle = result.entries[0]?.cycles[0]!;
+            const end = cycle.startTime.add(cycle.durationMin, 'minute');
+            // Cycle should end at or before 10:00 (re-anchored to morning window).
+            expect(end.isAfter(cycle.startTime.startOf('day').hour(10))).toBe(false);
+        });
+
+        it('skips the day when totalRunTime exceeds every allowed window', () => {
+            // Crank up the depletion so the planner wants a long run, and shrink
+            // the allowed windows so they cannot fit.
+            const zone = createTestZone({
+                currentDepletionMm: 22,
+                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+                precipitationRateMmPerHr: 50,
+            });
+            const weather = weatherFromDates('2026-05-06', 1, 6);
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                // Two tiny 5-minute windows — total runtime (~34 min) cannot fit either.
+                allowedTimeWindows: [
+                    { start: '03:00', end: '03:05' },
+                    { start: '22:00', end: '22:05' },
+                ],
+            });
+
+            expect(result.entries).toHaveLength(0);
+        });
+
+        it('Calgary case: cycles only ever land on Wed/Fri/Sun within the two allowed windows', () => {
+            // 7-day window starting Monday 2026-05-04.
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-04', 7, 6);
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: [3, 5, 7],
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            });
+
+            for (const entry of result.entries) {
+                const isoWd = entry.date.isoWeekday();
+                expect([3, 5, 7]).toContain(isoWd);
+                for (const cycle of entry.cycles) {
+                    const dayStart = cycle.startTime.startOf('day');
+                    const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+                    const morningStart = dayStart;
+                    const morningEnd = dayStart.hour(10);
+                    const eveningStart = dayStart.hour(19);
+                    const eveningEnd = dayStart.hour(23).minute(59);
+                    const inMorning = !cycle.startTime.isBefore(morningStart) && !cycleEnd.isAfter(morningEnd);
+                    const inEvening = !cycle.startTime.isBefore(eveningStart) && !cycleEnd.isAfter(eveningEnd);
+                    expect(inMorning || inEvening).toBe(true);
+                }
+            }
+        });
+
+        it('pushes a cycle into the evening window when a busy interval blocks the morning window', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-06', 1, 6);
+
+            // Cross-zone busy block covers the entire morning window.
+            const busyWindows = [{
+                start: dayjs('2026-05-06').hour(0).minute(0).second(0).millisecond(0),
+                end: dayjs('2026-05-06').hour(11).minute(0).second(0).millisecond(0),
+            }];
+
+            const result = planZoneSchedule(zone, weather, busyWindows, {
+                allowedDays: null,
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            });
+
+            const cycle = result.entries[0]?.cycles[0];
+            expect(cycle).toBeDefined();
+            const start = cycle!.startTime;
+            const end = start.add(cycle!.durationMin, 'minute');
+            // Cycle is in the 19:00–23:59 window.
+            expect(start.hour()).toBeGreaterThanOrEqual(19);
+            expect(end.isAfter(start.startOf('day').hour(19))).toBe(true);
+            expect(end.isAfter(start.startOf('day').hour(23).minute(59))).toBe(false);
+        });
+
+        it('multi-zone: deconfliction still produces non-overlapping cycles within allowed windows', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-06', 1, 6);
+
+            // First zone has already grabbed 05:00–05:30 (typical pre-sunrise).
+            const zoneABusy = [{
+                start: dayjs('2026-05-06').hour(5).minute(0).second(0).millisecond(0),
+                end: dayjs('2026-05-06').hour(5).minute(30).second(0).millisecond(0),
+            }];
+
+            const result = planZoneSchedule(zone, weather, zoneABusy, {
+                allowedDays: null,
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            });
+
+            const cycle = result.entries[0]?.cycles[0]!;
+            const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+            // No overlap with zone A's window.
+            const overlapsA = cycle.startTime.isBefore(zoneABusy[0]!.end) && cycleEnd.isAfter(zoneABusy[0]!.start);
+            expect(overlapsA).toBe(false);
+            // Still inside one of the allowed windows.
+            const dayStart = cycle.startTime.startOf('day');
+            const inMorning = !cycle.startTime.isBefore(dayStart) && !cycleEnd.isAfter(dayStart.hour(10));
+            const inEvening = !cycle.startTime.isBefore(dayStart.hour(19)) && !cycleEnd.isAfter(dayStart.hour(23).minute(59));
+            expect(inMorning || inEvening).toBe(true);
+        });
+    });
 });

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -1,5 +1,15 @@
 import dayjs from 'dayjs';
 import type { Zone, DailyWeather, IrrigationScheduleEntry, IrrigationCycle } from '../../models';
+import {
+    computeAllowedIntervalsForDay,
+    computeForbiddenIntervalsForDay,
+    isDayAllowed,
+    pickAnchorForCycles,
+    type AllowedInterval,
+    type ScheduleRestrictions,
+} from './restrictions';
+
+const NO_RESTRICTIONS: ScheduleRestrictions = { allowedDays: null, allowedTimeWindows: null };
 
 /**
  * A time interval the planner must avoid placing cycles inside. Used by the
@@ -33,12 +43,17 @@ export type PlanZoneScheduleResult = {
  *   cycles. Cycles whose preferred placement (per `buildCyclePlan`) would
  *   overlap a busy window are shifted forward until they fit. Defaults to
  *   empty for first-zone-in-the-batch / standalone planning calls.
+ * @param restrictions - Per-schedule day/time-window constraints. When a
+ *   day is disallowed or the planned irrigation block can't fit any allowed
+ *   window, the day's cycles are dropped (with a warning) and depletion
+ *   carries forward into the next allowed day. Defaults to "no restriction".
  * @returns Per-day entries plus the projected next-day starting depletion.
  */
 export function planZoneSchedule(
     zone: Zone,
     weatherHistory: DailyWeather[],
     busyWindows: ReadonlyArray<BusyWindow> = [],
+    restrictions: ScheduleRestrictions = NO_RESTRICTIONS,
 ): PlanZoneScheduleResult {
     const totalAvailableWaterMillimetersForClamp = zone.soil.availableWaterHoldingCapacityMmPerM * zone.rootDepthM,
         clampedStartingDepletion = clampValue(zone.currentDepletionMm ?? 0, 0, totalAvailableWaterMillimetersForClamp);
@@ -90,66 +105,42 @@ export function planZoneSchedule(
 
         // Check if irrigation is needed.
         if (currentDepletionMillimeters >= readilyAvailableWaterMillimeters) {
-            const depletionBeforeIrrigation = currentDepletionMillimeters;
-
-            // Calculate net irrigation depth needed to fully replenish soil.
-            const netIrrigationDepthMillimeters = currentDepletionMillimeters;
-
-            // Adjust for irrigation efficiency to get gross depth applied.
-            const irrigationEfficiency = zone.irrigationEfficiency,
-                grossIrrigationDepthMillimeters = Math.min(
-                    netIrrigationDepthMillimeters / irrigationEfficiency,
-                    totalAvailableWaterMillimeters
-                );
-
-            // Calculate total runtime without cycle splitting.
-            const totalRunTimeMinutes = (grossIrrigationDepthMillimeters / precipitationRateMillimetersPerHour) * 60;
-
-            // Determine maximum cycle duration based on infiltration rate.
-            const maximumCycleMinutes =
-                infiltrationRateMillimetersPerHour > 0
-                    ? (infiltrationRateMillimetersPerHour / precipitationRateMillimetersPerHour) * 60
-                    : totalRunTimeMinutes;
-
-            // Build cycle plan ending before sunrise.
-            const plannedCycles = buildCyclePlan(
-                totalRunTimeMinutes,
-                maximumCycleMinutes,
+            const irrigationOutcome = tryPlaceIrrigationForDay({
+                date,
                 sunrise,
-                soakTimeMinutes
-            );
-
-            // Shift cycles forward as needed to avoid any already-occupied
-            // window (cross-zone or within this zone's earlier days).
-            const placedCycles = deconflictCycles(plannedCycles, busyWindowsSoFar, soakTimeMinutes);
-
-            // Each placed cycle becomes a busy window for the rest of the
-            // planning horizon (this zone's later days and any later zones).
-            for (const cycle of placedCycles) {
-                busyWindowsSoFar.push({
-                    start: cycle.startTime,
-                    end: cycle.startTime.add(cycle.durationMin, 'minute'),
-                });
-            }
-
-            // Reset depletion to zero after irrigation (soil fully replenished).
-            const depletionAfterIrrigation = 0;
-
-            irrigationSchedule.push({
-                date: date,
-                zoneId: zone.id,
-                cycles: placedCycles,
-                appliedDepthMm: roundTo1Decimal(grossIrrigationDepthMillimeters),
-                depletionBeforeMm: roundTo1Decimal(depletionBeforeIrrigation),
-                depletionAfterMm: roundTo1Decimal(depletionAfterIrrigation),
+                zone,
+                currentDepletionMillimeters,
+                totalAvailableWaterMillimeters,
+                precipitationRateMillimetersPerHour,
+                infiltrationRateMillimetersPerHour,
+                soakTimeMinutes,
+                busyWindowsSoFar,
+                restrictions,
             });
 
-            // Continue accumulating depletion for the rest of the day after irrigation.
-            currentDepletionMillimeters = clampValue(
-                depletionAfterIrrigation + cropEvapotranspiration - effectiveRainfallMillimeters,
-                0,
-                totalAvailableWaterMillimeters
-            );
+            if (irrigationOutcome !== null) {
+                // Each placed cycle becomes a busy window for the rest of
+                // the planning horizon.
+                for (const cycle of irrigationOutcome.cycles) {
+                    busyWindowsSoFar.push({
+                        start: cycle.startTime,
+                        end: cycle.startTime.add(cycle.durationMin, 'minute'),
+                    });
+                }
+
+                irrigationSchedule.push(irrigationOutcome.entry);
+
+                // Reset depletion to zero after irrigation, then re-apply
+                // the day's net ET for the post-irrigation portion.
+                currentDepletionMillimeters = clampValue(
+                    cropEvapotranspiration - effectiveRainfallMillimeters,
+                    0,
+                    totalAvailableWaterMillimeters
+                );
+            }
+            // When `irrigationOutcome === null`, the day was skipped due to
+            // restrictions. Depletion carries forward unchanged — the next
+            // allowed day will see the larger accumulated value.
         }
 
         // Ensure depletion stays within valid bounds.
@@ -161,6 +152,120 @@ export function planZoneSchedule(
     }
 
     return { entries: irrigationSchedule, projectedNextDepletionMm };
+}
+
+type PlaceIrrigationInputs = {
+    date: dayjs.Dayjs;
+    sunrise: dayjs.Dayjs;
+    zone: Zone;
+    currentDepletionMillimeters: number;
+    totalAvailableWaterMillimeters: number;
+    precipitationRateMillimetersPerHour: number;
+    infiltrationRateMillimetersPerHour: number;
+    soakTimeMinutes: number;
+    busyWindowsSoFar: ReadonlyArray<BusyWindow>;
+    restrictions: ScheduleRestrictions;
+};
+
+type PlaceIrrigationOutcome = {
+    cycles: IrrigationCycle[];
+    entry: IrrigationScheduleEntry;
+};
+
+/**
+ * Computes the day's irrigation block and places it within the day's
+ * allowed time windows (if any). Returns `null` when the day is fully
+ * disallowed or no allowed window can hold the requested runtime —
+ * callers should treat that as "skip, carry depletion forward."
+ */
+function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigationOutcome | null {
+    const {
+        date, sunrise, zone, currentDepletionMillimeters, totalAvailableWaterMillimeters,
+        precipitationRateMillimetersPerHour, infiltrationRateMillimetersPerHour, soakTimeMinutes,
+        busyWindowsSoFar, restrictions,
+    } = inputs;
+
+    if (!isDayAllowed(restrictions, date.isoWeekday())) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} (isoWeekday ${date.isoWeekday()}) disallowed by schedule restrictions — skipping irrigation.`);
+        return null;
+    }
+
+    const depletionBeforeIrrigation = currentDepletionMillimeters;
+    const grossIrrigationDepthMillimeters = Math.min(
+        currentDepletionMillimeters / zone.irrigationEfficiency,
+        totalAvailableWaterMillimeters,
+    );
+    const totalRunTimeMinutes = (grossIrrigationDepthMillimeters / precipitationRateMillimetersPerHour) * 60;
+    const maximumCycleMinutes = infiltrationRateMillimetersPerHour > 0
+        ? (infiltrationRateMillimetersPerHour / precipitationRateMillimetersPerHour) * 60
+        : totalRunTimeMinutes;
+
+    const numberOfCycles = totalRunTimeMinutes <= maximumCycleMinutes || maximumCycleMinutes <= 0
+        ? 1
+        : Math.ceil(totalRunTimeMinutes / maximumCycleMinutes);
+    const requiredSpanMinutes = totalRunTimeMinutes + (numberOfCycles - 1) * soakTimeMinutes;
+
+    const allowedIntervals = computeAllowedIntervalsForDay(date, restrictions);
+    const hasTimeWindows = restrictions.allowedTimeWindows !== null && restrictions.allowedTimeWindows.length > 0;
+    const forbiddenForDay = hasTimeWindows ? computeForbiddenIntervalsForDay(date, restrictions) : [];
+
+    // Pick an anchor:
+    //  - No time-window restriction: the existing sunrise anchor.
+    //  - Time-window restriction: latest allowed interval that fits, preferring
+    //    one whose end is ≤ sunrise (preserves pre-dawn placement when feasible).
+    const anchor = hasTimeWindows
+        ? pickAnchorForCycles(allowedIntervals, sunrise, requiredSpanMinutes)
+        : sunrise;
+    if (anchor === null) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): requested runtime ${requiredSpanMinutes.toFixed(1)} min cannot fit any allowed window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
+        return null;
+    }
+
+    const plannedCycles = buildCyclePlan(
+        totalRunTimeMinutes,
+        maximumCycleMinutes,
+        anchor,
+        soakTimeMinutes,
+    );
+
+    const combinedBusy = forbiddenForDay.length === 0
+        ? busyWindowsSoFar
+        : [...busyWindowsSoFar, ...forbiddenForDay];
+    const placedCycles = deconflictCycles(plannedCycles, combinedBusy, soakTimeMinutes);
+
+    // After deconflict, verify each cycle still lies wholly within an allowed
+    // interval. A cycle pushed into a forbidden gap or beyond today's last
+    // allowed interval means the placement failed.
+    if (hasTimeWindows && !cyclesFitAllowed(placedCycles, allowedIntervals)) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): cycles could not be placed within allowed windows on ${date.format('YYYY-MM-DD')} (cross-zone or window-gap conflict) — skipping irrigation.`);
+        return null;
+    }
+
+    const entry: IrrigationScheduleEntry = {
+        date,
+        zoneId: zone.id,
+        cycles: placedCycles,
+        appliedDepthMm: roundTo1Decimal(grossIrrigationDepthMillimeters),
+        depletionBeforeMm: roundTo1Decimal(depletionBeforeIrrigation),
+        depletionAfterMm: 0,
+    };
+    return { cycles: placedCycles, entry };
+}
+
+function cyclesFitAllowed(cycles: ReadonlyArray<IrrigationCycle>, allowedIntervals: ReadonlyArray<AllowedInterval>): boolean {
+    // 1-second tolerance absorbs floating-point creep from non-integer
+    // durations (e.g. 34.4-minute cycles where the ms arithmetic doesn't
+    // round-trip exactly through Dayjs).
+    const toleranceMs = 1000;
+    for (const cycle of cycles) {
+        const startMs = cycle.startTime.valueOf();
+        const endMs = startMs + cycle.durationMin * 60_000;
+        const inside = allowedIntervals.some(interval =>
+            startMs + toleranceMs >= interval.start.valueOf()
+                && endMs <= interval.end.valueOf() + toleranceMs);
+        if (!inside) return false;
+    }
+    return true;
 }
 
 /**
@@ -183,13 +288,15 @@ function buildCyclePlan(
 
     // Use single cycle if total time fits within infiltration constraint.
     if (maximumCycleMinutes <= 0 || totalRunTimeMinutes <= maximumCycleMinutes) {
-        const startTime = sunrise.subtract(totalRunTimeMinutes, 'minute');
-        return [{ startTime, durationMin: roundTo1Decimal(totalRunTimeMinutes) }];
+        const durationMin = roundTo1Decimal(totalRunTimeMinutes);
+        const startTime = sunrise.subtract(durationMin, 'minute');
+        return [{ startTime, durationMin }];
     }
 
     // Split into multiple cycles with soak time between.
     const numberOfCycles = Math.ceil(totalRunTimeMinutes / maximumCycleMinutes),
-        perCycleMinutes = totalRunTimeMinutes / numberOfCycles;
+        perCycleMinutesRaw = totalRunTimeMinutes / numberOfCycles,
+        perCycleMinutes = roundTo1Decimal(perCycleMinutesRaw);
 
     const cyclesInReverse: IrrigationCycle[] = [];
     let totalMinutesBeforeSunrise = 0;
@@ -200,7 +307,7 @@ function buildCyclePlan(
 
         cyclesInReverse.push({
             startTime: cycleStart,
-            durationMin: roundTo1Decimal(perCycleMinutes),
+            durationMin: perCycleMinutes,
         });
 
         // Add soak time before next earlier cycle.

--- a/api/schedules/dynamic/restrictions.ts
+++ b/api/schedules/dynamic/restrictions.ts
@@ -1,0 +1,169 @@
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+
+dayjs.extend(isoWeek);
+
+/**
+ * One allowed irrigation window within a day. `start` and `end` are
+ * `HH:mm` strings interpreted in the site's local timezone. Windows do
+ * not wrap past midnight — encode overnight allowances as two windows
+ * on consecutive days.
+ */
+export type ScheduleTimeWindow = {
+    start: string;
+    end: string;
+};
+
+/**
+ * Restrictions a schedule applies to the planner's per-day cycle placement.
+ * `null` (or an empty array) for either field means "no restriction"; both
+ * null is the no-op shape used when no schedule has constraints.
+ */
+export type ScheduleRestrictions = {
+    allowedDays: number[] | null;
+    allowedTimeWindows: ScheduleTimeWindow[] | null;
+};
+
+/**
+ * Closed-open interval the planner can place cycles inside.
+ */
+export type AllowedInterval = {
+    start: dayjs.Dayjs;
+    end: dayjs.Dayjs;
+};
+
+/**
+ * Returns true when the given ISO weekday (1=Mon..7=Sun) is allowed by the
+ * restriction's `allowedDays`. Null or empty means "no day restriction" so
+ * every day is allowed.
+ */
+export function isDayAllowed(restrictions: ScheduleRestrictions, isoWeekday: number): boolean {
+    const allowed = restrictions.allowedDays;
+    if (allowed === null || allowed.length === 0) return true;
+    return allowed.includes(isoWeekday);
+}
+
+/**
+ * Returns the set of allowed time intervals on `day`, anchored as absolute
+ * Dayjs values. When `allowedTimeWindows` is null or empty, the whole day is
+ * allowed (one interval covering midnight-to-midnight). Skipped silently
+ * (returns []) when the day itself is disallowed — callers should consult
+ * `isDayAllowed` first.
+ *
+ * @param day - Reference Dayjs already anchored at midnight in the site's
+ *   timezone. The returned intervals share its tz.
+ * @param restrictions - Effective restrictions for the active schedule.
+ */
+export function computeAllowedIntervalsForDay(day: dayjs.Dayjs, restrictions: ScheduleRestrictions): AllowedInterval[] {
+    if (!isDayAllowed(restrictions, day.isoWeekday())) return [];
+
+    const windows = restrictions.allowedTimeWindows;
+    if (windows === null || windows.length === 0) {
+        return [{ start: day.startOf('day'), end: day.add(1, 'day').startOf('day') }];
+    }
+
+    const base = day.startOf('day');
+    return windows
+        .map(w => ({
+            start: applyHhmm(base, w.start),
+            end: applyHhmm(base, w.end),
+        }))
+        .filter(interval => interval.end.isAfter(interval.start))
+        .sort((a, b) => a.start.valueOf() - b.start.valueOf());
+}
+
+/**
+ * Returns the forbidden gaps within `day` — the complement of the allowed
+ * intervals. When the day is fully forbidden, the result is a single
+ * interval spanning the whole day. Used as additional busy windows in
+ * `deconflictCycles` so forward shifts skip past restricted time.
+ */
+export function computeForbiddenIntervalsForDay(day: dayjs.Dayjs, restrictions: ScheduleRestrictions): AllowedInterval[] {
+    const dayStart = day.startOf('day');
+    const dayEnd = day.add(1, 'day').startOf('day');
+
+    if (!isDayAllowed(restrictions, day.isoWeekday())) {
+        return [{ start: dayStart, end: dayEnd }];
+    }
+
+    const allowed = computeAllowedIntervalsForDay(day, restrictions);
+    if (allowed.length === 0) return [{ start: dayStart, end: dayEnd }];
+
+    const gaps: AllowedInterval[] = [];
+    let cursor = dayStart;
+    for (const interval of allowed) {
+        if (interval.start.isAfter(cursor)) {
+            gaps.push({ start: cursor, end: interval.start });
+        }
+        if (interval.end.isAfter(cursor)) {
+            cursor = interval.end;
+        }
+    }
+    if (dayEnd.isAfter(cursor)) {
+        gaps.push({ start: cursor, end: dayEnd });
+    }
+    return gaps;
+}
+
+/**
+ * Picks an anchor instant to hand to `buildCyclePlan`, given the day's
+ * allowed intervals and the irrigation block's required span. Preference
+ * is the latest allowed interval whose end is ≤ sunrise — that preserves
+ * the planner's "fire just before sunrise" heuristic. Falls back to the
+ * latest allowed interval today that can hold the span. Returns null when
+ * no single interval can fit the block.
+ *
+ * @param allowedIntervals - Pre-computed by `computeAllowedIntervalsForDay`.
+ * @param sunrise - Day's sunrise (or default 06:00) in the site's tz.
+ * @param requiredSpanMinutes - `totalRunTime + (numCycles-1)*soakTime`.
+ */
+export function pickAnchorForCycles(
+    allowedIntervals: ReadonlyArray<AllowedInterval>,
+    sunrise: dayjs.Dayjs,
+    requiredSpanMinutes: number,
+): dayjs.Dayjs | null {
+    if (allowedIntervals.length === 0) return null;
+    if (requiredSpanMinutes <= 0) return null;
+    const spanMs = requiredSpanMinutes * 60_000;
+
+    const fits = allowedIntervals.filter(interval =>
+        (interval.end.valueOf() - interval.start.valueOf()) >= spanMs);
+    if (fits.length === 0) return null;
+
+    // Preference 1: the interval that contains sunrise. Anchor at sunrise
+    // itself when there's room before it; otherwise anchor at the interval's
+    // end so cycles still fit but end after sunrise.
+    const containing = fits.find(i =>
+        !i.start.isAfter(sunrise) && !i.end.isBefore(sunrise));
+    if (containing !== undefined) {
+        const canFitEndingAtSunrise = (sunrise.valueOf() - containing.start.valueOf()) >= spanMs;
+        return canFitEndingAtSunrise ? sunrise : containing.end;
+    }
+
+    // Preference 2: the latest interval whose end is ≤ sunrise (entirely
+    // pre-sunrise — common when sunrise is in a forbidden gap).
+    const beforeSunrise = fits.filter(i => !i.end.isAfter(sunrise));
+    if (beforeSunrise.length > 0) {
+        return beforeSunrise[beforeSunrise.length - 1]!.end;
+    }
+
+    // Preference 3: the latest interval today that fits, regardless of
+    // position vs. sunrise (evening window for a very late sunrise).
+    return fits[fits.length - 1]!.end;
+}
+
+function applyHhmm(base: dayjs.Dayjs, hhmm: string): dayjs.Dayjs {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
+    if (!match) {
+        throw new Error(`schedule-restrictions: invalid HH:mm value '${hhmm}'.`);
+    }
+    const hour = Number.parseInt(match[1]!, 10);
+    const minute = Number.parseInt(match[2]!, 10);
+    if (!Number.isFinite(hour) || hour < 0 || hour > 23) {
+        throw new Error(`schedule-restrictions: hour out of range in '${hhmm}'.`);
+    }
+    if (!Number.isFinite(minute) || minute < 0 || minute > 59) {
+        throw new Error(`schedule-restrictions: minute out of range in '${hhmm}'.`);
+    }
+    return base.hour(hour).minute(minute).second(0).millisecond(0);
+}

--- a/api/schedules/index.ts
+++ b/api/schedules/index.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { getWeatherData } from '../data/weather';
 import type { Zone } from '../models';
 import { planZoneSchedule, type BusyWindow, type PlanZoneScheduleResult } from './dynamic';
+import type { ScheduleRestrictions } from './dynamic/restrictions';
 
 export type RunScheduleForZoneOptions = {
     /** Optional. Number of days of forecast weather to plan against. Default 7. */
@@ -14,6 +15,12 @@ export type RunScheduleForZoneOptions = {
      * windows so subsequent zones plan around them.
      */
     busyWindows?: ReadonlyArray<{ start: Date; end: Date }>;
+
+    /**
+     * Optional. Day/time-window restrictions from the active schedule.
+     * `null`/empty fields mean "no restriction" for that dimension.
+     */
+    restrictions?: ScheduleRestrictions;
 };
 
 /**
@@ -51,5 +58,5 @@ export async function runScheduleForZone(
         end: dayjs(w.end),
     }));
 
-    return planZoneSchedule(zone, weather, busyWindows);
+    return planZoneSchedule(zone, weather, busyWindows, options?.restrictions);
 }

--- a/api/scripts/disable-schedule.test.ts
+++ b/api/scripts/disable-schedule.test.ts
@@ -11,6 +11,8 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         slug: 'maintenance',
         name: 'Maintenance',
         isActive: false,
+        allowedDays: null,
+        allowedTimeWindows: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/scripts/enable-schedule.test.ts
+++ b/api/scripts/enable-schedule.test.ts
@@ -11,6 +11,8 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         slug: 'maintenance',
         name: 'Maintenance',
         isActive: true,
+        allowedDays: null,
+        allowedTimeWindows: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,


### PR DESCRIPTION
## Ticket

[API-25](http://192.168.2.100:7123/irrigo/browse/API-25/) — Honor per-schedule water-restriction days and time windows when planning irrigation

## Summary

- Adds `allowedDays` (int[] of ISO weekdays) and `allowedTimeWindows` (jsonb `{start,end}` HH:mm in site-local TZ) to the `schedules` table. Both nullable — NULL/empty means "no restriction" so existing rows behave identically until an operator opts in.
- New `api/schedules/dynamic/restrictions.ts` carries the per-day math: `isDayAllowed`, `computeAllowedIntervalsForDay`, `computeForbiddenIntervalsForDay`, `pickAnchorForCycles`. dayjs gets the `isoWeek` plugin so `isoWeekday()` works.
- `planZoneSchedule` accepts a fourth `restrictions` parameter. Per day:
  - Disallowed weekday → skip cycle placement, depletion carries forward into the next allowed day.
  - Time windows set → anchor cycles at sunrise when sunrise sits inside an allowed window, otherwise at the end of the latest pre-sunrise allowed window. Forbidden gaps fold into the busy-window set so `deconflictCycles` skips past them.
  - Validation pass after deconflict: any cycle still landing in a forbidden gap drops the day with a warn.
- Fixed a long-standing rounding drift in `buildCyclePlan`: subtraction used the unrounded run time while duration was rounded to 1 decimal, leaving the cycle end up to ~30s past the anchor. Now both use the rounded duration.
- Restrictions plumb through: `RunScheduleForZoneOptions.restrictions` → `runScheduleForZone` → `planZoneSchedule`. The daemon's `rePlan` reads `allowedDays` / `allowedTimeWindows` off the active schedule and forwards them.
- Skipped days **carry depletion forward** (no reset). The next allowed day sees the larger accumulated depletion and irrigates accordingly.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 392/392 passing
- 9 new planner-restriction tests, 1 forwarding test in schedules suite, 1 daemon-side test asserting restrictions reach `runPlan`
- Manual smoke (optional, requires a running stack with seeded sites + schedules):
  - `UPDATE schedules SET allowed_days = '{3,5,7}', allowed_time_windows = '[{"start":"00:00","end":"10:00"},{"start":"19:00","end":"23:59"}]' WHERE slug = 'maintenance';`
  - Restart the api container; the next 04:00 re-plan should place cycles only on Wed/Fri/Sun and only within the two windows.

## Out of scope

- Cycle-splitting across multiple windows in a single day (each cycle still wholly in one window).
- Even/odd-address day rules, seasonal date ranges (separate tickets if needed).
- Admin HTTP/CLI for editing the new columns — operators set via SQL or the JSON-driven seed once API-28 lands.