### PR TITLE
[API-31] Add next-runs CLI script to preview upcoming irrigation cycles

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -11,6 +11,7 @@
     "seed": "bun scripts/seed.ts",
     "enable-schedule": "bun scripts/enable-schedule.ts",
     "disable-schedule": "bun scripts/disable-schedule.ts",
+    "next-runs": "bun scripts/next-runs.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/api/scripts/next-runs.test.ts
+++ b/api/scripts/next-runs.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'bun:test';
+import { nextRunsCli, type NextRun, type NextRunsCliDeps } from './next-runs';
+
+function makeRun(overrides?: Partial<NextRun>): NextRun {
+    return {
+        zoneName: 'Front Lawn',
+        zoneSlug: 'front-lawn',
+        startTime: new Date('2026-05-13T05:30:00.000Z'),
+        endTime: new Date('2026-05-13T05:45:00.000Z'),
+        siteTimezone: 'UTC',
+        ...overrides,
+    };
+}
+
+function recordingDeps(overrides: Partial<NextRunsCliDeps>): {
+    deps: NextRunsCliDeps;
+    logs: string[];
+    errors: string[];
+} {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const deps: NextRunsCliDeps = {
+        loadRuns: async () => [],
+        log: m => logs.push(m),
+        error: m => errors.push(m),
+        ...overrides,
+    };
+    return { deps, logs, errors };
+}
+
+describe('nextRunsCli', () => {
+    it('returns 0 and logs header + formatted rows when runs are available', async () => {
+        const run1 = makeRun({
+            zoneName: 'Front Lawn',
+            startTime: new Date('2026-05-13T05:30:00.000Z'),
+            endTime: new Date('2026-05-13T05:45:00.000Z'),
+        });
+        const run2 = makeRun({
+            zoneName: 'Back Garden',
+            zoneSlug: 'back-garden',
+            startTime: new Date('2026-05-13T06:00:00.000Z'),
+            endTime: new Date('2026-05-13T06:20:00.000Z'),
+        });
+        const { deps, logs, errors } = recordingDeps({
+            loadRuns: async () => [run1, run2],
+        });
+
+        const code = await nextRunsCli(deps);
+
+        expect(code).toBe(0);
+        expect(errors).toEqual([]);
+
+        const header = logs[0]!;
+        expect(header).toContain('Zone');
+        expect(header).toContain('Start');
+        expect(header).toContain('End');
+
+        const row1 = logs[1]!;
+        expect(row1).toContain('Front Lawn');
+        expect(row1).toContain('2026-05-13T05:30:00+00:00');
+        expect(row1).toContain('2026-05-13T05:45:00+00:00');
+
+        const row2 = logs[2]!;
+        expect(row2).toContain('Back Garden');
+        expect(row2).toContain('2026-05-13T06:00:00+00:00');
+        expect(row2).toContain('2026-05-13T06:20:00+00:00');
+
+        expect(logs).toHaveLength(3);
+    });
+
+    it('returns 0 and logs all 5 when exactly 5 runs are available', async () => {
+        const runs = Array.from({ length: 5 }, (_, i) =>
+            makeRun({
+                zoneName: `Zone ${i + 1}`,
+                zoneSlug: `zone-${i + 1}`,
+                startTime: new Date(Date.UTC(2026, 4, 13, i + 5)),
+                endTime: new Date(Date.UTC(2026, 4, 13, i + 5, 15)),
+            }),
+        );
+        const { deps, logs, errors } = recordingDeps({
+            loadRuns: async () => runs,
+        });
+
+        const code = await nextRunsCli(deps);
+
+        expect(code).toBe(0);
+        expect(errors).toEqual([]);
+        expect(logs).toHaveLength(6); // header + 5 rows
+    });
+
+    it('returns 0 and prints a no-runs message when zero cycles are returned', async () => {
+        const { deps, logs, errors } = recordingDeps({
+            loadRuns: async () => [],
+        });
+
+        const code = await nextRunsCli(deps);
+
+        expect(code).toBe(0);
+        expect(errors).toEqual([]);
+        expect(logs).toHaveLength(1);
+        expect(logs[0]).toContain('no upcoming scheduled irrigation cycles');
+    });
+
+    it('returns 1 and logs an error message when loadRuns rejects', async () => {
+        const { deps, logs, errors } = recordingDeps({
+            loadRuns: async () => { throw new Error('connection refused'); },
+        });
+
+        const code = await nextRunsCli(deps);
+
+        expect(code).toBe(1);
+        expect(logs).toEqual([]);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('failed to load upcoming cycles');
+        expect(errors[0]).toContain('connection refused');
+    });
+
+    it('passes now and limit=5 to loadRuns', async () => {
+        const calls: Array<{ now: Date; limit: number }> = [];
+        const { deps } = recordingDeps({
+            loadRuns: async (now, limit) => {
+                calls.push({ now, limit });
+                return [];
+            },
+        });
+
+        await nextRunsCli(deps);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]!.now).toBeInstanceOf(Date);
+        expect(calls[0]!.limit).toBe(5);
+    });
+});

--- a/api/scripts/next-runs.ts
+++ b/api/scripts/next-runs.ts
@@ -1,0 +1,111 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import { and, eq, gte, isNull } from 'drizzle-orm';
+import { irrigationCycles, scheduleEntries, sites, zones } from '@/db/schema';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const NEXT_RUNS_LIMIT = 5;
+const ZONE_COL_WIDTH = 30;
+const TIME_COL_WIDTH = 25; // 'YYYY-MM-DDTHH:mm:ss±HH:mm' is always 25 chars
+
+export type NextRun = {
+    zoneName: string;
+    zoneSlug: string;
+    startTime: Date;
+    endTime: Date;
+    siteTimezone: string;
+};
+
+export type NextRunsCliDeps = {
+    loadRuns: (now: Date, limit: number) => Promise<NextRun[]>;
+    log: (message: string) => void;
+    error: (message: string) => void;
+};
+
+export async function nextRunsCli(deps: NextRunsCliDeps): Promise<0 | 1> {
+    let runs: NextRun[];
+    try {
+        runs = await deps.loadRuns(new Date(), NEXT_RUNS_LIMIT);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`next-runs: failed to load upcoming cycles — ${message}`);
+        return 1;
+    }
+
+    if (runs.length === 0) {
+        deps.log('next-runs: no upcoming scheduled irrigation cycles.');
+        return 0;
+    }
+
+    deps.log(formatHeader());
+    for (const run of runs) {
+        deps.log(formatRun(run));
+    }
+    return 0;
+}
+
+function formatHeader(): string {
+    return (
+        'Zone'.padEnd(ZONE_COL_WIDTH) + '  ' +
+        'Start'.padEnd(TIME_COL_WIDTH) + '  ' +
+        'End'
+    );
+}
+
+function formatRun(run: NextRun): string {
+    const startFmt = dayjs(run.startTime).tz(run.siteTimezone).format('YYYY-MM-DDTHH:mm:ssZ');
+    const endFmt = dayjs(run.endTime).tz(run.siteTimezone).format('YYYY-MM-DDTHH:mm:ssZ');
+    return (
+        run.zoneName.padEnd(ZONE_COL_WIDTH) + '  ' +
+        startFmt.padEnd(TIME_COL_WIDTH) + '  ' +
+        endFmt
+    );
+}
+
+if (import.meta.main) {
+    const deps: NextRunsCliDeps = {
+        loadRuns: async (now, limit) => {
+            const { db } = await import('@/db');
+
+            const rows = await db
+                .select({
+                    startTime: irrigationCycles.startTime,
+                    durationMin: irrigationCycles.durationMin,
+                    zoneName: zones.name,
+                    zoneSlug: zones.slug,
+                    siteTimezone: sites.timezone,
+                })
+                .from(irrigationCycles)
+                .innerJoin(scheduleEntries, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+                .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+                .innerJoin(sites, eq(zones.siteId, sites.id))
+                .where(
+                    and(
+                        isNull(irrigationCycles.firedAt),
+                        gte(irrigationCycles.startTime, now),
+                        eq(zones.isEnabled, true),
+                    ),
+                );
+
+            return rows
+                .sort((a, b) => {
+                    const diff = a.startTime.getTime() - b.startTime.getTime();
+                    return diff !== 0 ? diff : a.zoneSlug.localeCompare(b.zoneSlug);
+                })
+                .slice(0, limit)
+                .map(row => ({
+                    zoneName: row.zoneName,
+                    zoneSlug: row.zoneSlug,
+                    startTime: row.startTime,
+                    endTime: new Date(row.startTime.getTime() + row.durationMin * 60_000),
+                    siteTimezone: row.siteTimezone,
+                }));
+        },
+        log: m => console.log(m),
+        error: m => console.error(m),
+    };
+    nextRunsCli(deps).then(code => process.exit(code));
+}


### PR DESCRIPTION
## Ticket

[API-31](http://192.168.2.100:7123/irrigo/browse/API-31/) Add CLI script to preview the next 5 scheduled sprinkler runs

## Summary

- Adds `bun --cwd api run next-runs` script that prints the next 5 upcoming irrigation cycles (zone name, start time, end time) in a human-readable table
- Reads directly from `irrigation_cycles` joined with `zones` and `sites` — no daemon required, no replanning
- Times are rendered in the site's local timezone as ISO-8601 with UTC offset (e.g. `2026-05-13T05:30:00-06:00`)
- Sorted ascending by start time, tie-broken by zone slug for determinism
- Prints a clear message when no upcoming cycles exist
- Follows the same wiring pattern as the `enable-schedule` / `disable-schedule` scripts (exported CLI body + injected deps for testability)