### PR TITLE
[API-27] Re-plan immediately on schedule enable/disable

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { buildApp, gracefulShutdown } from '@/index';
+import { buildApp, gracefulShutdown, wrapScheduleWithReplan, type ScheduleApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
 import { BusyError, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
@@ -451,6 +451,168 @@ describe('buildApp schedule routes', () => {
         const app = buildApp({ getStatus: () => buildStatus() });
 
         const res = await app.inject({ method: 'POST', url: '/schedule/enable/maintenance' });
+
+        expect(res.statusCode).toBe(404);
+        await app.close();
+    });
+
+    describe('wrapped with replan', () => {
+        it('returns 502 when the wrapped enable closure rejects (re-plan failed)', async () => {
+            // Simulate the production wiring: enable throws because replan threw.
+            const base: ScheduleApi = {
+                enable: async slug => buildSchedule({ slug }),
+                disable: async () => null,
+            };
+            const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('HA 503'); });
+            const app = buildApp({ getStatus: () => buildStatus(), schedule: wrapped });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/enable/maintenance' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'HA 503' });
+            await app.close();
+        });
+
+        it('returns 502 when the wrapped disable closure rejects', async () => {
+            const base: ScheduleApi = {
+                enable: async () => null,
+                disable: async slug => buildSchedule({ slug, isActive: false }),
+            };
+            const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('HA 504'); });
+            const app = buildApp({ getStatus: () => buildStatus(), schedule: wrapped });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/disable/maintenance' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'HA 504' });
+            await app.close();
+        });
+    });
+});
+
+describe('wrapScheduleWithReplan', () => {
+    const buildSchedule = (overrides?: Partial<{ slug: string; name: string; siteId: string; isActive: boolean }>) => ({
+        id: 'sched-1',
+        siteId: 'site-A',
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: true,
+        allowedDays: null,
+        allowedTimeWindows: null,
+        rootDepthMOverride: null,
+        allowableDepletionFractionOverride: null,
+        createdAt: new Date('2026-05-11T18:00:00.000Z'),
+        updatedAt: new Date('2026-05-11T18:00:00.000Z'),
+        ...overrides,
+    });
+
+    it('calls replan after a non-null enable result, awaiting it before returning', async () => {
+        const callOrder: string[] = [];
+        const base: ScheduleApi = {
+            enable: async (slug) => { callOrder.push('enable'); return buildSchedule({ slug }); },
+            disable: async () => null,
+        };
+        const replan = async () => {
+            await Promise.resolve();
+            callOrder.push('replan');
+        };
+        const wrapped = wrapScheduleWithReplan(base, replan);
+
+        const result = await wrapped.enable('maintenance');
+        callOrder.push('returned');
+
+        expect(result?.slug).toBe('maintenance');
+        expect(callOrder).toEqual(['enable', 'replan', 'returned']);
+    });
+
+    it('skips replan when enable returns null (unknown slug)', async () => {
+        let replanCalls = 0;
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { replanCalls += 1; });
+
+        const result = await wrapped.enable('no-such');
+
+        expect(result).toBeNull();
+        expect(replanCalls).toBe(0);
+    });
+
+    it('calls replan after a non-null disable result', async () => {
+        const callOrder: string[] = [];
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async (slug) => { callOrder.push('disable'); return buildSchedule({ slug, isActive: false }); },
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { callOrder.push('replan'); });
+
+        await wrapped.disable('maintenance');
+
+        expect(callOrder).toEqual(['disable', 'replan']);
+    });
+
+    it('skips replan when disable returns null', async () => {
+        let replanCalls = 0;
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { replanCalls += 1; });
+
+        await wrapped.disable('no-such');
+
+        expect(replanCalls).toBe(0);
+    });
+
+    it('propagates rejections from replan so the route handler can map them to 502', async () => {
+        const base: ScheduleApi = {
+            enable: async (slug) => buildSchedule({ slug }),
+            disable: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('replan failed'); });
+
+        await expect(wrapped.enable('maintenance')).rejects.toThrow('replan failed');
+    });
+});
+
+describe('buildApp /replan route', () => {
+    const NOW_ISO = '2026-05-11T18:00:00.000Z';
+
+    it('returns 200 with lastRePlanAt from getStatus after the replan resolves', async () => {
+        let replanCalls = 0;
+        const replan = async () => { replanCalls += 1; };
+        const app = buildApp({
+            getStatus: () => buildStatus({ lastRePlanAt: NOW_ISO }),
+            replan,
+        });
+
+        const res = await app.inject({ method: 'POST', url: '/replan' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({ status: 'replanned', lastRePlanAt: NOW_ISO });
+        expect(replanCalls).toBe(1);
+        await app.close();
+    });
+
+    it('returns 502 with error: replan-failed when the supplied replan rejects', async () => {
+        const replan = async () => { throw new Error('weather API timeout'); };
+        const app = buildApp({
+            getStatus: () => buildStatus(),
+            replan,
+        });
+
+        const res = await app.inject({ method: 'POST', url: '/replan' });
+
+        expect(res.statusCode).toBe(502);
+        expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'weather API timeout' });
+        await app.close();
+    });
+
+    it('does not register /replan when the option is absent', async () => {
+        const app = buildApp({ getStatus: () => buildStatus() });
+
+        const res = await app.inject({ method: 'POST', url: '/replan' });
 
         expect(res.statusCode).toBe(404);
         await app.close();

--- a/api/index.ts
+++ b/api/index.ts
@@ -29,11 +29,48 @@ export type ScheduleApi = {
     disable: (slug: string) => Promise<Schedule | null>;
 };
 
+/**
+ * Wraps a base `ScheduleApi` so that any non-null `enable` / `disable`
+ * result triggers `replan` before resolving. The wrapper keeps the route
+ * handler synchronous-looking: when the route awaits `schedule.enable`,
+ * it implicitly awaits the re-plan too. When the base call returns null
+ * (unknown slug), the re-plan is skipped — there's nothing to re-plan
+ * against. Errors from `replan` propagate to the route, which maps them
+ * to a 502 response.
+ *
+ * @param base - The underlying schedule manager (DB-backed in production).
+ * @param replan - The daemon's `rePlan` reference.
+ * @returns A new `ScheduleApi` that drives a re-plan after each successful
+ *   activation change.
+ */
+export function wrapScheduleWithReplan(base: ScheduleApi, replan: () => Promise<void>): ScheduleApi {
+    return {
+        enable: async slug => {
+            const result = await base.enable(slug);
+            if (result !== null) await replan();
+            return result;
+        },
+        disable: async slug => {
+            const result = await base.disable(slug);
+            if (result !== null) await replan();
+            return result;
+        },
+    };
+}
+
 export type BuildAppOptions = {
     getStatus: () => DaemonStatus;
     manual?: ManualController;
     zoneById?: (zoneId: string) => Promise<Zone | null>;
     schedule?: ScheduleApi;
+
+    /**
+     * Optional. When supplied, registers `POST /replan` that calls this
+     * function. The route returns the post-re-plan daemon status so
+     * operators can confirm `lastRePlanAt` advanced. Production wires
+     * `daemon.rePlan` here.
+     */
+    replan?: () => Promise<void>;
 };
 
 /**
@@ -69,7 +106,34 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerScheduleRoutes(app, opts.schedule);
     }
 
+    if (opts.replan) {
+        registerReplanRoute(app, opts.replan, opts.getStatus);
+    }
+
     return app;
+}
+
+function registerReplanRoute(
+    app: FastifyInstance,
+    replan: () => Promise<void>,
+    getStatus: () => DaemonStatus,
+): void {
+    /**
+     * `POST /replan` — forces the daemon to re-plan immediately. Used by the
+     * CLI scripts to make schedule changes take effect within seconds rather
+     * than at the next 04:00 site-local tick. Returns 200 with the post-
+     * re-plan `lastRePlanAt`; 502 if the re-plan itself rejects.
+     */
+    app.post('/replan', async (_req, reply) => {
+        try {
+            await replan();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
+        const status = getStatus();
+        return reply.code(200).send({ status: 'replanned', lastRePlanAt: status.lastRePlanAt });
+    });
 }
 
 function registerScheduleRoutes(app: FastifyInstance, schedule: ScheduleApi): void {
@@ -80,7 +144,13 @@ function registerScheduleRoutes(app: FastifyInstance, schedule: ScheduleApi): vo
      */
     app.post('/schedule/enable/:slug', async (req, reply) => {
         const { slug } = req.params as { slug: string };
-        const result = await schedule.enable(slug);
+        let result;
+        try {
+            result = await schedule.enable(slug);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
         if (result === null) {
             return reply.code(404).send({ error: 'not-found', message: `Schedule '${slug}' not found.` });
         }
@@ -97,7 +167,13 @@ function registerScheduleRoutes(app: FastifyInstance, schedule: ScheduleApi): vo
      */
     app.post('/schedule/disable/:slug', async (req, reply) => {
         const { slug } = req.params as { slug: string };
-        const result = await schedule.disable(slug);
+        let result;
+        try {
+            result = await schedule.disable(slug);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
         if (result === null) {
             return reply.code(404).send({ error: 'not-found', message: `Schedule '${slug}' not found.` });
         }
@@ -238,14 +314,16 @@ if (import.meta.main) {
         isAnyScheduledInFlight: () => daemon.getStatus().activeZones.length > 0,
     });
     const scheduleDb = db as unknown as ScheduleManagerDb;
+    const baseSchedule: ScheduleApi = {
+        enable: slug => defaultEnableSchedule(scheduleDb, slug),
+        disable: slug => defaultDisableSchedule(scheduleDb, slug),
+    };
     const app = buildApp({
         getStatus: daemon.getStatus,
         manual,
         zoneById: zoneId => loadZoneById(db as unknown as Parameters<typeof loadZoneById>[0], zoneId),
-        schedule: {
-            enable: slug => defaultEnableSchedule(scheduleDb, slug),
-            disable: slug => defaultDisableSchedule(scheduleDb, slug),
-        },
+        schedule: wrapScheduleWithReplan(baseSchedule, () => daemon.rePlan()),
+        replan: () => daemon.rePlan(),
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/scripts/disable-schedule.test.ts
+++ b/api/scripts/disable-schedule.test.ts
@@ -25,35 +25,43 @@ function recordingDeps(overrides: Partial<DisableScheduleCliDeps>): {
     deps: DisableScheduleCliDeps;
     logs: string[];
     errors: string[];
+    replanCalls: { count: number };
 } {
     const logs: string[] = [];
     const errors: string[] = [];
+    const replanCalls = { count: 0 };
     const deps: DisableScheduleCliDeps = {
         disableSchedule: async () => null,
         loadDb: async () => ({} as ScheduleManagerDb),
+        triggerReplan: async () => { replanCalls.count += 1; },
         log: m => logs.push(m),
         error: m => errors.push(m),
         ...overrides,
     };
-    return { deps, logs, errors };
+    return { deps, logs, errors, replanCalls };
 }
 
 describe('disableScheduleCli', () => {
-    it('returns 0 and logs the deactivated schedule on success', async () => {
-        const { deps, logs, errors } = recordingDeps({
-            disableSchedule: async (_db, slug) => buildSchedule({ slug }),
+    it('returns 0, logs the deactivated schedule, and triggers a re-plan on success', async () => {
+        const callOrder: string[] = [];
+        const { deps, logs, errors, replanCalls } = recordingDeps({
+            disableSchedule: async (_db, slug) => { callOrder.push('disable'); return buildSchedule({ slug }); },
+            triggerReplan: async () => { callOrder.push('replan'); replanCalls.count += 1; },
         });
 
         const code = await disableScheduleCli(['bun', 'disable-schedule.ts', 'maintenance'], deps);
 
         expect(code).toBe(0);
-        expect(logs[0]).toContain(`disabled 'maintenance'`);
+        expect(logs.some(m => m.includes(`disabled 'maintenance'`))).toBe(true);
+        expect(logs.some(m => m.includes('re-plan triggered'))).toBe(true);
         expect(errors).toEqual([]);
+        expect(replanCalls.count).toBe(1);
+        expect(callOrder).toEqual(['disable', 'replan']);
     });
 
     it('returns 1 with a usage error when the slug is missing from argv', async () => {
         let called = 0;
-        const { deps, errors } = recordingDeps({
+        const { deps, errors, replanCalls } = recordingDeps({
             disableSchedule: async () => { called += 1; return null; },
         });
 
@@ -62,10 +70,11 @@ describe('disableScheduleCli', () => {
         expect(code).toBe(1);
         expect(errors[0]).toContain('usage');
         expect(called).toBe(0);
+        expect(replanCalls.count).toBe(0);
     });
 
-    it('returns 1 with a clear error when the underlying call returns null', async () => {
-        const { deps, errors } = recordingDeps({
+    it('returns 1 with a clear error when the underlying call returns null, never triggers a re-plan', async () => {
+        const { deps, errors, replanCalls } = recordingDeps({
             disableSchedule: async () => null,
         });
 
@@ -73,5 +82,21 @@ describe('disableScheduleCli', () => {
 
         expect(code).toBe(1);
         expect(errors[0]).toContain(`no schedule with slug 'no-such'`);
+        expect(replanCalls.count).toBe(0);
+    });
+
+    it('returns 1 with a clear error when triggerReplan rejects after a successful DB write', async () => {
+        const { deps, logs, errors } = recordingDeps({
+            disableSchedule: async (_db, slug) => buildSchedule({ slug }),
+            triggerReplan: async () => { throw new Error('POST /replan failed: 502 Bad Gateway'); },
+        });
+
+        const code = await disableScheduleCli(['bun', 'disable-schedule.ts', 'maintenance'], deps);
+
+        expect(code).toBe(1);
+        expect(logs.some(m => m.includes(`disabled 'maintenance'`))).toBe(true);
+        expect(errors[0]).toContain('re-plan request failed');
+        expect(errors[0]).toContain('already persisted');
+        expect(errors[0]).toContain('502 Bad Gateway');
     });
 });

--- a/api/scripts/disable-schedule.ts
+++ b/api/scripts/disable-schedule.ts
@@ -1,3 +1,4 @@
+import Config from '@/config';
 import { disableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/schedule-manager';
 
 /**
@@ -7,6 +8,12 @@ import { disableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon
 export type DisableScheduleCliDeps = {
     disableSchedule: (db: ScheduleManagerDb, slug: string) => Promise<Schedule | null>;
     loadDb: () => Promise<ScheduleManagerDb>;
+    /**
+     * Drives an immediate re-plan against the running api process so the
+     * disabled schedule's effect (sites with no active schedule are skipped
+     * at plan time) materialises within seconds rather than at 04:00.
+     */
+    triggerReplan: () => Promise<void>;
     log: (message: string) => void;
     error: (message: string) => void;
 };
@@ -35,7 +42,25 @@ export async function disableScheduleCli(argv: ReadonlyArray<string>, deps: Disa
     }
 
     deps.log(`disable-schedule: disabled '${result.slug}' (${result.name}) on site ${result.siteId}.`);
+
+    try {
+        await deps.triggerReplan();
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`disable-schedule: re-plan request failed — the DB change is already persisted. Re-run /replan to retry. Cause: ${message}`);
+        return 1;
+    }
+    deps.log('disable-schedule: re-plan triggered.');
     return 0;
+}
+
+async function postReplan(): Promise<void> {
+    const baseUrl = process.env.IRRIGO_BASE_URL ?? `http://127.0.0.1:${Config.port}`;
+    const response = await fetch(`${baseUrl}/replan`, { method: 'POST' });
+    if (!response.ok) {
+        const body = await response.text().catch(() => '<no body>');
+        throw new Error(`POST ${baseUrl}/replan failed: ${response.status} ${response.statusText} — ${body}`);
+    }
 }
 
 if (import.meta.main) {
@@ -45,6 +70,7 @@ if (import.meta.main) {
             const { db } = await import('@/db');
             return db as unknown as ScheduleManagerDb;
         },
+        triggerReplan: postReplan,
         log: (m) => console.log(m),
         error: (m) => console.error(m),
     };

--- a/api/scripts/enable-schedule.test.ts
+++ b/api/scripts/enable-schedule.test.ts
@@ -25,35 +25,43 @@ function recordingDeps(overrides: Partial<EnableScheduleCliDeps>): {
     deps: EnableScheduleCliDeps;
     logs: string[];
     errors: string[];
+    replanCalls: { count: number };
 } {
     const logs: string[] = [];
     const errors: string[] = [];
+    const replanCalls = { count: 0 };
     const deps: EnableScheduleCliDeps = {
         enableSchedule: async () => null,
         loadDb: async () => ({} as ScheduleManagerDb),
+        triggerReplan: async () => { replanCalls.count += 1; },
         log: m => logs.push(m),
         error: m => errors.push(m),
         ...overrides,
     };
-    return { deps, logs, errors };
+    return { deps, logs, errors, replanCalls };
 }
 
 describe('enableScheduleCli', () => {
-    it('returns 0 and logs the activated schedule on success', async () => {
-        const { deps, logs, errors } = recordingDeps({
-            enableSchedule: async (_db, slug) => buildSchedule({ slug, isActive: true }),
+    it('returns 0, logs the activated schedule, and triggers a re-plan on success', async () => {
+        const callOrder: string[] = [];
+        const { deps, logs, errors, replanCalls } = recordingDeps({
+            enableSchedule: async (_db, slug) => { callOrder.push('enable'); return buildSchedule({ slug, isActive: true }); },
+            triggerReplan: async () => { callOrder.push('replan'); replanCalls.count += 1; },
         });
 
         const code = await enableScheduleCli(['bun', 'enable-schedule.ts', 'maintenance'], deps);
 
         expect(code).toBe(0);
-        expect(logs[0]).toContain(`enabled 'maintenance'`);
+        expect(logs.some(m => m.includes(`enabled 'maintenance'`))).toBe(true);
+        expect(logs.some(m => m.includes('re-plan triggered'))).toBe(true);
         expect(errors).toEqual([]);
+        expect(replanCalls.count).toBe(1);
+        expect(callOrder).toEqual(['enable', 'replan']);
     });
 
     it('returns 1 with a usage error when the slug is missing from argv', async () => {
         let called = 0;
-        const { deps, errors } = recordingDeps({
+        const { deps, errors, replanCalls } = recordingDeps({
             enableSchedule: async () => { called += 1; return null; },
         });
 
@@ -62,10 +70,11 @@ describe('enableScheduleCli', () => {
         expect(code).toBe(1);
         expect(errors[0]).toContain('usage');
         expect(called).toBe(0);
+        expect(replanCalls.count).toBe(0);
     });
 
-    it('returns 1 with a clear error when the underlying call returns null', async () => {
-        const { deps, errors } = recordingDeps({
+    it('returns 1 with a clear error when the underlying call returns null, never triggers a re-plan', async () => {
+        const { deps, errors, replanCalls } = recordingDeps({
             enableSchedule: async () => null,
         });
 
@@ -73,5 +82,23 @@ describe('enableScheduleCli', () => {
 
         expect(code).toBe(1);
         expect(errors[0]).toContain(`no schedule with slug 'no-such'`);
+        expect(replanCalls.count).toBe(0);
+    });
+
+    it('returns 1 with a clear error when triggerReplan rejects after a successful DB write', async () => {
+        const { deps, logs, errors } = recordingDeps({
+            enableSchedule: async (_db, slug) => buildSchedule({ slug, isActive: true }),
+            triggerReplan: async () => { throw new Error('POST /replan failed: 502 Bad Gateway'); },
+        });
+
+        const code = await enableScheduleCli(['bun', 'enable-schedule.ts', 'maintenance'], deps);
+
+        expect(code).toBe(1);
+        // The DB write succeeded — the success log for enable still fires.
+        expect(logs.some(m => m.includes(`enabled 'maintenance'`))).toBe(true);
+        // Operator-friendly error explains the partial state.
+        expect(errors[0]).toContain('re-plan request failed');
+        expect(errors[0]).toContain('already persisted');
+        expect(errors[0]).toContain('502 Bad Gateway');
     });
 });

--- a/api/scripts/enable-schedule.ts
+++ b/api/scripts/enable-schedule.ts
@@ -1,3 +1,4 @@
+import Config from '@/config';
 import { enableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/schedule-manager';
 
 /**
@@ -7,6 +8,13 @@ import { enableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/
 export type EnableScheduleCliDeps = {
     enableSchedule: (db: ScheduleManagerDb, slug: string) => Promise<Schedule | null>;
     loadDb: () => Promise<ScheduleManagerDb>;
+    /**
+     * Drives an immediate re-plan against the running api process so the
+     * new schedule's effect on cycles materialises within seconds rather
+     * than at the next 04:00 tick. Production wiring POSTs `/replan`; the
+     * tests pass a recording stub.
+     */
+    triggerReplan: () => Promise<void>;
     log: (message: string) => void;
     error: (message: string) => void;
 };
@@ -35,7 +43,31 @@ export async function enableScheduleCli(argv: ReadonlyArray<string>, deps: Enabl
     }
 
     deps.log(`enable-schedule: enabled '${result.slug}' (${result.name}) on site ${result.siteId}.`);
+
+    try {
+        await deps.triggerReplan();
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`enable-schedule: re-plan request failed — the DB change is already persisted. Re-run /replan to retry. Cause: ${message}`);
+        return 1;
+    }
+    deps.log('enable-schedule: re-plan triggered.');
     return 0;
+}
+
+/**
+ * Production `triggerReplan` wiring. POSTs `/replan` against the api's
+ * own HTTP surface so the running daemon picks up the new schedule
+ * within seconds. Override via `IRRIGO_BASE_URL` for non-default host /
+ * port (e.g. when the CLI runs from a different host).
+ */
+async function postReplan(): Promise<void> {
+    const baseUrl = process.env.IRRIGO_BASE_URL ?? `http://127.0.0.1:${Config.port}`;
+    const response = await fetch(`${baseUrl}/replan`, { method: 'POST' });
+    if (!response.ok) {
+        const body = await response.text().catch(() => '<no body>');
+        throw new Error(`POST ${baseUrl}/replan failed: ${response.status} ${response.statusText} — ${body}`);
+    }
 }
 
 if (import.meta.main) {
@@ -45,6 +77,7 @@ if (import.meta.main) {
             const { db } = await import('@/db');
             return db as unknown as ScheduleManagerDb;
         },
+        triggerReplan: postReplan,
         log: (m) => console.log(m),
         error: (m) => console.error(m),
     };


### PR DESCRIPTION
## Ticket

[API-27](http://192.168.2.100:7123/irrigo/browse/API-27/) — Trigger an immediate re-plan when a schedule is enabled or disabled

## Summary

- `BuildAppOptions.replan` registers a new `POST /replan` endpoint that returns 200 with `{ status: 'replanned', lastRePlanAt }` on success and 502 with `{ error: 'replan-failed', message }` on rejection.
- New `wrapScheduleWithReplan(base, replan)` helper composes a `ScheduleApi` that awaits `replan()` after any non-null `enable` / `disable` result. The entrypoint uses it to wrap the DB-backed manager around `daemon.rePlan`, so `POST /schedule/{enable,disable}/:slug` now drives an immediate re-plan before responding.
- Schedule routes catch closure rejections and map them to 502 with `error: 'replan-failed'`, so a transient daemon failure surfaces cleanly to operators.
- CLI scripts (`bun --cwd api run enable-schedule` / `disable-schedule`) gain a `triggerReplan` dep — production wiring `POST`s `${IRRIGO_BASE_URL ?? \`http://127.0.0.1:\${Config.port}\`}/replan` after a successful DB write. Re-plan failure surfaces with a clear operator-facing error noting that the DB change is already persisted.
- The daily 04:00 re-plan stays as the depletion-math safety net; this PR just adds the on-demand path.

## Test plan

- [x] `bun --cwd api run type-check` — clean
- [x] `bun --cwd api test` — 413/413 passing
- 10 new tests in `api/.test.ts` covering `wrapScheduleWithReplan` (5), the `/replan` route (3), and 502 mapping on schedule routes (2)
- CLI tests asserting call order (`enable` → `replan`) and the failure-after-DB-write path on both `enable-schedule` and `disable-schedule`
- Manual smoke (optional, requires a running stack):
  - `curl -X POST http://localhost:9753/replan` → 200 with `lastRePlanAt` matching the daemon log
  - `curl -X POST http://localhost:9753/schedule/enable/overseeding` → 200; daemon stdout shows the re-plan ran before the curl returned
  - `bun --cwd api run enable-schedule overseeding` exits 0; `lastRePlanAt` advances

## Out of scope

- Replacing the daily 04:00 re-plan.
- Auth on `/replan` (LAN-only posture).
- Rate-limit on `/replan` (re-plan is fast + idempotent; back-to-back operator actions chain serially).
- Richer summary in the `/replan` response (zones touched, cycle counts, etc.) — `lastRePlanAt` is enough for v1.