### PR TITLE
[API-30] Cap morning irrigation at sunrise via endBySunrise flag

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1298,6 +1298,7 @@ type DaemonStubInputs = {
         allowedTimeWindows: Array<{ start: string; end: string }> | null;
         rootDepthMOverride: number | null;
         allowableDepletionFractionOverride: number | null;
+        endBySunrise: boolean | null;
         createdAt: Date;
         updatedAt: Date;
     } }>;
@@ -1348,6 +1349,7 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             allowedTimeWindows: null,
             rootDepthMOverride: null,
             allowableDepletionFractionOverride: null,
+            endBySunrise: null,
             createdAt: NOW_FOR_SCHEDULES,
             updatedAt: NOW_FOR_SCHEDULES,
         },
@@ -2046,6 +2048,7 @@ describe('start', () => {
                         allowedTimeWindows: null,
                         rootDepthMOverride: null,
                         allowableDepletionFractionOverride: null,
+                        endBySunrise: null,
                         createdAt: NOW, updatedAt: NOW,
                     },
                 }],
@@ -2090,6 +2093,7 @@ describe('start', () => {
                         ],
                         rootDepthMOverride: null,
                         allowableDepletionFractionOverride: null,
+                        endBySunrise: null,
                         createdAt: NOW, updatedAt: NOW,
                     },
                 }],
@@ -2129,7 +2133,7 @@ describe('start', () => {
                 activeSchedules: [{
                     schedule: {
                         id: 'sched-active', siteId: 'site-A', slug: 'maintenance', name: 'Maintenance',
-                        isActive: true, allowedDays: null, allowedTimeWindows: null, rootDepthMOverride: null, allowableDepletionFractionOverride: null, createdAt: NOW, updatedAt: NOW,
+                        isActive: true, allowedDays: null, allowedTimeWindows: null, rootDepthMOverride: null, allowableDepletionFractionOverride: null, endBySunrise: null, createdAt: NOW, updatedAt: NOW,
                     },
                 }],
             });
@@ -2196,7 +2200,7 @@ describe('start', () => {
                     activeSchedules: [{
                         schedule: {
                             id: 'sched-A', siteId: 'site-active', slug: 'maintenance', name: 'Maintenance',
-                            isActive: true, allowedDays: null, allowedTimeWindows: null, rootDepthMOverride: null, allowableDepletionFractionOverride: null, createdAt: NOW, updatedAt: NOW,
+                            isActive: true, allowedDays: null, allowedTimeWindows: null, rootDepthMOverride: null, allowableDepletionFractionOverride: null, endBySunrise: null, createdAt: NOW, updatedAt: NOW,
                         },
                     }],
                 });

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -2099,7 +2099,7 @@ describe('start', () => {
                 }],
             });
             const { clock } = createFakeClock(NOW);
-            const planCalls: Array<{ allowedDays: number[] | null | undefined; allowedTimeWindows: unknown }> = [];
+            const planCalls: Array<{ allowedDays: number[] | null | undefined; allowedTimeWindows: unknown; endBySunrise: unknown }> = [];
 
             const control = await start(db, {
                 clock,
@@ -2108,6 +2108,7 @@ describe('start', () => {
                     planCalls.push({
                         allowedDays: opts?.restrictions?.allowedDays,
                         allowedTimeWindows: opts?.restrictions?.allowedTimeWindows,
+                        endBySunrise: opts?.restrictions?.endBySunrise,
                     });
                     return { entries: [], projectedNextDepletionMm: 0 };
                 },
@@ -2124,6 +2125,45 @@ describe('start', () => {
                 { start: '00:00', end: '10:00' },
                 { start: '19:00', end: '23:59' },
             ]);
+            expect(planCalls[0]?.endBySunrise).toBe(false);
+        });
+
+        it('forwards endBySunrise: true from the active schedule to runPlan', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-ebs', siteId: 'site-EBS' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-ebs', siteId: 'site-EBS', slug: 'maintenance', name: 'Maintenance',
+                        isActive: true,
+                        allowedDays: null,
+                        allowedTimeWindows: null,
+                        rootDepthMOverride: null,
+                        allowableDepletionFractionOverride: null,
+                        endBySunrise: true,
+                        createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: Array<{ endBySunrise: unknown }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    planCalls.push({ endBySunrise: opts?.restrictions?.endBySunrise });
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toHaveLength(1);
+            expect(planCalls[0]?.endBySunrise).toBe(true);
         });
 
         it('stamps the active schedule id on each schedule_entries insert during rePlan', async () => {

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -177,6 +177,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                 const restrictions = {
                     allowedDays: activeSchedule.allowedDays,
                     allowedTimeWindows: activeSchedule.allowedTimeWindows,
+                    endBySunrise: activeSchedule.endBySunrise ?? false,
                 };
                 const overrides = {
                     rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -25,6 +25,7 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         allowedTimeWindows: null,
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
+        endBySunrise: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -203,6 +203,7 @@ describe('parseSchedules', () => {
             ],
             rootDepthMOverride: null,
             allowableDepletionFractionOverride: null,
+            endBySunrise: null,
         });
     });
 

--- a/api/data/seeds/index.ts
+++ b/api/data/seeds/index.ts
@@ -43,6 +43,7 @@ export const ScheduleSeedSchema = z.object({
     allowedTimeWindows: z.array(ScheduleTimeWindowSeedSchema).nullable(),
     rootDepthMOverride: z.number().nullable().default(null),
     allowableDepletionFractionOverride: z.number().nullable().default(null),
+    endBySunrise: z.boolean().nullable().default(null),
 });
 
 export const ZoneSeedSchema = z.object({

--- a/api/data/seeds/schedules.json
+++ b/api/data/seeds/schedules.json
@@ -8,7 +8,8 @@
         "allowedTimeWindows": [
             { "start": "00:00", "end": "10:00" },
             { "start": "19:00", "end": "23:59" }
-        ]
+        ],
+        "endBySunrise": true
     },
     {
         "slug": "overseeding",

--- a/api/db/schema/schedules.ts
+++ b/api/db/schema/schedules.ts
@@ -33,6 +33,7 @@ export const schedules = pgTable('schedules', {
     allowedTimeWindows: jsonb('allowed_time_windows').$type<ScheduleTimeWindow[]>(),
     rootDepthMOverride: real('root_depth_m_override'),
     allowableDepletionFractionOverride: real('allowable_depletion_fraction_override'),
+    endBySunrise: boolean('end_by_sunrise'),
     ...auditColumns,
 }, table => [
     uniqueIndex('schedules_site_slug_idx').on(table.siteId, table.slug),

--- a/api/drizzle/0007_lying_charles_xavier.sql
+++ b/api/drizzle/0007_lying_charles_xavier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schedules" ADD COLUMN "end_by_sunrise" boolean;

--- a/api/drizzle/meta/0007_snapshot.json
+++ b/api/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,733 @@
+{
+  "id": "e1d86cac-9447-458f-b881-3eb9380b0d27",
+  "prevId": "64cb8301-7769-4634-a158-912b7641bdc3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778619200457,
       "tag": "0006_dizzy_pet_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1778640910071,
+      "tag": "0007_lying_charles_xavier",
+      "breakpoints": true
     }
   ]
 }

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -231,9 +231,9 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         : Math.ceil(totalRunTimeMinutes / maximumCycleMinutes);
     const requiredSpanMinutes = totalRunTimeMinutes + (numberOfCycles - 1) * soakTimeMinutes;
 
-    const allowedIntervals = computeAllowedIntervalsForDay(date, restrictions);
+    const allowedIntervals = computeAllowedIntervalsForDay(date, restrictions, sunrise);
     const hasTimeWindows = restrictions.allowedTimeWindows !== null && restrictions.allowedTimeWindows.length > 0;
-    const forbiddenForDay = hasTimeWindows ? computeForbiddenIntervalsForDay(date, restrictions) : [];
+    const forbiddenForDay = hasTimeWindows ? computeForbiddenIntervalsForDay(date, restrictions, sunrise) : [];
 
     // Pick an anchor:
     //  - No time-window restriction: the existing sunrise anchor.

--- a/api/schedules/dynamic/restrictions.test.ts
+++ b/api/schedules/dynamic/restrictions.test.ts
@@ -1,0 +1,106 @@
+import dayjs from 'dayjs';
+import { describe, it, expect } from 'bun:test';
+import {
+    computeAllowedIntervalsForDay,
+    computeForbiddenIntervalsForDay,
+    type ScheduleRestrictions,
+} from './restrictions';
+
+const BASE_DAY = dayjs('2026-05-13T00:00:00.000Z');
+const SUNRISE = BASE_DAY.hour(5).minute(30).second(0).millisecond(0);
+
+const MUNICIPAL_WINDOWS: ScheduleRestrictions = {
+    allowedDays: null,
+    allowedTimeWindows: [
+        { start: '00:00', end: '10:00' },
+        { start: '19:00', end: '23:59' },
+    ],
+};
+
+describe('computeAllowedIntervalsForDay — endBySunrise flag', () => {
+    it('leaves intervals unchanged when endBySunrise is false', () => {
+        const restrictions: ScheduleRestrictions = { ...MUNICIPAL_WINDOWS, endBySunrise: false };
+        const intervals = computeAllowedIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        expect(intervals).toHaveLength(2);
+        expect(intervals[0]!.start.format('HH:mm')).toBe('00:00');
+        expect(intervals[0]!.end.format('HH:mm')).toBe('10:00');
+        expect(intervals[1]!.start.format('HH:mm')).toBe('19:00');
+        expect(intervals[1]!.end.format('HH:mm')).toBe('23:59');
+    });
+
+    it('leaves intervals unchanged when endBySunrise is absent', () => {
+        const intervals = computeAllowedIntervalsForDay(BASE_DAY, MUNICIPAL_WINDOWS, SUNRISE);
+
+        expect(intervals).toHaveLength(2);
+        expect(intervals[0]!.end.format('HH:mm')).toBe('10:00');
+    });
+
+    it('narrows morning window end to sunrise when endBySunrise is true', () => {
+        const restrictions: ScheduleRestrictions = { ...MUNICIPAL_WINDOWS, endBySunrise: true };
+        const intervals = computeAllowedIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        expect(intervals).toHaveLength(2);
+        expect(intervals[0]!.start.format('HH:mm')).toBe('00:00');
+        expect(intervals[0]!.end.format('HH:mm')).toBe('05:30');
+    });
+
+    it('leaves evening window unchanged when endBySunrise is true', () => {
+        const restrictions: ScheduleRestrictions = { ...MUNICIPAL_WINDOWS, endBySunrise: true };
+        const intervals = computeAllowedIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        const evening = intervals.find(i => i.start.hour() >= 19);
+        expect(evening).toBeDefined();
+        expect(evening!.start.format('HH:mm')).toBe('19:00');
+        expect(evening!.end.format('HH:mm')).toBe('23:59');
+    });
+
+    it('leaves a window entirely before sunrise unchanged', () => {
+        const restrictions: ScheduleRestrictions = {
+            allowedDays: null,
+            allowedTimeWindows: [{ start: '00:00', end: '04:00' }],
+            endBySunrise: true,
+        };
+        const intervals = computeAllowedIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        expect(intervals).toHaveLength(1);
+        expect(intervals[0]!.start.format('HH:mm')).toBe('00:00');
+        expect(intervals[0]!.end.format('HH:mm')).toBe('04:00');
+    });
+
+    it('keeps a window starting at sunrise as-is (start not before sunrise)', () => {
+        const restrictions: ScheduleRestrictions = {
+            allowedDays: null,
+            allowedTimeWindows: [{ start: '05:30', end: '08:00' }],
+            endBySunrise: true,
+        };
+        const intervals = computeAllowedIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        expect(intervals).toHaveLength(1);
+        expect(intervals[0]!.start.format('HH:mm')).toBe('05:30');
+        expect(intervals[0]!.end.format('HH:mm')).toBe('08:00');
+    });
+});
+
+describe('computeForbiddenIntervalsForDay — endBySunrise flag', () => {
+    it('includes the post-sunrise morning stretch as a forbidden gap when endBySunrise is true', () => {
+        const restrictions: ScheduleRestrictions = { ...MUNICIPAL_WINDOWS, endBySunrise: true };
+        const forbidden = computeForbiddenIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        // Expected gaps:
+        //   midnight–midnight (full day) minus [00:00–05:30] and [19:00–23:59]
+        //   → [05:30–19:00] and [23:59–midnight]
+        const postSunrise = forbidden.find(f =>
+            f.start.format('HH:mm') === '05:30' && f.end.format('HH:mm') === '19:00');
+        expect(postSunrise).toBeDefined();
+    });
+
+    it('does not include post-sunrise stretch as forbidden when endBySunrise is false', () => {
+        const restrictions: ScheduleRestrictions = { ...MUNICIPAL_WINDOWS, endBySunrise: false };
+        const forbidden = computeForbiddenIntervalsForDay(BASE_DAY, restrictions, SUNRISE);
+
+        // Without the flag, morning window is 00:00–10:00 so the gap after it starts at 10:00
+        const postSunrise = forbidden.find(f => f.start.format('HH:mm') === '05:30');
+        expect(postSunrise).toBeUndefined();
+    });
+});

--- a/api/schedules/dynamic/restrictions.ts
+++ b/api/schedules/dynamic/restrictions.ts
@@ -18,10 +18,15 @@ export type ScheduleTimeWindow = {
  * Restrictions a schedule applies to the planner's per-day cycle placement.
  * `null` (or an empty array) for either field means "no restriction"; both
  * null is the no-op shape used when no schedule has constraints.
+ *
+ * `endBySunrise`: when true, the planner narrows each morning allowed window
+ * to `[start, min(end, sunrise)]` so no placed cycle can finish post-sunrise.
+ * Evening windows (those that start after sunrise) are left untouched.
  */
 export type ScheduleRestrictions = {
     allowedDays: number[] | null;
     allowedTimeWindows: ScheduleTimeWindow[] | null;
+    endBySunrise?: boolean;
 };
 
 /**
@@ -50,26 +55,59 @@ export function isDayAllowed(restrictions: ScheduleRestrictions, isoWeekday: num
  * (returns []) when the day itself is disallowed — callers should consult
  * `isDayAllowed` first.
  *
+ * When `restrictions.endBySunrise` is true and `sunrise` is provided, morning
+ * windows (those that start before sunrise) are narrowed to end at sunrise.
+ * Evening windows (start >= sunrise) are kept as-is.
+ *
  * @param day - Reference Dayjs already anchored at midnight in the site's
  *   timezone. The returned intervals share its tz.
  * @param restrictions - Effective restrictions for the active schedule.
+ * @param sunrise - Optional sunrise time for the day; required when
+ *   `restrictions.endBySunrise` is true to apply morning-window narrowing.
  */
-export function computeAllowedIntervalsForDay(day: dayjs.Dayjs, restrictions: ScheduleRestrictions): AllowedInterval[] {
+export function computeAllowedIntervalsForDay(
+    day: dayjs.Dayjs,
+    restrictions: ScheduleRestrictions,
+    sunrise?: dayjs.Dayjs,
+): AllowedInterval[] {
     if (!isDayAllowed(restrictions, day.isoWeekday())) return [];
 
     const windows = restrictions.allowedTimeWindows;
+    let intervals: AllowedInterval[];
     if (windows === null || windows.length === 0) {
-        return [{ start: day.startOf('day'), end: day.add(1, 'day').startOf('day') }];
+        intervals = [{ start: day.startOf('day'), end: day.add(1, 'day').startOf('day') }];
+    } else {
+        const base = day.startOf('day');
+        intervals = windows
+            .map(w => ({
+                start: applyHhmm(base, w.start),
+                end: applyHhmm(base, w.end),
+            }))
+            .filter(interval => interval.end.isAfter(interval.start))
+            .sort((a, b) => a.start.valueOf() - b.start.valueOf());
     }
 
-    const base = day.startOf('day');
-    return windows
-        .map(w => ({
-            start: applyHhmm(base, w.start),
-            end: applyHhmm(base, w.end),
-        }))
-        .filter(interval => interval.end.isAfter(interval.start))
-        .sort((a, b) => a.start.valueOf() - b.start.valueOf());
+    if (restrictions.endBySunrise && sunrise !== undefined) {
+        intervals = applyEndBySunrise(intervals, sunrise);
+    }
+
+    return intervals;
+}
+
+/**
+ * Narrows morning windows so no cycle can end after sunrise. Windows that
+ * start before sunrise are capped at `[start, min(end, sunrise)]`; windows
+ * that start at or after sunrise (evening windows) are kept as-is. Zero-
+ * length results (edge case: window starts exactly at sunrise) are dropped.
+ */
+function applyEndBySunrise(intervals: AllowedInterval[], sunrise: dayjs.Dayjs): AllowedInterval[] {
+    return intervals
+        .map(interval => {
+            if (!interval.start.isBefore(sunrise)) return interval;
+            const cappedEnd = interval.end.isAfter(sunrise) ? sunrise : interval.end;
+            return { start: interval.start, end: cappedEnd };
+        })
+        .filter(interval => interval.end.isAfter(interval.start));
 }
 
 /**
@@ -77,8 +115,15 @@ export function computeAllowedIntervalsForDay(day: dayjs.Dayjs, restrictions: Sc
  * intervals. When the day is fully forbidden, the result is a single
  * interval spanning the whole day. Used as additional busy windows in
  * `deconflictCycles` so forward shifts skip past restricted time.
+ *
+ * Pass `sunrise` when `restrictions.endBySunrise` is true so the post-sunrise
+ * portion of morning windows also appears as a forbidden gap.
  */
-export function computeForbiddenIntervalsForDay(day: dayjs.Dayjs, restrictions: ScheduleRestrictions): AllowedInterval[] {
+export function computeForbiddenIntervalsForDay(
+    day: dayjs.Dayjs,
+    restrictions: ScheduleRestrictions,
+    sunrise?: dayjs.Dayjs,
+): AllowedInterval[] {
     const dayStart = day.startOf('day');
     const dayEnd = day.add(1, 'day').startOf('day');
 
@@ -86,7 +131,7 @@ export function computeForbiddenIntervalsForDay(day: dayjs.Dayjs, restrictions: 
         return [{ start: dayStart, end: dayEnd }];
     }
 
-    const allowed = computeAllowedIntervalsForDay(day, restrictions);
+    const allowed = computeAllowedIntervalsForDay(day, restrictions, sunrise);
     if (allowed.length === 0) return [{ start: dayStart, end: dayEnd }];
 
     const gaps: AllowedInterval[] = [];

--- a/api/scripts/disable-schedule.test.ts
+++ b/api/scripts/disable-schedule.test.ts
@@ -15,6 +15,7 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         allowedTimeWindows: null,
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
+        endBySunrise: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/scripts/enable-schedule.test.ts
+++ b/api/scripts/enable-schedule.test.ts
@@ -15,6 +15,7 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         allowedTimeWindows: null,
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
+        endBySunrise: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/scripts/seed.test.ts
+++ b/api/scripts/seed.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { describe, it, expect } from 'bun:test';
-import { zones } from '@/db/schema';
+import { schedules, zones } from '@/db/schema';
 import { computeInitialDepletionMm, seed, type SeedDb } from './seed';
 
 const SEEDS_DIR = path.resolve(import.meta.dir, '../data/seeds');
@@ -8,6 +8,8 @@ const SEEDS_DIR = path.resolve(import.meta.dir, '../data/seeds');
 function makeSeedDb() {
     const zoneConflictSets: Array<Record<string, unknown>> = [];
     const zoneInsertValues: Array<ReadonlyArray<Record<string, unknown>>> = [];
+    const scheduleConflictSets: Array<Record<string, unknown>> = [];
+    const scheduleInsertValues: Array<ReadonlyArray<Record<string, unknown>>> = [];
 
     const db: SeedDb = {
         insert: (table) => ({
@@ -16,6 +18,10 @@ function makeSeedDb() {
                     if (table === zones) {
                         zoneConflictSets.push(config.set as Record<string, unknown>);
                         zoneInsertValues.push(rows as ReadonlyArray<Record<string, unknown>>);
+                    }
+                    if (table === schedules) {
+                        scheduleConflictSets.push(config.set as Record<string, unknown>);
+                        scheduleInsertValues.push(rows as ReadonlyArray<Record<string, unknown>>);
                     }
                     return {
                         returning: async () =>
@@ -29,7 +35,7 @@ function makeSeedDb() {
         }),
     };
 
-    return { db, zoneConflictSets, zoneInsertValues };
+    return { db, zoneConflictSets, zoneInsertValues, scheduleConflictSets, scheduleInsertValues };
 }
 
 describe('computeInitialDepletionMm', () => {
@@ -80,5 +86,28 @@ describe('seed zone upsert', () => {
 
         expect(zoneConflictSets).toHaveLength(1);
         expect('currentDepletionMm' in zoneConflictSets[0]!).toBe(false);
+    });
+});
+
+describe('seed schedule upsert', () => {
+    it('includes endBySunrise in schedule insert values', async () => {
+        const { db, scheduleInsertValues } = makeSeedDb();
+
+        await seed({ db, dataDir: SEEDS_DIR });
+
+        const rows = scheduleInsertValues[0];
+        expect(rows).toBeDefined();
+        const maintenance = rows!.find(r => r['slug'] === 'maintenance');
+        expect(maintenance).toBeDefined();
+        expect(maintenance!['endBySunrise']).toBe(true);
+    });
+
+    it('does not include endBySunrise in the ON CONFLICT set (re-seed preserves operator edits)', async () => {
+        const { db, scheduleConflictSets } = makeSeedDb();
+
+        await seed({ db, dataDir: SEEDS_DIR });
+
+        expect(scheduleConflictSets).toHaveLength(1);
+        expect('endBySunrise' in scheduleConflictSets[0]!).toBe(false);
     });
 });

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -276,6 +276,7 @@ async function upsertSchedules(
             allowedTimeWindows: row.allowedTimeWindows,
             rootDepthMOverride: row.rootDepthMOverride,
             allowableDepletionFractionOverride: row.allowableDepletionFractionOverride,
+            endBySunrise: row.endBySunrise ?? null,
         };
     });
 


### PR DESCRIPTION
## Ticket

[API-30](http://192.168.2.100:7123/irrigo/browse/API-30/) Cap morning irrigation at sunrise via per-schedule endBySunrise flag

## Summary

- Adds a nullable `end_by_sunrise` boolean column to the `schedules` table (migration `0007`)
- When the flag is true, `computeAllowedIntervalsForDay` narrows morning windows to `[start, min(end, sunrise)]` before anchor selection and deconflict — no placed cycle can finish post-sunrise on the morning side
- Evening windows (start ≥ sunrise) are kept as-is
- Forbidden intervals are recomputed from the narrowed allowed intervals, so `deconflictCycles` treats the post-sunrise morning stretch as a busy window
- Daemon's `rePlan` forwards `endBySunrise` from the active schedule into planner restrictions
- `api/data/seeds/schedules.json` Maintenance row gains `"endBySunrise": true`; `upsertSchedules` includes the field in inserts but omits it from the ON CONFLICT set (preserves operator edits on re-seed)