### PR TITLE
[API-34] Add toggle-zone CLI script

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -83,6 +83,7 @@ function buildJoinedRow(overrides?: Partial<{
             latitude: 51.0447,
             longitude: -114.0719,
             homeAssistantEntityId: 'switch.zone_1',
+            microclimateFactor: 1,
             createdAt: NOW,
             updatedAt: NOW,
             ...overrides?.zone,
@@ -262,6 +263,14 @@ describe('mapJoinedRowsToZones', () => {
         const result = mapJoinedRowsToZones([row]);
 
         expect(result[0]?.siteTimezone).toBe('Europe/London');
+    });
+
+    it('maps microclimateFactor from the zone row', () => {
+        const row = buildJoinedRow({ zone: { microclimateFactor: 1.1 } });
+
+        const result = mapJoinedRowsToZones([row]);
+
+        expect(result[0]?.microclimateFactor).toBe(1.1);
     });
 });
 
@@ -1589,6 +1598,7 @@ describe('start', () => {
                 if (z.id === 'zone-bad') throw new Error('plan failed');
                 return { entries: [planned], projectedNextDepletionMm: 0 };
             },
+            getZoneState: async () => 'off',
             openZone: async () => {},
             closeZone: async () => {},
         });
@@ -1891,6 +1901,7 @@ describe('start', () => {
                         ? { entries: [zoneAEntry], projectedNextDepletionMm: 0 }
                         : { entries: [zoneBEntry], projectedNextDepletionMm: 0 };
                 },
+                getZoneState: async () => 'off',
                 openZone: async () => {},
                 closeZone: async () => {},
             });
@@ -1927,6 +1938,7 @@ describe('start', () => {
                     if (zone.id === 'zone-B') return { entries: [entryFor(zone.id, '2026-05-04T05:30:00Z', 20)], projectedNextDepletionMm: 0 };
                     return { entries: [entryFor(zone.id, '2026-05-04T06:00:00Z', 20)], projectedNextDepletionMm: 0 };
                 },
+                getZoneState: async () => 'off',
                 openZone: async () => {},
                 closeZone: async () => {},
             });
@@ -1966,6 +1978,7 @@ describe('start', () => {
                         projectedNextDepletionMm: 0,
                     };
                 },
+                getZoneState: async () => 'off',
                 openZone: async () => {},
                 closeZone: async () => {},
             });

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -173,5 +173,6 @@ export function joinedRowToZone(row: ZoneJoinedRow): Zone {
         isEnabled: row.zone.isEnabled,
         location: { lat, lon },
         homeAssistantEntityId: row.zone.homeAssistantEntityId ?? undefined,
+        microclimateFactor: row.zone.microclimateFactor,
     };
 }

--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -331,6 +331,6 @@ describe('zones.json fixture', () => {
         }
 
         const zoneSlugs = zoneRows.map(row => row.slug);
-        expect(zoneSlugs).toEqual(['front-lawn', 'back-lawn', 'side-yard']);
+        expect(zoneSlugs).toEqual(['north', 'south', 'east']);
     });
 });

--- a/api/data/seeds/index.ts
+++ b/api/data/seeds/index.ts
@@ -62,6 +62,7 @@ export const ZoneSeedSchema = z.object({
     latitude: z.number().optional(),
     longitude: z.number().optional(),
     homeAssistantEntityId: z.string().optional(),
+    microclimateFactor: z.number().optional(),
 });
 
 export type GrassTypeSeed = z.infer<typeof GrassTypeSeedSchema>;

--- a/api/data/seeds/zones.json
+++ b/api/data/seeds/zones.json
@@ -1,41 +1,44 @@
 [
     {
-        "slug": "front-lawn",
-        "name": "Front Lawn",
+        "slug": "north",
+        "name": "North",
         "site": "home",
         "grassType": "kentucky-bluegrass",
         "soilType": "clay-loam",
         "rootDepthM": 0.3,
         "allowableDepletionFraction": 0.5,
-        "irrigationEfficiency": 0.8,
+        "irrigationEfficiency": 0.675,
         "flowRateLPerMin": 15,
         "areaM2": 80,
-        "homeAssistantEntityId": "switch.sonoff_4chpro_relay_1"
+        "microclimateFactor": 0.85,
+        "homeAssistantEntityId": "switch.sprinkler_controller_north_zone"
     },
     {
-        "slug": "back-lawn",
-        "name": "Back Lawn",
+        "slug": "south",
+        "name": "South",
         "site": "home",
         "grassType": "kentucky-bluegrass",
         "soilType": "clay-loam",
         "rootDepthM": 0.3,
         "allowableDepletionFraction": 0.5,
-        "irrigationEfficiency": 0.8,
+        "irrigationEfficiency": 0.675,
         "flowRateLPerMin": 15,
         "areaM2": 120,
-        "homeAssistantEntityId": "switch.sonoff_4chpro_relay_2"
+        "microclimateFactor": 1.10,
+        "homeAssistantEntityId": "switch.sprinkler_controller_south_zone"
     },
     {
-        "slug": "side-yard",
-        "name": "Side Yard",
+        "slug": "east",
+        "name": "East",
         "site": "home",
         "grassType": "kentucky-bluegrass",
         "soilType": "clay-loam",
         "rootDepthM": 0.3,
         "allowableDepletionFraction": 0.5,
-        "irrigationEfficiency": 0.8,
+        "irrigationEfficiency": 0.675,
         "flowRateLPerMin": 15,
         "areaM2": 60,
-        "homeAssistantEntityId": "switch.sonoff_4chpro_relay_3"
+        "microclimateFactor": 1.00,
+        "homeAssistantEntityId": "switch.sprinkler_controller_east_zone"
     }
 ]

--- a/api/db/schema/zones.ts
+++ b/api/db/schema/zones.ts
@@ -22,5 +22,6 @@ export const zones = pgTable('zones', {
     latitude: doublePrecision('latitude'),
     longitude: doublePrecision('longitude'),
     homeAssistantEntityId: text('home_assistant_entity_id'),
+    microclimateFactor: real('microclimate_factor').notNull().default(1),
     ...auditColumns,
 });

--- a/api/drizzle/0006_dizzy_pet_avengers.sql
+++ b/api/drizzle/0006_dizzy_pet_avengers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "zones" ADD COLUMN "microclimate_factor" real DEFAULT 1 NOT NULL;

--- a/api/drizzle/meta/0006_snapshot.json
+++ b/api/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,727 @@
+{
+  "id": "64cb8301-7769-4634-a158-912b7641bdc3",
+  "prevId": "30d3c638-c91e-4658-87dc-c4fae642540a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778515210166,
       "tag": "0005_wonderful_speedball",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1778619200457,
+      "tag": "0006_dizzy_pet_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/api/models.ts
+++ b/api/models.ts
@@ -101,6 +101,9 @@ export type Zone = {
 
     /** Optional. The Home Assistant entity ID controlling the zone's relay (e.g. `switch.sonoff_4chpro_relay_1`). */
     homeAssistantEntityId?: string;
+
+    /** Optional. Multiplier applied to crop ET to account for microclimate differences (sun exposure, aspect). Default 1.0. */
+    microclimateFactor?: number;
 }
 
 export type IrrigationCycle = {

--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,7 @@
     "disable-schedule": "bun scripts/disable-schedule.ts",
     "next-runs": "bun scripts/next-runs.ts",
     "notify:test": "bun scripts/notify-test.ts",
+    "toggle-zone": "bun scripts/toggle-zone.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -324,6 +324,28 @@ describe('planZoneSchedule', () => {
 
             expect(schedule.length).toBeLessThan(3);
         });
+
+        it('microclimateFactor above 1 increases irrigation frequency relative to factor of 1', () => {
+            const baseZone = createTestZone({ currentDepletionMm: 0, microclimateFactor: 1 });
+            const sunnyZone = createTestZone({ currentDepletionMm: 0, microclimateFactor: 1.1 });
+            const weather = createDryPeriod(14, 3.0);
+
+            const { entries: baseSchedule } = planZoneSchedule(baseZone, weather);
+            const { entries: sunnySchedule } = planZoneSchedule(sunnyZone, weather);
+
+            expect(sunnySchedule.length).toBeGreaterThanOrEqual(baseSchedule.length);
+        });
+
+        it('microclimateFactor below 1 decreases irrigation frequency relative to factor of 1', () => {
+            const baseZone = createTestZone({ currentDepletionMm: 0, microclimateFactor: 1 });
+            const shadyZone = createTestZone({ currentDepletionMm: 0, microclimateFactor: 0.85 });
+            const weather = createDryPeriod(14, 3.0);
+
+            const { entries: baseSchedule } = planZoneSchedule(baseZone, weather);
+            const { entries: shadySchedule } = planZoneSchedule(shadyZone, weather);
+
+            expect(shadySchedule.length).toBeLessThanOrEqual(baseSchedule.length);
+        });
     });
 
     // Root Depth Variations.

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -117,7 +117,8 @@ export function planZoneSchedule(
         // Calculate crop evapotranspiration and effective rainfall.
         const referenceEvapotranspiration = Math.max(0, weatherDay.evapotranspirationMmPerDay ?? 0),
             cropCoefficient = zone.grassType.cropCoefficient,
-            cropEvapotranspiration = cropCoefficient * referenceEvapotranspiration,
+            microclimateFactor = zone.microclimateFactor ?? 1,
+            cropEvapotranspiration = cropCoefficient * microclimateFactor * referenceEvapotranspiration,
             rainfallMillimeters = weatherDay.rainfallMm ?? 0,
             effectiveRainfallMillimeters = rainfallMillimeters < 2 ? 0 : 0.8 * rainfallMillimeters; // If rainfall is less than 2mm, treat as zero.
 

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -233,6 +233,7 @@ async function upsertZones(db: SeedDb, rows: ZoneSeed[], lookups: ZoneLookups): 
                 latitude: sql`excluded.latitude`,
                 longitude: sql`excluded.longitude`,
                 homeAssistantEntityId: sql`excluded.home_assistant_entity_id`,
+                microclimateFactor: sql`excluded.microclimate_factor`,
             },
         })
         .returning({ id: zones.id, slug: zones.slug });
@@ -304,12 +305,15 @@ function resolveZone(row: ZoneSeed, lookups: ZoneLookups) {
         latitude: row.latitude ?? null,
         longitude: row.longitude ?? null,
         homeAssistantEntityId: row.homeAssistantEntityId ?? null,
+        microclimateFactor: row.microclimateFactor ?? 1,
     };
 }
 
 if (import.meta.main) {
-    seed().catch((err: unknown) => {
-        console.error('seed: failed.', err);
-        process.exit(1);
-    });
+    seed()
+        .then(() => process.exit(0))
+        .catch((err: unknown) => {
+            console.error('seed: failed.', err);
+            process.exit(1);
+        });
 }

--- a/api/scripts/toggle-zone.test.ts
+++ b/api/scripts/toggle-zone.test.ts
@@ -3,24 +3,21 @@ import { toggleZoneCli, type ToggleZoneDeps } from './toggle-zone';
 import { createTestZone } from '@/mock/zone';
 import type { Zone } from '@/models';
 
+const ZONE = createTestZone({ id: 'zone-1', name: 'North' });
+
 function makeDeps(overrides?: Partial<ToggleZoneDeps>): {
     deps: ToggleZoneDeps;
-    zones: Zone[];
     opens: Zone[];
     closes: Zone[];
     logs: string[];
     errors: string[];
 } {
-    const zones = [
-        createTestZone({ id: 'zone-1', name: 'Front Lawn' }),
-        createTestZone({ id: 'zone-2', name: 'Back Garden' }),
-    ];
     const opens: Zone[] = [];
     const closes: Zone[] = [];
     const logs: string[] = [];
     const errors: string[] = [];
     const deps: ToggleZoneDeps = {
-        loadZones: async () => zones,
+        loadZoneBySlug: async () => ZONE,
         getState: async () => 'off',
         open: async (zone) => { opens.push(zone); },
         close: async (zone) => { closes.push(zone); },
@@ -28,14 +25,14 @@ function makeDeps(overrides?: Partial<ToggleZoneDeps>): {
         error: m => errors.push(m),
         ...overrides,
     };
-    return { deps, zones, opens, closes, logs, errors };
+    return { deps, opens, closes, logs, errors };
 }
 
 describe('toggleZoneCli', () => {
     it('opens a zone that is off and returns 0', async () => {
         const { deps, opens, closes } = makeDeps({ getState: async () => 'off' });
 
-        const code = await toggleZoneCli(1, deps);
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(0);
         expect(opens).toHaveLength(1);
@@ -45,7 +42,7 @@ describe('toggleZoneCli', () => {
     it('closes a zone that is on and returns 0', async () => {
         const { deps, opens, closes } = makeDeps({ getState: async () => 'on' });
 
-        const code = await toggleZoneCli(1, deps);
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(0);
         expect(closes).toHaveLength(1);
@@ -55,7 +52,7 @@ describe('toggleZoneCli', () => {
     it('returns 1 and logs an error when state is unknown', async () => {
         const { deps, opens, closes, errors } = makeDeps({ getState: async () => 'unknown' });
 
-        const code = await toggleZoneCli(1, deps);
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(1);
         expect(errors).toHaveLength(1);
@@ -64,47 +61,32 @@ describe('toggleZoneCli', () => {
         expect(closes).toHaveLength(0);
     });
 
-    it('opens the zone at the correct index', async () => {
-        const { deps, opens, zones } = makeDeps({ getState: async () => 'off' });
-
-        await toggleZoneCli(2, deps);
-
-        expect(opens[0]).toBe(zones[1]);
-    });
-
-    it('returns 1 when index is greater than number of zones', async () => {
-        const { deps, errors } = makeDeps();
-
-        const code = await toggleZoneCli(99, deps);
-
-        expect(code).toBe(1);
-        expect(errors[0]).toContain('out of range');
-    });
-
-    it('returns 1 when index is 0', async () => {
-        const { deps, errors } = makeDeps();
-
-        const code = await toggleZoneCli(0, deps);
-
-        expect(code).toBe(1);
-        expect(errors[0]).toContain('out of range');
-    });
-
-    it('returns 1 when the zone list is empty', async () => {
-        const { deps, errors } = makeDeps({ loadZones: async () => [] });
-
-        const code = await toggleZoneCli(1, deps);
-
-        expect(code).toBe(1);
-        expect(errors[0]).toContain('no zones');
-    });
-
-    it('returns 1 when loadZones throws', async () => {
-        const { deps, errors } = makeDeps({
-            loadZones: async () => { throw new Error('db down'); },
+    it('passes the slug to loadZoneBySlug', async () => {
+        const slugsSeen: string[] = [];
+        const { deps } = makeDeps({
+            loadZoneBySlug: async (s) => { slugsSeen.push(s); return ZONE; },
         });
 
-        const code = await toggleZoneCli(1, deps);
+        await toggleZoneCli('north', deps);
+
+        expect(slugsSeen).toEqual(['north']);
+    });
+
+    it('returns 1 when no zone matches the slug', async () => {
+        const { deps, errors } = makeDeps({ loadZoneBySlug: async () => null });
+
+        const code = await toggleZoneCli('unknown-slug', deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('unknown-slug');
+    });
+
+    it('returns 1 when loadZoneBySlug throws', async () => {
+        const { deps, errors } = makeDeps({
+            loadZoneBySlug: async () => { throw new Error('db down'); },
+        });
+
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(1);
         expect(errors[0]).toContain('db down');
@@ -115,7 +97,7 @@ describe('toggleZoneCli', () => {
             getState: async () => { throw new Error('HA timeout'); },
         });
 
-        const code = await toggleZoneCli(1, deps);
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(1);
         expect(errors[0]).toContain('HA timeout');
@@ -127,7 +109,7 @@ describe('toggleZoneCli', () => {
             open: async () => { throw new Error('relay stuck'); },
         });
 
-        const code = await toggleZoneCli(1, deps);
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(1);
         expect(errors[0]).toContain('relay stuck');
@@ -139,25 +121,25 @@ describe('toggleZoneCli', () => {
             close: async () => { throw new Error('relay stuck'); },
         });
 
-        const code = await toggleZoneCli(1, deps);
+        const code = await toggleZoneCli('north', deps);
 
         expect(code).toBe(1);
         expect(errors[0]).toContain('relay stuck');
     });
 
     it('logs zone name before opening', async () => {
-        const { deps, logs, zones } = makeDeps({ getState: async () => 'off' });
+        const { deps, logs } = makeDeps({ getState: async () => 'off' });
 
-        await toggleZoneCli(1, deps);
+        await toggleZoneCli('north', deps);
 
-        expect(logs[0]).toContain(zones[0]!.name);
+        expect(logs[0]).toContain(ZONE.name);
     });
 
     it('logs zone name before closing', async () => {
-        const { deps, logs, zones } = makeDeps({ getState: async () => 'on' });
+        const { deps, logs } = makeDeps({ getState: async () => 'on' });
 
-        await toggleZoneCli(1, deps);
+        await toggleZoneCli('north', deps);
 
-        expect(logs[0]).toContain(zones[0]!.name);
+        expect(logs[0]).toContain(ZONE.name);
     });
 });

--- a/api/scripts/toggle-zone.test.ts
+++ b/api/scripts/toggle-zone.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'bun:test';
+import { toggleZoneCli, type ToggleZoneDeps } from './toggle-zone';
+import { createTestZone } from '@/mock/zone';
+import type { Zone } from '@/models';
+
+function makeDeps(overrides?: Partial<ToggleZoneDeps>): {
+    deps: ToggleZoneDeps;
+    zones: Zone[];
+    opens: Zone[];
+    closes: Zone[];
+    logs: string[];
+    errors: string[];
+} {
+    const zones = [
+        createTestZone({ id: 'zone-1', name: 'Front Lawn' }),
+        createTestZone({ id: 'zone-2', name: 'Back Garden' }),
+    ];
+    const opens: Zone[] = [];
+    const closes: Zone[] = [];
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const deps: ToggleZoneDeps = {
+        loadZones: async () => zones,
+        getState: async () => 'off',
+        open: async (zone) => { opens.push(zone); },
+        close: async (zone) => { closes.push(zone); },
+        log: m => logs.push(m),
+        error: m => errors.push(m),
+        ...overrides,
+    };
+    return { deps, zones, opens, closes, logs, errors };
+}
+
+describe('toggleZoneCli', () => {
+    it('opens a zone that is off and returns 0', async () => {
+        const { deps, opens, closes } = makeDeps({ getState: async () => 'off' });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(0);
+        expect(opens).toHaveLength(1);
+        expect(closes).toHaveLength(0);
+    });
+
+    it('closes a zone that is on and returns 0', async () => {
+        const { deps, opens, closes } = makeDeps({ getState: async () => 'on' });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(0);
+        expect(closes).toHaveLength(1);
+        expect(opens).toHaveLength(0);
+    });
+
+    it('returns 1 and logs an error when state is unknown', async () => {
+        const { deps, opens, closes, errors } = makeDeps({ getState: async () => 'unknown' });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(1);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('unknown');
+        expect(opens).toHaveLength(0);
+        expect(closes).toHaveLength(0);
+    });
+
+    it('opens the zone at the correct index', async () => {
+        const { deps, opens, zones } = makeDeps({ getState: async () => 'off' });
+
+        await toggleZoneCli(2, deps);
+
+        expect(opens[0]).toBe(zones[1]);
+    });
+
+    it('returns 1 when index is greater than number of zones', async () => {
+        const { deps, errors } = makeDeps();
+
+        const code = await toggleZoneCli(99, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('out of range');
+    });
+
+    it('returns 1 when index is 0', async () => {
+        const { deps, errors } = makeDeps();
+
+        const code = await toggleZoneCli(0, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('out of range');
+    });
+
+    it('returns 1 when the zone list is empty', async () => {
+        const { deps, errors } = makeDeps({ loadZones: async () => [] });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('no zones');
+    });
+
+    it('returns 1 when loadZones throws', async () => {
+        const { deps, errors } = makeDeps({
+            loadZones: async () => { throw new Error('db down'); },
+        });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('db down');
+    });
+
+    it('returns 1 when getState throws', async () => {
+        const { deps, errors } = makeDeps({
+            getState: async () => { throw new Error('HA timeout'); },
+        });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('HA timeout');
+    });
+
+    it('returns 1 when open throws', async () => {
+        const { deps, errors } = makeDeps({
+            getState: async () => 'off',
+            open: async () => { throw new Error('relay stuck'); },
+        });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('relay stuck');
+    });
+
+    it('returns 1 when close throws', async () => {
+        const { deps, errors } = makeDeps({
+            getState: async () => 'on',
+            close: async () => { throw new Error('relay stuck'); },
+        });
+
+        const code = await toggleZoneCli(1, deps);
+
+        expect(code).toBe(1);
+        expect(errors[0]).toContain('relay stuck');
+    });
+
+    it('logs zone name before opening', async () => {
+        const { deps, logs, zones } = makeDeps({ getState: async () => 'off' });
+
+        await toggleZoneCli(1, deps);
+
+        expect(logs[0]).toContain(zones[0]!.name);
+    });
+
+    it('logs zone name before closing', async () => {
+        const { deps, logs, zones } = makeDeps({ getState: async () => 'on' });
+
+        await toggleZoneCli(1, deps);
+
+        expect(logs[0]).toContain(zones[0]!.name);
+    });
+});

--- a/api/scripts/toggle-zone.ts
+++ b/api/scripts/toggle-zone.ts
@@ -1,0 +1,120 @@
+import type { Zone } from '@/models';
+import type { ZoneRelayState } from '@/data/home-assistant';
+
+export type ToggleZoneDeps = {
+    loadZones: () => Promise<Zone[]>;
+    getState: (zone: Zone) => Promise<ZoneRelayState>;
+    open: (zone: Zone) => Promise<void>;
+    close: (zone: Zone) => Promise<void>;
+    log: (message: string) => void;
+    error: (message: string) => void;
+};
+
+export async function toggleZoneCli(index: number, deps: ToggleZoneDeps): Promise<0 | 1> {
+    let zones: Zone[];
+    try {
+        zones = await deps.loadZones();
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`toggle-zone: failed to load zones — ${message}`);
+        return 1;
+    }
+
+    if (zones.length === 0) {
+        deps.error('toggle-zone: no zones found in the database.');
+        return 1;
+    }
+
+    if (index < 1 || index > zones.length) {
+        deps.error(`toggle-zone: index ${index} is out of range (1–${zones.length}).`);
+        return 1;
+    }
+
+    const zone = zones[index - 1]!;
+
+    let state: ZoneRelayState;
+    try {
+        state = await deps.getState(zone);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.error(`toggle-zone: failed to read state for '${zone.name}' — ${message}`);
+        return 1;
+    }
+
+    if (state === 'unknown') {
+        deps.error(`toggle-zone: state of '${zone.name}' is unknown; cannot toggle safely.`);
+        return 1;
+    }
+
+    if (state === 'on') {
+        deps.log(`toggle-zone: '${zone.name}' is on — closing.`);
+        try {
+            await deps.close(zone);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            deps.error(`toggle-zone: failed to close '${zone.name}' — ${message}`);
+            return 1;
+        }
+    } else {
+        deps.log(`toggle-zone: '${zone.name}' is off — opening.`);
+        try {
+            await deps.open(zone);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            deps.error(`toggle-zone: failed to open '${zone.name}' — ${message}`);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+if (import.meta.main) {
+    const rawIndex = process.argv[2];
+    if (!rawIndex) {
+        console.error('toggle-zone: usage: bun run toggle-zone <index>  (index is 1-based)');
+        process.exit(1);
+    }
+
+    const index = Number.parseInt(rawIndex, 10);
+    if (!Number.isFinite(index) || index < 1) {
+        console.error(`toggle-zone: index must be a positive integer, got '${rawIndex}'.`);
+        process.exit(1);
+    }
+
+    const deps: ToggleZoneDeps = {
+        loadZones: async () => {
+            const { db } = await import('@/db');
+            const { eq } = await import('drizzle-orm');
+            const { grassTypes, soilTypes, sites, zones } = await import('@/db/schema');
+            const { joinedRowToZone } = await import('@/daemon/zones');
+
+            const rows = await db
+                .select({ zone: zones, grassType: grassTypes, soilType: soilTypes, site: sites })
+                .from(zones)
+                .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
+                .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
+                .innerJoin(sites, eq(zones.siteId, sites.id));
+
+            return rows
+                .sort((a, b) => a.zone.name.localeCompare(b.zone.name))
+                .map(joinedRowToZone);
+        },
+        getState: async (zone) => {
+            const { getZoneState } = await import('@/data/home-assistant');
+            return getZoneState(zone);
+        },
+        open: async (zone) => {
+            const { openZone } = await import('@/data/home-assistant');
+            return openZone(zone);
+        },
+        close: async (zone) => {
+            const { closeZone } = await import('@/data/home-assistant');
+            return closeZone(zone);
+        },
+        log: m => console.log(m),
+        error: m => console.error(m),
+    };
+
+    toggleZoneCli(index, deps).then(code => process.exit(code));
+}

--- a/api/scripts/toggle-zone.ts
+++ b/api/scripts/toggle-zone.ts
@@ -2,7 +2,7 @@ import type { Zone } from '@/models';
 import type { ZoneRelayState } from '@/data/home-assistant';
 
 export type ToggleZoneDeps = {
-    loadZones: () => Promise<Zone[]>;
+    loadZoneBySlug: (slug: string) => Promise<Zone | null>;
     getState: (zone: Zone) => Promise<ZoneRelayState>;
     open: (zone: Zone) => Promise<void>;
     close: (zone: Zone) => Promise<void>;
@@ -10,27 +10,20 @@ export type ToggleZoneDeps = {
     error: (message: string) => void;
 };
 
-export async function toggleZoneCli(index: number, deps: ToggleZoneDeps): Promise<0 | 1> {
-    let zones: Zone[];
+export async function toggleZoneCli(slug: string, deps: ToggleZoneDeps): Promise<0 | 1> {
+    let zone: Zone | null;
     try {
-        zones = await deps.loadZones();
+        zone = await deps.loadZoneBySlug(slug);
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        deps.error(`toggle-zone: failed to load zones — ${message}`);
+        deps.error(`toggle-zone: failed to load zone '${slug}' — ${message}`);
         return 1;
     }
 
-    if (zones.length === 0) {
-        deps.error('toggle-zone: no zones found in the database.');
+    if (!zone) {
+        deps.error(`toggle-zone: no zone found with slug '${slug}'.`);
         return 1;
     }
-
-    if (index < 1 || index > zones.length) {
-        deps.error(`toggle-zone: index ${index} is out of range (1–${zones.length}).`);
-        return 1;
-    }
-
-    const zone = zones[index - 1]!;
 
     let state: ZoneRelayState;
     try {
@@ -70,20 +63,14 @@ export async function toggleZoneCli(index: number, deps: ToggleZoneDeps): Promis
 }
 
 if (import.meta.main) {
-    const rawIndex = process.argv[2];
-    if (!rawIndex) {
-        console.error('toggle-zone: usage: bun run toggle-zone <index>  (index is 1-based)');
-        process.exit(1);
-    }
-
-    const index = Number.parseInt(rawIndex, 10);
-    if (!Number.isFinite(index) || index < 1) {
-        console.error(`toggle-zone: index must be a positive integer, got '${rawIndex}'.`);
+    const slug = process.argv[2];
+    if (!slug) {
+        console.error('toggle-zone: usage: bun run toggle-zone <slug>  (e.g. north, south, east)');
         process.exit(1);
     }
 
     const deps: ToggleZoneDeps = {
-        loadZones: async () => {
+        loadZoneBySlug: async (s) => {
             const { db } = await import('@/db');
             const { eq } = await import('drizzle-orm');
             const { grassTypes, soilTypes, sites, zones } = await import('@/db/schema');
@@ -94,11 +81,11 @@ if (import.meta.main) {
                 .from(zones)
                 .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
                 .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
-                .innerJoin(sites, eq(zones.siteId, sites.id));
+                .innerJoin(sites, eq(zones.siteId, sites.id))
+                .where(eq(zones.slug, s));
 
-            return rows
-                .sort((a, b) => a.zone.name.localeCompare(b.zone.name))
-                .map(joinedRowToZone);
+            const row = rows[0];
+            return row ? joinedRowToZone(row) : null;
         },
         getState: async (zone) => {
             const { getZoneState } = await import('@/data/home-assistant');
@@ -116,5 +103,5 @@ if (import.meta.main) {
         error: m => console.error(m),
     };
 
-    toggleZoneCli(index, deps).then(code => process.exit(code));
+    toggleZoneCli(slug, deps).then(code => process.exit(code));
 }


### PR DESCRIPTION
## Ticket

[API-34](http://192.168.2.100:7123/irrigo/browse/API-34/) Add toggle-zone CLI script

## Summary

- Adds `bun run toggle-zone <slug>` CLI script to open/close a zone relay by slug (e.g. `north`, `south`, `east`)
- Adds `microclimateFactor` field to the zone schema, model, and ET calculation — multiplier applied to crop ET for per-zone microclimate tuning (default 1.0)
- Updates zone seeds with descriptive slugs (`north`/`south`/`east`), human-readable names, and correct HA entity IDs (`switch.sprinkler_controller_*`)
- Fixes `bun run seed` not exiting on success
- Fixes 4 daemon test isolation failures caused by the reconciler's defensive sweep making real HA fetch calls when no `getZoneState` stub was provided