### PR TITLE
[API-36] Reschedule past-dated cycles to the next available slot

### DIFF
--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1933,10 +1933,16 @@ describe('start', () => {
             await control.rePlan();
 
             expect(calls).toHaveLength(2);
-            expect(calls[0]).toEqual({ zoneId: 'zone-A', busyWindows: [] });
+            // zone-A receives only the past window (no cross-zone windows yet).
+            expect(calls[0]?.zoneId).toBe('zone-A');
+            const zoneAWindows = calls[0]!.busyWindows.filter(w => w.start.getTime() > 0);
+            expect(zoneAWindows).toHaveLength(0);
+
+            // zone-B receives the past window + zone-A's placed cycle.
             expect(calls[1]?.zoneId).toBe('zone-B');
-            expect(calls[1]?.busyWindows).toHaveLength(1);
-            const zoneABusy = calls[1]!.busyWindows[0]!;
+            const zoneBCrossWindows = calls[1]!.busyWindows.filter(w => w.start.getTime() > 0);
+            expect(zoneBCrossWindows).toHaveLength(1);
+            const zoneABusy = zoneBCrossWindows[0]!;
             expect(zoneABusy.start.toISOString()).toBe('2026-05-04T05:00:00.000Z');
             expect(zoneABusy.end.toISOString()).toBe('2026-05-04T05:30:00.000Z');
         });
@@ -1969,8 +1975,10 @@ describe('start', () => {
 
             await control.rePlan();
 
-            expect(calls.map(c => c.busyWindows.length)).toEqual([0, 1, 2]);
-            const zoneCBusy = calls[2]!.busyWindows;
+            // Each call includes the past window + cross-zone windows accumulated so far.
+            const crossZoneCounts = calls.map(c => c.busyWindows.filter(w => w.start.getTime() > 0).length);
+            expect(crossZoneCounts).toEqual([0, 1, 2]);
+            const zoneCBusy = calls[2]!.busyWindows.filter(w => w.start.getTime() > 0);
             expect(zoneCBusy[0]?.start.toISOString()).toBe('2026-05-04T05:00:00.000Z');
             expect(zoneCBusy[0]?.end.toISOString()).toBe('2026-05-04T05:20:00.000Z');
             expect(zoneCBusy[1]?.start.toISOString()).toBe('2026-05-04T05:30:00.000Z');
@@ -2010,9 +2018,10 @@ describe('start', () => {
             await control.rePlan();
 
             expect(calls.map(c => c.zoneId)).toEqual(['zone-A', 'zone-bad', 'zone-C']);
-            // zone-C must see only zone-A's window — not the failed zone's.
-            expect(calls[2]?.busyWindows).toHaveLength(1);
-            expect(calls[2]?.busyWindows[0]?.start.toISOString()).toBe('2026-05-04T05:00:00.000Z');
+            // zone-C must see only zone-A's cross-zone window — not the failed zone's.
+            const zoneCCrossWindows = calls[2]!.busyWindows.filter(w => w.start.getTime() > 0);
+            expect(zoneCCrossWindows).toHaveLength(1);
+            expect(zoneCCrossWindows[0]?.start.toISOString()).toBe('2026-05-04T05:00:00.000Z');
         });
 
         it('includes in-flight cycle windows in the initial busy set passed to each zone\'s planner', async () => {
@@ -2111,6 +2120,75 @@ describe('start', () => {
             } finally {
                 warnSpy.mockRestore();
             }
+        });
+
+        it('always includes a past-covering busy window (epoch → now) in the set passed to each zone\'s planner', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-A' } });
+            const { db } = createDaemonDbStub({ enabledZones: [enabledRow] });
+            const { clock } = createFakeClock(NOW);
+            let receivedBusyWindows: ReadonlyArray<{ start: Date; end: Date }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    receivedBusyWindows = [...(opts?.busyWindows ?? [])];
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            const pastWindow = receivedBusyWindows.find(w => w.start.getTime() === 0);
+            expect(pastWindow).toBeDefined();
+            expect(pastWindow!.end.toISOString()).toBe(NOW.toISOString());
+        });
+    });
+
+    describe('past-dated cycle rescheduling', () => {
+        it('persists planner output even when a returned cycle has a past start time — rescheduling is the planner\'s job', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded', name: 'Loaded Zone' } });
+            const { db, inserts } = createDaemonDbStub({ enabledZones: [enabledRow] });
+            const { clock } = createFakeClock(NOW);
+            // Cycle startTime is 2 hours before NOW — the daemon must not filter it;
+            // the planner (given pastWindow) is responsible for shifting it to the future.
+            const pastEntry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T10:00:00Z', durationMin: 30 }]);
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [pastEntry], projectedNextDepletionMm: 0 }),
+                openZone: async () => {},
+                closeZone: async () => {},
+            });
+
+            await control.rePlan();
+
+            expect(inserts.filter(c => c.table === scheduleEntries)).toHaveLength(1);
+            expect(inserts.filter(c => c.table === irrigationCycles)).toHaveLength(1);
+        });
+
+        it('does not open a zone when the planner returns no entries (all slots past)', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded' } });
+            const { db } = createDaemonDbStub({ enabledZones: [enabledRow] });
+            const { clock, advanceTo } = createFakeClock(NOW);
+            const opens: string[] = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+                openZone: async (z) => { opens.push(z.id); },
+                closeZone: async () => {},
+            });
+
+            await control.rePlan();
+            await advanceTo(new Date('2026-05-04T20:00:00.000Z'));
+
+            expect(opens).toHaveLength(0);
         });
     });
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -167,6 +167,9 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         const now = clock.now();
         const busyWindows: Array<{ start: Date; end: Date }> = registry.snapshotInFlight()
             .map(({ endTime }) => ({ start: now, end: endTime }));
+        // Sentinel covering the entire past so deconflictCycles shifts any
+        // cycle whose planned start has already passed to fire at or after now.
+        const pastWindow: { start: Date; end: Date } = { start: new Date(0), end: now };
 
         for (const zone of enabledZones) {
             const activeSchedule = activeSchedulesBySite.get(zone.siteId);
@@ -185,7 +188,11 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                     rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,
                     allowableDepletionFraction: activeSchedule.allowableDepletionFractionOverride ?? undefined,
                 };
-                const { entries, projectedNextDepletionMm } = await runPlan(zone, { busyWindows, restrictions, overrides });
+                const { entries, projectedNextDepletionMm } = await runPlan(zone, {
+                    busyWindows: [pastWindow, ...busyWindows],
+                    restrictions,
+                    overrides,
+                });
                 const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm, activeSchedule.id);
                 for (const cycle of cycles) {
                     const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1521,4 +1521,100 @@ describe('planZoneSchedule', () => {
             expect(maintenanceFire.appliedDepthMm).toBeGreaterThan(overseedingFire.appliedDepthMm * 3);
         });
     });
+
+    describe('past-window deconfliction', () => {
+        // Simulates the daemon passing { start: epoch, end: now } as a busy window
+        // so that past-dated cycles are shifted forward to fire after now.
+
+        const NOW = dayjs('2026-05-04T14:00:00.000Z');
+        const PAST_WINDOW = { start: dayjs(new Date(0)), end: NOW };
+
+        function pastWindowZone() {
+            // Single-cycle zone: high infiltration → no cycle splitting.
+            // currentDepletionMm=22 plus ET=0.85 pushes over RAW (22.5 mm) on day 0.
+            return createTestZone({
+                currentDepletionMm: 22,
+                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+                precipitationRateMmPerHr: 50,
+            });
+        }
+
+        function multiCycleZone() {
+            // Clay soil (infiltration 4 mm/hr) forces 3 cycles.
+            // currentDepletionMm=8 plus ET=0.85 pushes over RAW (8 mm) on day 0.
+            return createTestZone({
+                currentDepletionMm: 8,
+                allowableDepletionFraction: 0.5,
+                rootDepthM: 0.08,
+                soil: SOIL_TYPES.clay,
+                precipitationRateMmPerHr: 9,
+            });
+        }
+
+        function weatherDay(sunriseHour = 6) {
+            return createWeatherDays(
+                [{ evapotranspirationMmPerDay: 1.0, rainfallMm: 0 }],
+                dayjs('2026-05-04'),
+            ).map(day => ({
+                ...day,
+                sunrise: dayjs('2026-05-04').hour(sunriseHour).minute(0).second(0).millisecond(0),
+            }));
+        }
+
+        it('shifts a single past-dated cycle to start at or after now when there is no time window restriction', () => {
+            const zone = pastWindowZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(zone, weather, [PAST_WINDOW]);
+
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(NOW.valueOf());
+        });
+
+        it('shifts all cycles in a multi-cycle plan to start sequentially after now', () => {
+            const zone = multiCycleZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(zone, weather, [PAST_WINDOW]);
+
+            expect(entries).toHaveLength(1);
+            const cycles = entries[0]!.cycles;
+            expect(cycles.length).toBeGreaterThan(1);
+            for (const cycle of cycles) {
+                expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(NOW.valueOf());
+            }
+        });
+
+        it('drops the day when all remaining allowed windows have closed', () => {
+            // Window is 00:00–10:00; now = 14:00 → past window pushes cycle to 14:00
+            // which is outside the window, so cyclesFitAllowed fails and the day is dropped.
+            const zone = pastWindowZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(zone, weather, [PAST_WINDOW], {
+                allowedDays: null,
+                allowedTimeWindows: [{ start: '00:00', end: '10:00' }],
+            });
+
+            expect(entries).toHaveLength(0);
+        });
+
+        it('places a cycle within the remaining window when today\'s window is still open', () => {
+            // Window is 00:00–23:59; now = 09:00 → past window pushes cycle to 09:00
+            // which fits within the window.
+            const NOW_09 = dayjs('2026-05-04T09:00:00.000Z');
+            const zone = pastWindowZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(zone, weather, [{ start: dayjs(new Date(0)), end: NOW_09 }], {
+                allowedDays: null,
+                allowedTimeWindows: [{ start: '00:00', end: '23:59' }],
+            });
+
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(NOW_09.valueOf());
+        });
+    });
 });


### PR DESCRIPTION
## Ticket

[API-36](http://192.168.2.100:7123/irrigo/browse/API-36/) Scheduler should discard cycles that fall before the allowed time window or current time

## Summary

- In `rePlan`, prepend a sentinel busy window `{ start: epoch, end: now }` to the `busyWindows` passed to each zone's planner. The existing `deconflictCycles` logic shifts any cycle whose planned start has already passed to fire at or after `now`.
- Cycles pushed past a closed time window (e.g., the window was 00:00–10:00 and it's now 14:00) are correctly dropped by the existing `cyclesFitAllowed` guard — irrigation picks up on the next allowed day.
- Updated 3 cross-zone deconfliction tests to account for the always-present past window; added 7 new tests covering the rescheduling behavior at both the daemon and planner levels.