### PR TITLE
[API-28] Seed Maintenance schedule with Calgary restrictions

### DIFF
--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -2,8 +2,9 @@ import path from 'node:path';
 import { describe, it, expect } from 'bun:test';
 import {
     parseGrassTypes,
-    parseSoilTypes,
+    parseSchedules,
     parseSites,
+    parseSoilTypes,
     parseZones,
 } from '.';
 
@@ -170,6 +171,91 @@ describe('sites.json fixture', () => {
         const home = rows.find(row => row.slug === 'home');
         expect(home).toBeDefined();
         expect(home?.timezone).toMatch(/\//);
+    });
+});
+
+describe('parseSchedules', () => {
+    it('parses a well-formed entry with all fields set', () => {
+        const rows = parseSchedules([
+            {
+                slug: 'maintenance',
+                siteSlug: 'home',
+                name: 'Maintenance',
+                isActive: true,
+                allowedDays: [3, 5, 7],
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            },
+        ]);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toEqual({
+            slug: 'maintenance',
+            siteSlug: 'home',
+            name: 'Maintenance',
+            isActive: true,
+            allowedDays: [3, 5, 7],
+            allowedTimeWindows: [
+                { start: '00:00', end: '10:00' },
+                { start: '19:00', end: '23:59' },
+            ],
+        });
+    });
+
+    it('accepts null values for allowedDays and allowedTimeWindows', () => {
+        const rows = parseSchedules([
+            {
+                slug: 'maintenance',
+                siteSlug: 'home',
+                name: 'Maintenance',
+                isActive: true,
+                allowedDays: null,
+                allowedTimeWindows: null,
+            },
+        ]);
+
+        expect(rows[0]?.allowedDays).toBeNull();
+        expect(rows[0]?.allowedTimeWindows).toBeNull();
+    });
+
+    it('rejects entries with an ISO weekday outside 1..7', () => {
+        const base = {
+            slug: 'maintenance',
+            siteSlug: 'home',
+            name: 'Maintenance',
+            isActive: true,
+            allowedTimeWindows: null,
+        };
+
+        expect(() => parseSchedules([{ ...base, allowedDays: [0] }])).toThrow();
+        expect(() => parseSchedules([{ ...base, allowedDays: [8] }])).toThrow();
+    });
+
+    it('rejects allowedTimeWindows whose start or end is not HH:mm', () => {
+        const base = {
+            slug: 'maintenance',
+            siteSlug: 'home',
+            name: 'Maintenance',
+            isActive: true,
+            allowedDays: null,
+        };
+
+        expect(() => parseSchedules([{ ...base, allowedTimeWindows: [{ start: '5pm', end: '11pm' }] }])).toThrow();
+        expect(() => parseSchedules([{ ...base, allowedTimeWindows: [{ start: '05:00' }] }])).toThrow();
+    });
+
+    it('rejects entries missing the required siteSlug field', () => {
+        expect(() => parseSchedules([
+            {
+                slug: 'maintenance',
+                name: 'Maintenance',
+                isActive: true,
+                allowedDays: null,
+                allowedTimeWindows: null,
+            },
+        ])).toThrow(/siteSlug/);
     });
 });
 

--- a/api/data/seeds/index.ts
+++ b/api/data/seeds/index.ts
@@ -29,6 +29,20 @@ export const SiteSeedSchema = z.object({
     address: z.string().optional(),
 });
 
+export const ScheduleTimeWindowSeedSchema = z.object({
+    start: z.string().regex(/^\d{2}:\d{2}$/, `start must be HH:mm`),
+    end: z.string().regex(/^\d{2}:\d{2}$/, `end must be HH:mm`),
+});
+
+export const ScheduleSeedSchema = z.object({
+    slug: z.string().min(1),
+    siteSlug: z.string().min(1),
+    name: z.string().min(1),
+    isActive: z.boolean(),
+    allowedDays: z.array(z.number().int().min(1).max(7)).nullable(),
+    allowedTimeWindows: z.array(ScheduleTimeWindowSeedSchema).nullable(),
+});
+
 export const ZoneSeedSchema = z.object({
     slug: z.string().min(1),
     name: z.string().min(1),
@@ -52,11 +66,14 @@ export type GrassTypeSeed = z.infer<typeof GrassTypeSeedSchema>;
 export type SoilTypeSeed = z.infer<typeof SoilTypeSeedSchema>;
 export type SiteSeed = z.infer<typeof SiteSeedSchema>;
 export type ZoneSeed = z.infer<typeof ZoneSeedSchema>;
+export type ScheduleSeed = z.infer<typeof ScheduleSeedSchema>;
+export type ScheduleTimeWindowSeed = z.infer<typeof ScheduleTimeWindowSeedSchema>;
 
 const GrassTypesArraySchema = z.array(GrassTypeSeedSchema);
 const SoilTypesArraySchema = z.array(SoilTypeSeedSchema);
 const SitesArraySchema = z.array(SiteSeedSchema);
 const ZonesArraySchema = z.array(ZoneSeedSchema);
+const SchedulesArraySchema = z.array(ScheduleSeedSchema);
 
 /**
  * Parses the contents of `grass-types.json` into typed seed rows.
@@ -102,4 +119,17 @@ export function parseSites(input: unknown): SiteSeed[] {
  */
 export function parseZones(input: unknown): ZoneSeed[] {
     return ZonesArraySchema.parse(input);
+}
+
+/**
+ * Parses the contents of `schedules.json` into typed seed rows. Site slug
+ * references (`siteSlug`) are validated as non-empty strings here; resolution
+ * against the actual site-id map happens in the seed orchestrator.
+ *
+ * @param input - Raw parsed JSON.
+ * @returns Validated schedule seed rows.
+ * @throws ZodError when the input doesn't match the schema.
+ */
+export function parseSchedules(input: unknown): ScheduleSeed[] {
+    return SchedulesArraySchema.parse(input);
 }

--- a/api/data/seeds/schedules.json
+++ b/api/data/seeds/schedules.json
@@ -1,0 +1,13 @@
+[
+    {
+        "slug": "maintenance",
+        "siteSlug": "home",
+        "name": "Maintenance",
+        "isActive": true,
+        "allowedDays": [3, 5, 7],
+        "allowedTimeWindows": [
+            { "start": "00:00", "end": "10:00" },
+            { "start": "19:00", "end": "23:59" }
+        ]
+    }
+]

--- a/api/scripts/.test.ts
+++ b/api/scripts/.test.ts
@@ -61,7 +61,7 @@ describe('seed orchestrator', () => {
         await rm(dataDir, { recursive: true, force: true });
     });
 
-    it('upserts each table in dependency order: grass types, soil types, sites, zones', async () => {
+    it('upserts each table in dependency order: grass types, soil types, sites, zones, schedules', async () => {
         await writeJson(dataDir, 'grass-types.json', [
             { slug: 'k-blue', name: 'Kentucky Bluegrass', cropCoefficient: 0.85 },
         ]);
@@ -84,6 +84,9 @@ describe('seed orchestrator', () => {
                 flowRateLPerMin: 15,
                 areaM2: 100,
             },
+        ]);
+        await writeJson(dataDir, 'schedules.json', [
+            { slug: 'maintenance', siteSlug: 'home', name: 'Maintenance', isActive: true, allowedDays: null, allowedTimeWindows: null },
         ]);
         const { db, calls } = createStubDb();
 
@@ -260,6 +263,11 @@ describe('seed orchestrator', () => {
             { slug: 'office', name: 'Office', timezone: 'America/Edmonton', latitude: 51.1, longitude: -114.1 },
         ]);
         await writeJson(dataDir, 'zones.json', []);
+        await writeJson(dataDir, 'schedules.json', [
+            { slug: 'maintenance', siteSlug: 'home', name: 'Maintenance', isActive: true, allowedDays: null, allowedTimeWindows: null },
+            { slug: 'maintenance', siteSlug: 'cabin', name: 'Maintenance', isActive: true, allowedDays: null, allowedTimeWindows: null },
+            { slug: 'maintenance', siteSlug: 'office', name: 'Maintenance', isActive: true, allowedDays: null, allowedTimeWindows: null },
+        ]);
         const { db } = createStubDb();
 
         const summary = await seed({ db, dataDir });
@@ -277,37 +285,56 @@ describe('seed orchestrator', () => {
         await expect(seed({ db, dataDir })).rejects.toThrow(/missing seed file .+zones\.json/);
     });
 
-    it('upserts a Maintenance/maintenance schedule for every seeded site with isActive=true', async () => {
+    it('upserts schedules from schedules.json with site references resolved to ids', async () => {
         await writeJson(dataDir, 'grass-types.json', []);
         await writeJson(dataDir, 'soil-types.json', []);
         await writeJson(dataDir, 'sites.json', [
             { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
-            { slug: 'cabin', name: 'Cabin', timezone: 'America/Edmonton', latitude: 52.0, longitude: -114.0 },
         ]);
         await writeJson(dataDir, 'zones.json', []);
+        await writeJson(dataDir, 'schedules.json', [
+            {
+                slug: 'maintenance',
+                siteSlug: 'home',
+                name: 'Maintenance',
+                isActive: true,
+                allowedDays: [3, 5, 7],
+                allowedTimeWindows: [
+                    { start: '00:00', end: '10:00' },
+                    { start: '19:00', end: '23:59' },
+                ],
+            },
+        ]);
         const { db, calls } = createStubDb();
 
         const summary = await seed({ db, dataDir });
 
-        expect(summary.schedules).toBe(2);
+        expect(summary.schedules).toBe(1);
         const scheduleCall = calls.find(c => c.table === schedules);
         expect(scheduleCall).toBeDefined();
-        expect(scheduleCall!.rows).toHaveLength(2);
-        for (const row of scheduleCall!.rows) {
-            expect(row['slug']).toBe('maintenance');
-            expect(row['name']).toBe('Maintenance');
-            expect(row['isActive']).toBe(true);
-            expect(typeof row['siteId']).toBe('string');
-        }
+        expect(scheduleCall!.rows).toHaveLength(1);
+        const row = scheduleCall!.rows[0]!;
+        expect(row['slug']).toBe('maintenance');
+        expect(row['name']).toBe('Maintenance');
+        expect(row['isActive']).toBe(true);
+        expect(row['siteId']).toBe('id-home');
+        expect(row['allowedDays']).toEqual([3, 5, 7]);
+        expect(row['allowedTimeWindows']).toEqual([
+            { start: '00:00', end: '10:00' },
+            { start: '19:00', end: '23:59' },
+        ]);
     });
 
-    it('omits isActive from the conflict-update set so re-seeding does not flip a deactivated schedule', async () => {
+    it('omits isActive, allowedDays, and allowedTimeWindows from the conflict-update set', async () => {
         await writeJson(dataDir, 'grass-types.json', []);
         await writeJson(dataDir, 'soil-types.json', []);
         await writeJson(dataDir, 'sites.json', [
             { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
         ]);
         await writeJson(dataDir, 'zones.json', []);
+        await writeJson(dataDir, 'schedules.json', [
+            { slug: 'maintenance', siteSlug: 'home', name: 'Maintenance', isActive: true, allowedDays: null, allowedTimeWindows: null },
+        ]);
         const { db, calls } = createStubDb();
 
         await seed({ db, dataDir });
@@ -316,13 +343,33 @@ describe('seed orchestrator', () => {
         expect(scheduleCall).toBeDefined();
         expect(Object.keys(scheduleCall!.conflictSet)).toEqual(['name']);
         expect('isActive' in scheduleCall!.conflictSet).toBe(false);
+        expect('allowedDays' in scheduleCall!.conflictSet).toBe(false);
+        expect('allowedTimeWindows' in scheduleCall!.conflictSet).toBe(false);
     });
 
-    it('skips schedules upsert when no sites are seeded', async () => {
+    it('throws when a schedule references an unknown siteSlug', async () => {
         await writeJson(dataDir, 'grass-types.json', []);
         await writeJson(dataDir, 'soil-types.json', []);
-        await writeJson(dataDir, 'sites.json', []);
+        await writeJson(dataDir, 'sites.json', [
+            { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
+        ]);
         await writeJson(dataDir, 'zones.json', []);
+        await writeJson(dataDir, 'schedules.json', [
+            { slug: 'maintenance', siteSlug: 'no-such-site', name: 'Maintenance', isActive: true, allowedDays: null, allowedTimeWindows: null },
+        ]);
+        const { db } = createStubDb();
+
+        await expect(seed({ db, dataDir })).rejects.toThrow(/unknown site "no-such-site"/);
+    });
+
+    it('treats a missing schedules.json as zero schedules to seed (no insert)', async () => {
+        await writeJson(dataDir, 'grass-types.json', []);
+        await writeJson(dataDir, 'soil-types.json', []);
+        await writeJson(dataDir, 'sites.json', [
+            { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
+        ]);
+        await writeJson(dataDir, 'zones.json', []);
+        // Intentionally omit schedules.json.
         const { db, calls } = createStubDb();
 
         const summary = await seed({ db, dataDir });

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -3,10 +3,12 @@ import { sql } from 'drizzle-orm';
 import { grassTypes, schedules, sites, soilTypes, zones } from '@/db/schema';
 import {
     parseGrassTypes,
+    parseSchedules,
     parseSites,
     parseSoilTypes,
     parseZones,
     type GrassTypeSeed,
+    type ScheduleSeed,
     type SiteSeed,
     type SoilTypeSeed,
     type ZoneSeed,
@@ -86,14 +88,15 @@ export async function seed(options?: SeedOptions): Promise<SeedSummary> {
     const soilRows = parseSoilTypes(await readJson(dataDir, 'soil-types.json'));
     const siteRows = parseSites(await readJson(dataDir, 'sites.json'));
     const zoneRows = parseZones(await readJson(dataDir, 'zones.json'));
+    const scheduleRows = parseSchedules(await readJsonOptional(dataDir, 'schedules.json') ?? []);
 
-    console.log(`seed: parsed ${grassRows.length} grass types, ${soilRows.length} soil types, ${siteRows.length} sites, ${zoneRows.length} zones.`);
+    console.log(`seed: parsed ${grassRows.length} grass types, ${soilRows.length} soil types, ${siteRows.length} sites, ${zoneRows.length} zones, ${scheduleRows.length} schedules.`);
 
     const grassMap = await upsertGrassTypes(db, grassRows);
     const soilMap = await upsertSoilTypes(db, soilRows);
     const siteMap = await upsertSites(db, siteRows);
     await upsertZones(db, zoneRows, { grassMap, soilMap, siteMap });
-    const scheduleCount = await upsertDefaultSchedules(db, siteMap);
+    const scheduleCount = await upsertSchedules(db, scheduleRows, siteMap);
 
     console.log('seed: complete.');
 
@@ -115,6 +118,19 @@ async function readJson(dir: string, file: string): Promise<unknown> {
     const filePath = path.join(dir, file);
     const handle = Bun.file(filePath);
     if (!(await handle.exists())) throw new Error(`seed: missing seed file ${filePath}.`);
+    return handle.json();
+}
+
+/**
+ * Like `readJson` but returns `null` when the file is missing, so older
+ * seed directories (or partial fixtures used in tests) can skip optional
+ * seed files cleanly. Used for `schedules.json` — the rest of the seeds
+ * are hard-required.
+ */
+async function readJsonOptional(dir: string, file: string): Promise<unknown> {
+    const filePath = path.join(dir, file);
+    const handle = Bun.file(filePath);
+    if (!(await handle.exists())) return null;
     return handle.json();
 }
 
@@ -222,18 +238,29 @@ async function upsertZones(db: SeedDb, rows: ZoneSeed[], lookups: ZoneLookups): 
         .returning({ id: zones.id, slug: zones.slug });
 }
 
-async function upsertDefaultSchedules(db: SeedDb, siteMap: Map<string, string>): Promise<number> {
-    if (siteMap.size === 0) return 0;
+async function upsertSchedules(
+    db: SeedDb,
+    rows: ScheduleSeed[],
+    siteMap: Map<string, string>,
+): Promise<number> {
+    if (rows.length === 0) return 0;
 
-    const valueRows = [...siteMap.values()].map(siteId => ({
-        siteId,
-        slug: 'maintenance',
-        name: 'Maintenance',
-        isActive: true,
-    }));
+    const valueRows = rows.map(row => {
+        const siteId = siteMap.get(row.siteSlug);
+        if (!siteId) throw new Error(`seed: schedule "${row.slug}" references unknown site "${row.siteSlug}".`);
+        return {
+            siteId,
+            slug: row.slug,
+            name: row.name,
+            isActive: row.isActive,
+            allowedDays: row.allowedDays,
+            allowedTimeWindows: row.allowedTimeWindows,
+        };
+    });
 
     // Conflict target: composite (siteId, slug). On conflict only refresh `name` —
-    // leave `isActive` alone so re-seeding doesn't clobber a runtime activation.
+    // leave `isActive`, `allowedDays`, and `allowedTimeWindows` alone so re-seeding
+    // doesn't clobber operator edits made via SQL or a future admin UI.
     await db
         .insert(schedules)
         .values(valueRows)


### PR DESCRIPTION
## Ticket

[API-28](http://192.168.2.100:7123/irrigo/browse/API-28/) — Seed the Maintenance schedule with Calgary outdoor-watering restrictions

## Summary

- Converts the schedule seed to JSON-driven for symmetry with the other seed files. New \`api/data/seeds/schedules.json\` declares the deployment's schedules; the seed reads, validates (Zod), and upserts them.
- Maintenance is seeded with Calgary's bylaw: \`allowedDays = [3, 5, 7]\` (Wed/Fri/Sun) and \`allowedTimeWindows = [{ 00:00, 10:00 }, { 19:00, 23:59 }]\`. A fresh \`bun --cwd api run seed\` now produces a usable schedule without any follow-up SQL.
- New \`ScheduleSeed\` / \`ScheduleTimeWindowSeed\` Zod schemas in \`api/data/seeds/index.ts\` reject obvious typos (ISO weekday out of 1..7, non-HH:mm strings, missing required fields).
- Conflict \`set\` clause continues to omit \`isActive\` and now also omits \`allowedDays\` / \`allowedTimeWindows\` — re-seeding never clobbers operator edits made via SQL or a future admin UI.
- Missing \`schedules.json\` is treated as zero schedules (a soft default), matching the optional-extras nature of the file. The other seed files remain hard-required.

## Test plan

- [x] \`bun --cwd api run type-check\` — clean
- [x] \`bun --cwd api test\` — 419/419 passing
- 5 new parser tests in \`api/data/seeds/.test.ts\` covering valid input, nullable fields, ISO weekday out of range, HH:mm regex, missing fields
- 4 new seed-orchestrator tests: site-id resolution + override fields, conflict-set exclusions, unknown-siteSlug error, missing-file soft default
- Manual smoke: \`bun --cwd api run db:migrate && bun --cwd api run seed\` against an empty DB; \`SELECT slug, is_active, allowed_days, allowed_time_windows FROM schedules;\` returns the Maintenance row with \`[3,5,7]\` and the two Calgary windows. Re-seeding after a runtime SQL toggle does not flip \`is_active\` or rewrite the windows.

## Out of scope

- Overseeding row (lands with API-29, which depends on this PR's JSON-driven plumbing).
- Seeding override columns (\`rootDepthMOverride\` / \`allowableDepletionFractionOverride\`) — also API-29.
- Validating that \`allowedTimeWindows\` don't wrap past midnight at the data layer. The seed Zod catches malformed HH:mm; semantic validation lives in the planner from API-25.