### PR TITLE
[API-29] Seed Overseeding schedule with shallow-root overrides

### DIFF
--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -201,6 +201,8 @@ describe('parseSchedules', () => {
                 { start: '00:00', end: '10:00' },
                 { start: '19:00', end: '23:59' },
             ],
+            rootDepthMOverride: null,
+            allowableDepletionFractionOverride: null,
         });
     });
 
@@ -256,6 +258,54 @@ describe('parseSchedules', () => {
                 allowedTimeWindows: null,
             },
         ])).toThrow(/siteSlug/);
+    });
+
+    it('carries the override fields through when set as numbers', () => {
+        const rows = parseSchedules([
+            {
+                slug: 'overseeding',
+                siteSlug: 'home',
+                name: 'Overseeding',
+                isActive: false,
+                allowedDays: null,
+                allowedTimeWindows: null,
+                rootDepthMOverride: 0.05,
+                allowableDepletionFractionOverride: 0.25,
+            },
+        ]);
+
+        expect(rows[0]?.rootDepthMOverride).toBe(0.05);
+        expect(rows[0]?.allowableDepletionFractionOverride).toBe(0.25);
+    });
+
+    it('defaults missing override fields to null so older JSON still parses', () => {
+        const rows = parseSchedules([
+            {
+                slug: 'maintenance',
+                siteSlug: 'home',
+                name: 'Maintenance',
+                isActive: true,
+                allowedDays: null,
+                allowedTimeWindows: null,
+            },
+        ]);
+
+        expect(rows[0]?.rootDepthMOverride).toBeNull();
+        expect(rows[0]?.allowableDepletionFractionOverride).toBeNull();
+    });
+
+    it('rejects non-numeric override values', () => {
+        expect(() => parseSchedules([
+            {
+                slug: 'overseeding',
+                siteSlug: 'home',
+                name: 'Overseeding',
+                isActive: false,
+                allowedDays: null,
+                allowedTimeWindows: null,
+                rootDepthMOverride: 'shallow',
+            },
+        ])).toThrow(/rootDepthMOverride/);
     });
 });
 

--- a/api/data/seeds/index.ts
+++ b/api/data/seeds/index.ts
@@ -41,6 +41,8 @@ export const ScheduleSeedSchema = z.object({
     isActive: z.boolean(),
     allowedDays: z.array(z.number().int().min(1).max(7)).nullable(),
     allowedTimeWindows: z.array(ScheduleTimeWindowSeedSchema).nullable(),
+    rootDepthMOverride: z.number().nullable().default(null),
+    allowableDepletionFractionOverride: z.number().nullable().default(null),
 });
 
 export const ZoneSeedSchema = z.object({

--- a/api/data/seeds/schedules.json
+++ b/api/data/seeds/schedules.json
@@ -9,5 +9,19 @@
             { "start": "00:00", "end": "10:00" },
             { "start": "19:00", "end": "23:59" }
         ]
+    },
+    {
+        "slug": "overseeding",
+        "siteSlug": "home",
+        "name": "Overseeding",
+        "isActive": false,
+        "allowedDays": null,
+        "allowedTimeWindows": [
+            { "start": "06:00", "end": "09:00" },
+            { "start": "11:00", "end": "13:00" },
+            { "start": "17:00", "end": "19:00" }
+        ],
+        "rootDepthMOverride": 0.05,
+        "allowableDepletionFractionOverride": 0.25
     }
 ]

--- a/api/scripts/.test.ts
+++ b/api/scripts/.test.ts
@@ -323,6 +323,39 @@ describe('seed orchestrator', () => {
             { start: '00:00', end: '10:00' },
             { start: '19:00', end: '23:59' },
         ]);
+        // Missing override fields default to null and still appear in the
+        // payload so the DB row has explicit values rather than UNDEFINED.
+        expect(row['rootDepthMOverride']).toBeNull();
+        expect(row['allowableDepletionFractionOverride']).toBeNull();
+    });
+
+    it('forwards rootDepthMOverride and allowableDepletionFractionOverride into the upsert payload', async () => {
+        await writeJson(dataDir, 'grass-types.json', []);
+        await writeJson(dataDir, 'soil-types.json', []);
+        await writeJson(dataDir, 'sites.json', [
+            { slug: 'home', name: 'Home', timezone: 'America/Edmonton', latitude: 51.05, longitude: -114.07 },
+        ]);
+        await writeJson(dataDir, 'zones.json', []);
+        await writeJson(dataDir, 'schedules.json', [
+            {
+                slug: 'overseeding',
+                siteSlug: 'home',
+                name: 'Overseeding',
+                isActive: false,
+                allowedDays: null,
+                allowedTimeWindows: null,
+                rootDepthMOverride: 0.05,
+                allowableDepletionFractionOverride: 0.25,
+            },
+        ]);
+        const { db, calls } = createStubDb();
+
+        await seed({ db, dataDir });
+
+        const scheduleCall = calls.find(c => c.table === schedules);
+        const row = scheduleCall!.rows[0]!;
+        expect(row['rootDepthMOverride']).toBe(0.05);
+        expect(row['allowableDepletionFractionOverride']).toBe(0.25);
     });
 
     it('omits isActive, allowedDays, and allowedTimeWindows from the conflict-update set', async () => {
@@ -399,5 +432,27 @@ describe('seed orchestrator against real api/data/seeds fixtures', () => {
             expect(row['grassTypeId']).toMatch(/^id-/);
             expect(row['soilTypeId']).toMatch(/^id-/);
         }
+    });
+
+    it('seeds both Maintenance (active) and Overseeding (inactive) with their respective fields', async () => {
+        const { db, calls } = createStubDb();
+
+        const summary = await seed({ db, dataDir: realDataDir });
+
+        expect(summary.schedules).toBe(2);
+        const scheduleCall = calls.find(c => c.table === schedules);
+        expect(scheduleCall).toBeDefined();
+
+        const maintenance = scheduleCall!.rows.find(r => r['slug'] === 'maintenance');
+        expect(maintenance).toBeDefined();
+        expect(maintenance!['isActive']).toBe(true);
+        expect(maintenance!['rootDepthMOverride']).toBeNull();
+        expect(maintenance!['allowableDepletionFractionOverride']).toBeNull();
+
+        const overseeding = scheduleCall!.rows.find(r => r['slug'] === 'overseeding');
+        expect(overseeding).toBeDefined();
+        expect(overseeding!['isActive']).toBe(false);
+        expect(overseeding!['rootDepthMOverride']).toBe(0.05);
+        expect(overseeding!['allowableDepletionFractionOverride']).toBe(0.25);
     });
 });

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -255,6 +255,8 @@ async function upsertSchedules(
             isActive: row.isActive,
             allowedDays: row.allowedDays,
             allowedTimeWindows: row.allowedTimeWindows,
+            rootDepthMOverride: row.rootDepthMOverride,
+            allowableDepletionFractionOverride: row.allowableDepletionFractionOverride,
         };
     });
 


### PR DESCRIPTION
## Ticket

[API-29](http://192.168.2.100:7123/irrigo/browse/API-29/) — Seed an Overseeding schedule with shallow-root, frequent-water overrides

## Summary

- Appends an \`Overseeding\` row to \`api/data/seeds/schedules.json\` with \`isActive: false\` (operator activates explicitly), \`allowedDays: null\` (daily watering permitted during seed establishment), three short windows at \`06:00–09:00\`, \`11:00–13:00\`, \`17:00–19:00\` (biased away from peak heat), and overrides \`rootDepthMOverride: 0.05\` + \`allowableDepletionFractionOverride: 0.25\` (RAW drops to ~2 mm so the planner refills daily with short cycles).
- Extends \`ScheduleSeedSchema\` with the two override fields as \`.nullable().default(null)\` so older JSON without these fields still parses cleanly — both Maintenance (no overrides) and Overseeding (overrides set) parse with the same schema.
- \`upsertSchedules\` payload now carries the two override columns; the conflict \`set\` clause is unchanged (still only \`name\`), so re-seeding never clobbers an operator's runtime edits to overrides.

After this merges, \`bun --cwd api run enable-schedule overseeding\` is the entire user-facing action to flip into seed-establishment mode — zero SQL, zero zone edits. \`enable-schedule maintenance\` flips back.

## Test plan

- [x] \`bun --cwd api run type-check\` — clean
- [x] \`bun --cwd api test\` — 424/424 passing
- 3 new \`parseSchedules\` tests covering: overrides carried through, missing overrides default to null, non-numeric overrides rejected
- 1 new seed-orchestrator test asserting overrides reach the upsert payload
- 1 new real-fixtures test asserting both Maintenance and Overseeding rows are seeded with their respective configurations
- Manual smoke: \`bun --cwd api run db:migrate && bun --cwd api run seed\`; \`SELECT slug, is_active, root_depth_m_override, allowable_depletion_fraction_override FROM schedules ORDER BY slug;\` returns Maintenance active with both null and Overseeding inactive with \`0.05\` / \`0.25\`.

## Out of scope

- Adding Overseeding to API-30's \`endBySunrise: true\` — Overseeding intentionally waters mid-day, so the flag stays \`null\`/\`false\` on this row.
- Multi-pass-per-window planning (firing morning AND mid-day AND evening on the same day). v1 still places one cycle per allowed window per day — operators augment with manual fires.
- A "watering profile" abstraction (more named templates beyond Maintenance / Overseeding). A third mode just lands as another row in \`schedules.json\`.