### PR TITLE
[API-26] Per-schedule root-depth and depletion overrides

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1980,6 +1980,88 @@ describe('start', () => {
     });
 
     describe('schedule integration', () => {
+        it('forwards the active schedule\'s rootDepthMOverride and allowableDepletionFractionOverride to runPlan', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-o', siteId: 'site-O' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-o', siteId: 'site-O', slug: 'overseeding', name: 'Overseeding',
+                        isActive: true,
+                        allowedDays: null,
+                        allowedTimeWindows: null,
+                        rootDepthMOverride: 0.05,
+                        allowableDepletionFractionOverride: 0.25,
+                        createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: Array<{ rootDepthM: number | undefined; allowableDepletionFraction: number | undefined }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    planCalls.push({
+                        rootDepthM: opts?.overrides?.rootDepthM,
+                        allowableDepletionFraction: opts?.overrides?.allowableDepletionFraction,
+                    });
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toHaveLength(1);
+            expect(planCalls[0]?.rootDepthM).toBe(0.05);
+            expect(planCalls[0]?.allowableDepletionFraction).toBe(0.25);
+        });
+
+        it('forwards undefined overrides when the active schedule has both override columns null', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-n', siteId: 'site-N' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-n', siteId: 'site-N', slug: 'maintenance', name: 'Maintenance',
+                        isActive: true,
+                        allowedDays: null,
+                        allowedTimeWindows: null,
+                        rootDepthMOverride: null,
+                        allowableDepletionFractionOverride: null,
+                        createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: Array<{ rootDepthM: number | undefined; allowableDepletionFraction: number | undefined }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    planCalls.push({
+                        rootDepthM: opts?.overrides?.rootDepthM,
+                        allowableDepletionFraction: opts?.overrides?.allowableDepletionFraction,
+                    });
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toHaveLength(1);
+            expect(planCalls[0]?.rootDepthM).toBeUndefined();
+            expect(planCalls[0]?.allowableDepletionFraction).toBeUndefined();
+        });
+
         it('forwards the active schedule\'s allowedDays and allowedTimeWindows to runPlan', async () => {
             const enabledRow = buildJoinedRow({ zone: { id: 'zone-r', siteId: 'site-R' } });
             const { db } = createDaemonDbStub({

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1287,6 +1287,8 @@ type DaemonStubInputs = {
         isActive: boolean;
         allowedDays: number[] | null;
         allowedTimeWindows: Array<{ start: string; end: string }> | null;
+        rootDepthMOverride: number | null;
+        allowableDepletionFractionOverride: number | null;
         createdAt: Date;
         updatedAt: Date;
     } }>;
@@ -1335,6 +1337,8 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             isActive: true,
             allowedDays: null,
             allowedTimeWindows: null,
+            rootDepthMOverride: null,
+            allowableDepletionFractionOverride: null,
             createdAt: NOW_FOR_SCHEDULES,
             updatedAt: NOW_FOR_SCHEDULES,
         },
@@ -1989,6 +1993,8 @@ describe('start', () => {
                             { start: '00:00', end: '10:00' },
                             { start: '19:00', end: '23:59' },
                         ],
+                        rootDepthMOverride: null,
+                        allowableDepletionFractionOverride: null,
                         createdAt: NOW, updatedAt: NOW,
                     },
                 }],
@@ -2028,7 +2034,7 @@ describe('start', () => {
                 activeSchedules: [{
                     schedule: {
                         id: 'sched-active', siteId: 'site-A', slug: 'maintenance', name: 'Maintenance',
-                        isActive: true, allowedDays: null, allowedTimeWindows: null, createdAt: NOW, updatedAt: NOW,
+                        isActive: true, allowedDays: null, allowedTimeWindows: null, rootDepthMOverride: null, allowableDepletionFractionOverride: null, createdAt: NOW, updatedAt: NOW,
                     },
                 }],
             });
@@ -2095,7 +2101,7 @@ describe('start', () => {
                     activeSchedules: [{
                         schedule: {
                             id: 'sched-A', siteId: 'site-active', slug: 'maintenance', name: 'Maintenance',
-                            isActive: true, allowedDays: null, allowedTimeWindows: null, createdAt: NOW, updatedAt: NOW,
+                            isActive: true, allowedDays: null, allowedTimeWindows: null, rootDepthMOverride: null, allowableDepletionFractionOverride: null, createdAt: NOW, updatedAt: NOW,
                         },
                     }],
                 });

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -178,7 +178,11 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                     allowedDays: activeSchedule.allowedDays,
                     allowedTimeWindows: activeSchedule.allowedTimeWindows,
                 };
-                const { entries, projectedNextDepletionMm } = await runPlan(zone, { busyWindows, restrictions });
+                const overrides = {
+                    rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,
+                    allowableDepletionFraction: activeSchedule.allowableDepletionFractionOverride ?? undefined,
+                };
+                const { entries, projectedNextDepletionMm } = await runPlan(zone, { busyWindows, restrictions, overrides });
                 const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm, activeSchedule.id);
                 for (const cycle of cycles) {
                     armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier });

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -23,6 +23,8 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         isActive: true,
         allowedDays: null,
         allowedTimeWindows: null,
+        rootDepthMOverride: null,
+        allowableDepletionFractionOverride: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/db/schema/schedules.ts
+++ b/api/db/schema/schedules.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { boolean, integer, jsonb, pgTable, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { boolean, integer, jsonb, pgTable, real, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
 import { sites } from './sites';
 
@@ -31,6 +31,8 @@ export const schedules = pgTable('schedules', {
     isActive: boolean('is_active').notNull().default(false),
     allowedDays: integer('allowed_days').array(),
     allowedTimeWindows: jsonb('allowed_time_windows').$type<ScheduleTimeWindow[]>(),
+    rootDepthMOverride: real('root_depth_m_override'),
+    allowableDepletionFractionOverride: real('allowable_depletion_fraction_override'),
     ...auditColumns,
 }, table => [
     uniqueIndex('schedules_site_slug_idx').on(table.siteId, table.slug),

--- a/api/drizzle/0005_wonderful_speedball.sql
+++ b/api/drizzle/0005_wonderful_speedball.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "schedules" ADD COLUMN "root_depth_m_override" real;--> statement-breakpoint
+ALTER TABLE "schedules" ADD COLUMN "allowable_depletion_fraction_override" real;

--- a/api/drizzle/meta/0005_snapshot.json
+++ b/api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,720 @@
+{
+  "id": "30d3c638-c91e-4658-87dc-c4fae642540a",
+  "prevId": "08b7c40f-f4b6-4956-805f-7b951c5efaf5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778510901466,
       "tag": "0004_living_joshua_kane",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778515210166,
+      "tag": "0005_wonderful_speedball",
+      "breakpoints": true
     }
   ]
 }

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -154,6 +154,28 @@ describe('runScheduleForZone', () => {
         expect(result.entries.some(e => e.date.format('YYYY-MM-DD') === '2025-10-20')).toBe(false);
     });
 
+    it('forwards schedule overrides to the planner so cycle counts change without zone edits', async () => {
+        const zone = createTestZone({
+            currentDepletionMm: 5,
+            allowableDepletionFraction: 0.5,
+            rootDepthM: 0.3,
+            soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+            location: { lat: 51.0447, lon: -114.0719 },
+        });
+
+        // Baseline — Maintenance-style cadence against the stubbed 3-day forecast.
+        stubSuccess();
+        const baseline = await runScheduleForZone(zone);
+
+        // Overseeding-style overrides: RAW ≈ 1.875 mm, ET ≈ 3.4 mm/day → daily.
+        stubSuccess();
+        const overseeding = await runScheduleForZone(zone, {
+            overrides: { rootDepthM: 0.05, allowableDepletionFraction: 0.25 },
+        });
+
+        expect(overseeding.entries.length).toBeGreaterThan(baseline.entries.length);
+    });
+
     it('returns an empty schedule when the weather API returns no days', async () => {
         mockFetch.mockResolvedValueOnce({
             ok: true,

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1378,4 +1378,125 @@ describe('planZoneSchedule', () => {
             expect(inMorning || inEvening).toBe(true);
         });
     });
+
+    describe('schedule overrides', () => {
+        const baseZone = () => createTestZone({
+            currentDepletionMm: 5,
+            allowableDepletionFraction: 0.5,
+            rootDepthM: 0.3,
+            soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+        });
+
+        const drySevenDays = () => createDryPeriod(7, 5.0, dayjs('2026-05-04'));
+
+        it('produces output identical to a no-args call when overrides are omitted (regression)', () => {
+            const zone = baseZone();
+            const weather = drySevenDays();
+
+            const baseline = planZoneSchedule(zone, weather);
+            const withEmpty = planZoneSchedule(zone, weather, [], undefined, {});
+
+            expect(withEmpty.entries.length).toBe(baseline.entries.length);
+            for (let i = 0; i < baseline.entries.length; i++) {
+                const a = baseline.entries[i]!;
+                const b = withEmpty.entries[i]!;
+                expect(b.date.isSame(a.date)).toBe(true);
+                expect(b.appliedDepthMm).toBeCloseTo(a.appliedDepthMm, 5);
+                expect(b.cycles.length).toBe(a.cycles.length);
+            }
+            expect(withEmpty.projectedNextDepletionMm).toBeCloseTo(baseline.projectedNextDepletionMm, 5);
+        });
+
+        it('shrinks TAW/RAW when only rootDepthM is overridden, triggering irrigation sooner', () => {
+            // Zone default RAW = 0.5 * (150 * 0.3) = 22.5 mm. Starting depletion 5 mm,
+            // Kc * ET = 0.85 * 5 = 4.25 mm/day → reaches RAW around day 5.
+            const zone = baseZone();
+            const weather = drySevenDays();
+
+            const baseline = planZoneSchedule(zone, weather);
+            // Override RAW = 0.5 * (150 * 0.05) = 3.75 mm. Starting depletion 5 mm
+            // already exceeds it, so day-0 triggers immediately.
+            const shallow = planZoneSchedule(zone, weather, [], undefined, { rootDepthM: 0.05 });
+
+            const baselineDay0 = baseline.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+            const shallowDay0 = shallow.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+
+            expect(baselineDay0).toBeUndefined();
+            expect(shallowDay0).toBeDefined();
+        });
+
+        it('tightens the trigger threshold when only allowableDepletionFraction is overridden', () => {
+            // Default RAW 22.5 mm. Tightening to 0.1 → RAW = 0.1 * 45 = 4.5 mm.
+            // Starting depletion 5 mm exceeds it → day 0 fires.
+            const zone = baseZone();
+            const weather = drySevenDays();
+
+            const baseline = planZoneSchedule(zone, weather);
+            const tight = planZoneSchedule(zone, weather, [], undefined, { allowableDepletionFraction: 0.1 });
+
+            const baselineDay0 = baseline.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+            const tightDay0 = tight.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+
+            expect(baselineDay0).toBeUndefined();
+            expect(tightDay0).toBeDefined();
+            // depletionBefore reflects the tight threshold (5 + 0.85*5 = 9.25 mm).
+            expect(tightDay0?.depletionBeforeMm).toBeCloseTo(9.3, 1);
+        });
+
+        it('produces daily entries across the forecast under overseeding-style overrides', () => {
+            // Overseeding-style: RAW = 0.25 * (150 * 0.05) = 1.875 mm.
+            // Daily ET ≈ 4.75 mm overwhelms RAW every day.
+            const zone = baseZone();
+            const weather = drySevenDays();
+
+            const overseeding = planZoneSchedule(zone, weather, [], undefined, {
+                rootDepthM: 0.05,
+                allowableDepletionFraction: 0.25,
+            });
+
+            expect(overseeding.entries.length).toBe(7);
+        });
+
+        it('clamps starting depletion against the overridden (shallower) TAW', () => {
+            // Default TAW = 45 mm, zone starts at 30 mm. With rootDepthM override
+            // of 0.05, TAW shrinks to 7.5 mm and the clamp pulls the starting
+            // depletion down accordingly. The post-day-0 projection reflects
+            // the clamp, not the seed value.
+            const zone = createTestZone({
+                currentDepletionMm: 30,
+                allowableDepletionFraction: 0.5,
+                rootDepthM: 0.3,
+                soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+            });
+            const weather = createWeatherDays([{ evapotranspirationMmPerDay: 0, rainfallMm: 0 }], dayjs('2026-05-04'));
+
+            const result = planZoneSchedule(zone, weather, [], undefined, { rootDepthM: 0.05 });
+
+            // With currentDepletion clamped to 7.5 mm (overridden TAW), starting
+            // depletion > RAW (1.875 mm) so day-0 triggers and refills to 0.
+            // With ET=0 the projected end-of-day depletion is 0, not 30.
+            expect(result.entries[0]?.depletionBeforeMm).toBeCloseTo(7.5, 1);
+            expect(result.projectedNextDepletionMm).toBe(0);
+        });
+
+        it('produces materially different output when the same fixture is planned under different override modes', () => {
+            const zone = baseZone();
+            const weather = drySevenDays();
+
+            const maintenance = planZoneSchedule(zone, weather);
+            const overseeding = planZoneSchedule(zone, weather, [], undefined, {
+                rootDepthM: 0.05,
+                allowableDepletionFraction: 0.25,
+            });
+
+            // Maintenance: ~1 entry in a 7-day dry run (refills once around day 5).
+            // Overseeding: an entry every day (7 in total).
+            expect(overseeding.entries.length).toBeGreaterThan(maintenance.entries.length);
+            // Maintenance per-fire applied depth is much larger (refills full RAW)
+            // than the overseeding per-fire applied depth (refills the much smaller RAW).
+            const maintenanceFire = maintenance.entries[0]!;
+            const overseedingFire = overseeding.entries[0]!;
+            expect(maintenanceFire.appliedDepthMm).toBeGreaterThan(overseedingFire.appliedDepthMm * 3);
+        });
+    });
 });

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -12,6 +12,19 @@ import {
 const NO_RESTRICTIONS: ScheduleRestrictions = { allowedDays: null, allowedTimeWindows: null };
 
 /**
+ * Per-schedule planner overrides. When set, the planner uses these values
+ * in place of the corresponding zone fields. Both null/undefined means
+ * "no override" — planner reads `zone.rootDepthM` and
+ * `zone.allowableDepletionFraction` as before.
+ */
+export type ScheduleOverrides = {
+    rootDepthM?: number;
+    allowableDepletionFraction?: number;
+};
+
+const NO_OVERRIDES: ScheduleOverrides = {};
+
+/**
  * A time interval the planner must avoid placing cycles inside. Used by the
  * daemon's sequential per-zone planning to prevent cross-zone overlap: each
  * zone's persisted cycles become busy windows for subsequent zones.
@@ -47,6 +60,10 @@ export type PlanZoneScheduleResult = {
  *   day is disallowed or the planned irrigation block can't fit any allowed
  *   window, the day's cycles are dropped (with a warning) and depletion
  *   carries forward into the next allowed day. Defaults to "no restriction".
+ * @param overrides - Per-schedule planner-parameter overrides. When set,
+ *   the planner uses these in place of the zone's own `rootDepthM` /
+ *   `allowableDepletionFraction`. Zone rows stay untouched — overrides
+ *   express the temporary planning mode (e.g. overseeding vs. maintenance).
  * @returns Per-day entries plus the projected next-day starting depletion.
  */
 export function planZoneSchedule(
@@ -54,16 +71,24 @@ export function planZoneSchedule(
     weatherHistory: DailyWeather[],
     busyWindows: ReadonlyArray<BusyWindow> = [],
     restrictions: ScheduleRestrictions = NO_RESTRICTIONS,
+    overrides: ScheduleOverrides = NO_OVERRIDES,
 ): PlanZoneScheduleResult {
-    const totalAvailableWaterMillimetersForClamp = zone.soil.availableWaterHoldingCapacityMmPerM * zone.rootDepthM,
+    const effectiveRootDepthM = overrides.rootDepthM ?? zone.rootDepthM,
+        effectiveAllowableDepletionFraction = overrides.allowableDepletionFraction ?? zone.allowableDepletionFraction;
+
+    if (overrides.rootDepthM !== undefined || overrides.allowableDepletionFraction !== undefined) {
+        console.log(`planZoneSchedule: zone ${zone.id} using overrides root=${effectiveRootDepthM} depletion=${effectiveAllowableDepletionFraction}.`);
+    }
+
+    const totalAvailableWaterMillimetersForClamp = zone.soil.availableWaterHoldingCapacityMmPerM * effectiveRootDepthM,
         clampedStartingDepletion = clampValue(zone.currentDepletionMm ?? 0, 0, totalAvailableWaterMillimetersForClamp);
 
     if (zone.isEnabled === false) return { entries: [], projectedNextDepletionMm: clampedStartingDepletion };
 
     // Calculate soil water holding capacity and thresholds.
     const availableWaterHoldingCapacity = zone.soil.availableWaterHoldingCapacityMmPerM,
-        totalAvailableWaterMillimeters = availableWaterHoldingCapacity * zone.rootDepthM,
-        readilyAvailableWaterMillimeters = zone.allowableDepletionFraction * totalAvailableWaterMillimeters;
+        totalAvailableWaterMillimeters = availableWaterHoldingCapacity * effectiveRootDepthM,
+        readilyAvailableWaterMillimeters = effectiveAllowableDepletionFraction * totalAvailableWaterMillimeters;
 
     // Calculate precipitation rate from flow rate and area (1 L/m² = 1 mm).
     const precipitationRateMillimetersPerHour = zone.precipitationRateMmPerHr ?? 60 * (zone.flowRateLPerMin / zone.areaM2);

--- a/api/schedules/index.ts
+++ b/api/schedules/index.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { getWeatherData } from '../data/weather';
 import type { Zone } from '../models';
-import { planZoneSchedule, type BusyWindow, type PlanZoneScheduleResult } from './dynamic';
+import { planZoneSchedule, type BusyWindow, type PlanZoneScheduleResult, type ScheduleOverrides } from './dynamic';
 import type { ScheduleRestrictions } from './dynamic/restrictions';
 
 export type RunScheduleForZoneOptions = {
@@ -21,6 +21,13 @@ export type RunScheduleForZoneOptions = {
      * `null`/empty fields mean "no restriction" for that dimension.
      */
     restrictions?: ScheduleRestrictions;
+
+    /**
+     * Optional. Per-schedule planner-parameter overrides. Both fields
+     * `undefined` means "no override" — planner reads the zone's own
+     * `rootDepthM` / `allowableDepletionFraction`.
+     */
+    overrides?: ScheduleOverrides;
 };
 
 /**
@@ -58,5 +65,5 @@ export async function runScheduleForZone(
         end: dayjs(w.end),
     }));
 
-    return planZoneSchedule(zone, weather, busyWindows, options?.restrictions);
+    return planZoneSchedule(zone, weather, busyWindows, options?.restrictions, options?.overrides);
 }

--- a/api/scripts/disable-schedule.test.ts
+++ b/api/scripts/disable-schedule.test.ts
@@ -13,6 +13,8 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         isActive: false,
         allowedDays: null,
         allowedTimeWindows: null,
+        rootDepthMOverride: null,
+        allowableDepletionFractionOverride: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/scripts/enable-schedule.test.ts
+++ b/api/scripts/enable-schedule.test.ts
@@ -13,6 +13,8 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         isActive: true,
         allowedDays: null,
         allowedTimeWindows: null,
+        rootDepthMOverride: null,
+        allowableDepletionFractionOverride: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,


### PR DESCRIPTION
## Ticket

[API-26](http://192.168.2.100:7123/irrigo/browse/API-26/) — Per-schedule planner overrides for root depth and allowable depletion

## Summary

- Adds `rootDepthMOverride` and `allowableDepletionFractionOverride` (both nullable `real`) to the `schedules` table. NULL = use the zone's own value.
- `planZoneSchedule` accepts an optional 5th `overrides?: ScheduleOverrides` parameter. Locals coalesce: `effectiveRootDepthM = overrides.rootDepthM ?? zone.rootDepthM` and similarly for depletion fraction. All downstream math (TAW, RAW, starting-depletion clamp) reads the locals. Single log line per re-plan when any override is in effect.
- `RunScheduleForZoneOptions.overrides` forwards into the planner. Daemon `rePlan` reads both override columns off the active schedule and passes them via `runPlan`.
- Switching schedules is now the entire user-facing action: zone rows stay stable describing the physical lawn; schedule rows express the temporary planning mode (Maintenance vs. Overseeding) without operator SQL surgery.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 401/401 passing
- 6 new planner-override tests, 1 forwarding test in schedules suite, 2 daemon-side tests (overrides set + both null)
- Manual smoke (optional, requires a running stack):
  - `UPDATE schedules SET root_depth_m_override = 0.05, allowable_depletion_fraction_override = 0.25 WHERE slug = 'maintenance';`
  - Restart the api container; the next 04:00 re-plan logs `planZoneSchedule: zone <id> using overrides root=0.05 depletion=0.25.` and produces materially shorter, more frequent cycles than before.

## Out of scope

- Per-zone-per-schedule overrides (a follow-up table layers on top — schedule-level values become the fallback).
- Overriding other zone fields (`irrigationEfficiency`, `precipitationRateMmPerHr`, `flowRateLPerMin`).
- Admin HTTP/CLI for editing override values. Operators set via SQL or the JSON-driven seed once API-29 lands.