### PR TITLE
[API-32] Add notify:test script to preview zone irrigation notifications

### DIFF
--- a/api/notifications/.test.ts
+++ b/api/notifications/.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { createNotifier, noopNotifier } from '.';
+import { createNotifier, noopNotifier, buildMessage } from '.';
 
 const mockFetch = mock(() => Promise.resolve({} as Response));
 (global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
@@ -192,5 +192,49 @@ describe('createNotifier', () => {
         await notifier('watering-ended', { zoneName: 'A' });
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('buildMessage', () => {
+    it('includes zone name and duration for watering-started', () => {
+        const msg = buildMessage('watering-started', { zoneName: 'Front Lawn', durationMin: 20 });
+        expect(msg).toContain('Front Lawn');
+        expect(msg).toContain('20');
+        expect(msg).toContain('watering started');
+    });
+
+    it('omits duration for watering-started when not provided', () => {
+        const msg = buildMessage('watering-started', { zoneName: 'Front Lawn' });
+        expect(msg).toContain('Front Lawn');
+        expect(msg).not.toContain('min');
+    });
+
+    it('appends boot-recovery qualifier for watering-started with reason=boot', () => {
+        const msg = buildMessage('watering-started', { zoneName: 'Front Lawn', durationMin: 10, reason: 'boot' });
+        expect(msg).toContain('daemon restart');
+    });
+
+    it('returns a simple ended message for watering-ended', () => {
+        const msg = buildMessage('watering-ended', { zoneName: 'Back Garden' });
+        expect(msg).toContain('Back Garden');
+        expect(msg).toContain('watering ended');
+        expect(msg).not.toContain('shutdown');
+    });
+
+    it('appends shutdown qualifier for watering-ended with reason=shutdown', () => {
+        const msg = buildMessage('watering-ended', { zoneName: 'Back Garden', reason: 'shutdown' });
+        expect(msg).toContain('shutdown');
+    });
+
+    it('includes operation and reason for error events', () => {
+        const msg = buildMessage('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
+        expect(msg).toContain('Front Lawn');
+        expect(msg).toContain('open');
+        expect(msg).toContain('HA 502');
+    });
+
+    it('falls back to Zone when zoneName is omitted', () => {
+        const msg = buildMessage('watering-started', {});
+        expect(msg).toContain('Zone');
     });
 });

--- a/api/notifications/index.ts
+++ b/api/notifications/index.ts
@@ -94,7 +94,7 @@ export function createNotifier(): Notifier {
     };
 }
 
-function buildMessage(event: NotificationEvent, context?: NotificationContext): string {
+export function buildMessage(event: NotificationEvent, context?: NotificationContext): string {
     const zone = context?.zoneName ?? 'Zone';
     if (event === 'watering-started') {
         const dur = context?.durationMin !== undefined ? ` (~${context.durationMin} min)` : '';

--- a/api/package.json
+++ b/api/package.json
@@ -12,6 +12,7 @@
     "enable-schedule": "bun scripts/enable-schedule.ts",
     "disable-schedule": "bun scripts/disable-schedule.ts",
     "next-runs": "bun scripts/next-runs.ts",
+    "notify:test": "bun scripts/notify-test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/api/scripts/notify-test.test.ts
+++ b/api/scripts/notify-test.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'bun:test';
+import { notifyTestCli, type NotifyTestDeps, type NotifyTestSendResult } from './notify-test';
+import { buildMessage } from '@/notifications';
+
+const ok: NotifyTestSendResult = { ok: true, status: 200, statusText: 'OK' };
+const fail: NotifyTestSendResult = { ok: false, status: 502, statusText: 'Bad Gateway' };
+
+function recordingDeps(overrides: Partial<NotifyTestDeps>): {
+    deps: NotifyTestDeps;
+    sends: string[];
+    logs: string[];
+    errors: string[];
+} {
+    const sends: string[] = [];
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const deps: NotifyTestDeps = {
+        send: async (msg) => { sends.push(msg); return ok; },
+        log: m => logs.push(m),
+        error: m => errors.push(m),
+        ...overrides,
+    };
+    return { deps, sends, logs, errors };
+}
+
+describe('notifyTestCli', () => {
+    it('sends watering-started then watering-ended in order', async () => {
+        const { deps, sends } = recordingDeps({});
+
+        await notifyTestCli(deps);
+
+        expect(sends).toHaveLength(2);
+        expect(sends[0]).toBe(buildMessage('watering-started', { zoneName: 'Front Lawn', durationMin: 15 }));
+        expect(sends[1]).toBe(buildMessage('watering-ended', { zoneName: 'Front Lawn' }));
+    });
+
+    it('returns 0 when both sends succeed', async () => {
+        const { deps } = recordingDeps({});
+
+        const code = await notifyTestCli(deps);
+
+        expect(code).toBe(0);
+    });
+
+    it('logs each message before sending', async () => {
+        const { deps, logs } = recordingDeps({});
+
+        await notifyTestCli(deps);
+
+        expect(logs).toHaveLength(2);
+        expect(logs[0]).toContain('watering-started');
+        expect(logs[1]).toContain('watering-ended');
+    });
+
+    it('returns 1 and logs an error when the first send fails', async () => {
+        let callCount = 0;
+        const { deps, errors } = recordingDeps({
+            send: async () => callCount++ === 0 ? fail : ok,
+        });
+
+        const code = await notifyTestCli(deps);
+
+        expect(code).toBe(1);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('watering-started');
+        expect(errors[0]).toContain('502');
+    });
+
+    it('returns 1 and logs an error when the second send fails', async () => {
+        let callCount = 0;
+        const { deps, errors } = recordingDeps({
+            send: async () => callCount++ === 0 ? ok : fail,
+        });
+
+        const code = await notifyTestCli(deps);
+
+        expect(code).toBe(1);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('watering-ended');
+        expect(errors[0]).toContain('502');
+    });
+
+    it('sends both notifications even when the first fails', async () => {
+        let callCount = 0;
+        const { deps, sends } = recordingDeps({
+            send: async (msg) => { sends.push(msg); return callCount++ === 0 ? fail : ok; },
+        });
+
+        await notifyTestCli(deps);
+
+        expect(sends).toHaveLength(2);
+    });
+});

--- a/api/scripts/notify-test.ts
+++ b/api/scripts/notify-test.ts
@@ -1,0 +1,65 @@
+import { buildMessage } from '@/notifications';
+
+const TEST_ZONE = 'Front Lawn';
+const TEST_DURATION_MIN = 15;
+
+export type NotifyTestSendResult = { ok: boolean; status: number; statusText: string };
+
+export type NotifyTestDeps = {
+    send: (message: string) => Promise<NotifyTestSendResult>;
+    log: (message: string) => void;
+    error: (message: string) => void;
+};
+
+export async function notifyTestCli(deps: NotifyTestDeps): Promise<0 | 1> {
+    let exitCode: 0 | 1 = 0;
+
+    const startedMsg = buildMessage('watering-started', { zoneName: TEST_ZONE, durationMin: TEST_DURATION_MIN });
+    deps.log(`notify-test: sending watering-started → "${startedMsg}"`);
+    const startedResult = await deps.send(startedMsg);
+    if (!startedResult.ok) {
+        deps.error(`notify-test: watering-started returned ${startedResult.status} ${startedResult.statusText}`);
+        exitCode = 1;
+    }
+
+    const endedMsg = buildMessage('watering-ended', { zoneName: TEST_ZONE });
+    deps.log(`notify-test: sending watering-ended → "${endedMsg}"`);
+    const endedResult = await deps.send(endedMsg);
+    if (!endedResult.ok) {
+        deps.error(`notify-test: watering-ended returned ${endedResult.status} ${endedResult.statusText}`);
+        exitCode = 1;
+    }
+
+    return exitCode;
+}
+
+if (import.meta.main) {
+    const url = process.env.HA_URL;
+    const token = process.env.HA_TOKEN;
+    const service = process.env.HA_NOTIFY_SERVICE;
+
+    if (!url || !token || !service) {
+        console.error('notify-test: HA_URL, HA_TOKEN, and HA_NOTIFY_SERVICE must all be set in the environment.');
+        process.exit(1);
+    }
+
+    const endpoint = `${url.endsWith('/') ? url.slice(0, -1) : url}/api/services/notify/${service}`;
+
+    const deps: NotifyTestDeps = {
+        send: async (message) => {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ message, title: 'Irrigo' }),
+            });
+            return { ok: response.ok, status: response.status, statusText: response.statusText };
+        },
+        log: m => console.log(m),
+        error: m => console.error(m),
+    };
+
+    notifyTestCli(deps).then(code => process.exit(code));
+}


### PR DESCRIPTION
## Ticket

[API-32](http://192.168.2.100:7123/irrigo/browse/API-32/) Add notify:test script to preview zone irrigation notifications

## Summary

- Exports `buildMessage` from `api/notifications/index.ts` so it can be reused by the script
- Adds `api/scripts/notify-test.ts` — a `bun run notify:test` script that sends a `watering-started` and `watering-ended` notification through the real HA notify path with a fictional zone ("Front Lawn", 15 min), bypassing the `NOTIFY_ON_WATERING_START`/`NOTIFY_ON_WATERING_END` opt-in flags
- Script logs each message string before sending so copy can be verified without waiting for HA; exits with a clear error if `HA_URL`, `HA_TOKEN`, or `HA_NOTIFY_SERVICE` are missing