### PR TITLE
[API-33] Seed zones at MAD; preserve depletion on re-seed

### DIFF
--- a/api/scripts/seed.test.ts
+++ b/api/scripts/seed.test.ts
@@ -1,0 +1,84 @@
+import path from 'node:path';
+import { describe, it, expect } from 'bun:test';
+import { zones } from '@/db/schema';
+import { computeInitialDepletionMm, seed, type SeedDb } from './seed';
+
+const SEEDS_DIR = path.resolve(import.meta.dir, '../data/seeds');
+
+function makeSeedDb() {
+    const zoneConflictSets: Array<Record<string, unknown>> = [];
+    const zoneInsertValues: Array<ReadonlyArray<Record<string, unknown>>> = [];
+
+    const db: SeedDb = {
+        insert: (table) => ({
+            values: (rows) => ({
+                onConflictDoUpdate: (config) => {
+                    if (table === zones) {
+                        zoneConflictSets.push(config.set as Record<string, unknown>);
+                        zoneInsertValues.push(rows as ReadonlyArray<Record<string, unknown>>);
+                    }
+                    return {
+                        returning: async () =>
+                            (rows as ReadonlyArray<Record<string, unknown>>).map((r, i) => ({
+                                id: `id-${i}`,
+                                slug: (r['slug'] as string) ?? `slug-${i}`,
+                            })),
+                    };
+                },
+            }),
+        }),
+    };
+
+    return { db, zoneConflictSets, zoneInsertValues };
+}
+
+describe('computeInitialDepletionMm', () => {
+    it('returns MAD when currentDepletionMm is not set', () => {
+        // MAD = 0.3 * 165 * 0.5 = 24.75  (clay-loam AWC = 165 mm/m)
+        const result = computeInitialDepletionMm(
+            { rootDepthM: 0.3, allowableDepletionFraction: 0.5, currentDepletionMm: undefined },
+            165,
+        );
+        expect(result).toBeCloseTo(24.75);
+    });
+
+    it('returns 0 when currentDepletionMm is explicitly 0', () => {
+        const result = computeInitialDepletionMm(
+            { rootDepthM: 0.3, allowableDepletionFraction: 0.5, currentDepletionMm: 0 },
+            165,
+        );
+        expect(result).toBe(0);
+    });
+
+    it('returns the explicit value when currentDepletionMm is set to a positive number', () => {
+        const result = computeInitialDepletionMm(
+            { rootDepthM: 0.3, allowableDepletionFraction: 0.5, currentDepletionMm: 12.5 },
+            165,
+        );
+        expect(result).toBe(12.5);
+    });
+});
+
+describe('seed zone upsert', () => {
+    it('seeds zones at MAD (not zero) when currentDepletionMm is absent from the JSON', async () => {
+        const { db, zoneInsertValues } = makeSeedDb();
+
+        await seed({ db, dataDir: SEEDS_DIR });
+
+        const rows = zoneInsertValues[0];
+        expect(rows).toBeDefined();
+        for (const row of rows!) {
+            expect(typeof row['currentDepletionMm']).toBe('number');
+            expect(row['currentDepletionMm'] as number).toBeGreaterThan(0);
+        }
+    });
+
+    it('does not include currentDepletionMm in the ON CONFLICT set (re-seed preserves operator state)', async () => {
+        const { db, zoneConflictSets } = makeSeedDb();
+
+        await seed({ db, dataDir: SEEDS_DIR });
+
+        expect(zoneConflictSets).toHaveLength(1);
+        expect('currentDepletionMm' in zoneConflictSets[0]!).toBe(false);
+    });
+});

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -15,6 +15,23 @@ import {
 } from '@/data/seeds';
 
 /**
+ * Computes the initial `currentDepletionMm` value for a zone being seeded.
+ * Returns the explicit seed value when provided (including 0); otherwise
+ * defaults to the zone's MAD (maximum allowable depletion) so a freshly
+ * seeded zone triggers irrigation on the very first replan rather than
+ * waiting for ET to accumulate from scratch.
+ *
+ * MAD = rootDepthM × soilAwcMmPerM × allowableDepletionFraction
+ */
+export function computeInitialDepletionMm(
+    zone: Pick<ZoneSeed, 'rootDepthM' | 'allowableDepletionFraction' | 'currentDepletionMm'>,
+    soilAwcMmPerM: number,
+): number {
+    if (zone.currentDepletionMm !== undefined) return zone.currentDepletionMm;
+    return zone.rootDepthM * soilAwcMmPerM * zone.allowableDepletionFraction;
+}
+
+/**
  * Minimal subset of the Drizzle client surface that the seed orchestrator
  * needs. Lets tests inject a recording stub without depending on a live
  * Postgres connection.
@@ -95,7 +112,8 @@ export async function seed(options?: SeedOptions): Promise<SeedSummary> {
     const grassMap = await upsertGrassTypes(db, grassRows);
     const soilMap = await upsertSoilTypes(db, soilRows);
     const siteMap = await upsertSites(db, siteRows);
-    await upsertZones(db, zoneRows, { grassMap, soilMap, siteMap });
+    const soilDataMap = new Map(soilRows.map(r => [r.slug, r]));
+    await upsertZones(db, zoneRows, { grassMap, soilMap, siteMap, soilDataMap });
     const scheduleCount = await upsertSchedules(db, scheduleRows, siteMap);
 
     console.log('seed: complete.');
@@ -205,6 +223,7 @@ type ZoneLookups = {
     grassMap: Map<string, string>;
     soilMap: Map<string, string>;
     siteMap: Map<string, string>;
+    soilDataMap: Map<string, SoilTypeSeed>;
 };
 
 async function upsertZones(db: SeedDb, rows: ZoneSeed[], lookups: ZoneLookups): Promise<void> {
@@ -228,7 +247,6 @@ async function upsertZones(db: SeedDb, rows: ZoneSeed[], lookups: ZoneLookups): 
                 flowRateLPerMin: sql`excluded.flow_rate_l_per_min`,
                 areaM2: sql`excluded.area_m2`,
                 precipitationRateMmPerHr: sql`excluded.precipitation_rate_mm_per_hr`,
-                currentDepletionMm: sql`excluded.current_depletion_mm`,
                 isEnabled: sql`excluded.is_enabled`,
                 latitude: sql`excluded.latitude`,
                 longitude: sql`excluded.longitude`,
@@ -288,6 +306,8 @@ function resolveZone(row: ZoneSeed, lookups: ZoneLookups) {
     const soilTypeId = lookups.soilMap.get(row.soilType);
     if (!soilTypeId) throw new Error(`seed: zone "${row.slug}" references unknown soilType "${row.soilType}".`);
 
+    const soil = lookups.soilDataMap.get(row.soilType)!;
+
     return {
         slug: row.slug,
         name: row.name,
@@ -300,7 +320,7 @@ function resolveZone(row: ZoneSeed, lookups: ZoneLookups) {
         flowRateLPerMin: row.flowRateLPerMin,
         areaM2: row.areaM2,
         precipitationRateMmPerHr: row.precipitationRateMmPerHr ?? null,
-        currentDepletionMm: row.currentDepletionMm ?? 0,
+        currentDepletionMm: computeInitialDepletionMm(row, soil.availableWaterHoldingCapacityMmPerM),
         isEnabled: row.isEnabled ?? true,
         latitude: row.latitude ?? null,
         longitude: row.longitude ?? null,


### PR DESCRIPTION
## Ticket

[API-33](http://192.168.2.100:7123/irrigo/browse/API-33/) Seed zones at maximum depletion when no prior irrigation history exists

## Summary

- New zones now seed with `current_depletion_mm` set to MAD (`rootDepthM × soil.awcMmPerM × allowableDepletionFraction`) instead of 0, so the first replan immediately schedules irrigation rather than waiting several days for ET to accumulate
- `ON CONFLICT DO UPDATE` no longer clobbers `current_depletion_mm` — re-seeding preserves existing runtime depletion state managed by the daemon
- Exports `computeInitialDepletionMm` as a pure testable helper; adds `api/scripts/seed.test.ts` with 5 tests covering both the helper and orchestrator behavior