### PR TITLE
[API-38] Configure weather integration via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,15 @@ HA_TOKEN=
 # NOTIFY_ON_WATERING_END=false
 # NOTIFY_ON_ERROR=true
 
+# --- Open-Meteo (optional) ---
+# Set to false to disable weather API calls entirely (e.g. offline dev). Default: true.
+# OPEN_METEO_ENABLED=true
+
+# Commercial API key from open-meteo.com. When set, requests are routed to
+# customer-api.open-meteo.com with the key appended as `apikey=<value>`.
+# When unset, the free-tier endpoint is used (no key required).
+# OPEN_METEO_API_KEY=
+
 # --- Postgres (optional; defaults work for the bundled `db` container) ---
 # POSTGRES_USER=postgres
 # POSTGRES_PASSWORD=postgres

--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { getWeatherData } from '.';
 
 // Mock the global fetch function.
@@ -30,6 +30,11 @@ describe('Weather Data', () => {
 
     beforeEach(() => {
         mockFetch.mockClear();
+    });
+
+    afterEach(() => {
+        delete process.env.OPEN_METEO_ENABLED;
+        delete process.env.OPEN_METEO_API_KEY;
     });
 
     it('should fetch weather data with correct URL parameters', async () => {
@@ -198,6 +203,44 @@ describe('Weather Data', () => {
                 longitude: 13.41,
             })
         ).rejects.toThrow();
+    });
+
+    it('throws when OPEN_METEO_ENABLED is false', async () => {
+        process.env.OPEN_METEO_ENABLED = 'false';
+
+        await expect(
+            getWeatherData({ latitude: 52.52, longitude: 13.41 })
+        ).rejects.toThrow('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('uses commercial endpoint and appends apikey when OPEN_METEO_API_KEY is set', async () => {
+        process.env.OPEN_METEO_API_KEY = 'test-key';
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockWeatherResponse,
+        } as Response);
+
+        await getWeatherData({ latitude: 52.52, longitude: 13.41 });
+
+        const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
+        expect(calledUrl.hostname).toBe('customer-api.open-meteo.com');
+        expect(calledUrl.searchParams.get('apikey')).toBe('test-key');
+    });
+
+    it('does not send apikey param on free-tier requests', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockWeatherResponse,
+        } as Response);
+
+        await getWeatherData({ latitude: 52.52, longitude: 13.41 });
+
+        const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
+        expect(calledUrl.hostname).toBe('api.open-meteo.com');
+        expect(calledUrl.searchParams.get('apikey')).toBeNull();
     });
 
     it('should throw error when API returns non-JSON response', async () => {

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -43,14 +43,25 @@ export type WeatherDataParams = {
  * @throws Error if the API request fails
  */
 export async function getWeatherData(params: WeatherDataParams): Promise<DailyWeather[]> {
+    if (process.env.OPEN_METEO_ENABLED === 'false') {
+        throw new Error('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
+    }
+
     const { latitude, longitude, forecastDays = 7 } = params;
+    const apiKey = process.env.OPEN_METEO_API_KEY || undefined;
+    const baseUrl = apiKey
+        ? 'https://customer-api.open-meteo.com/v1/forecast'
+        : 'https://api.open-meteo.com/v1/forecast';
 
     // Construct the API URL with required parameters.
-    const url = new URL('https://api.open-meteo.com/v1/forecast');
+    const url = new URL(baseUrl);
     url.searchParams.set('latitude', latitude.toString());
     url.searchParams.set('longitude', longitude.toString());
     url.searchParams.set('daily', 'sunrise,rain_sum,et0_fao_evapotranspiration');
     url.searchParams.set('forecast_days', forecastDays.toString());
+    if (apiKey) {
+        url.searchParams.set('apikey', apiKey);
+    }
 
     // Make the API request.
     const response = await fetch(url.toString());


### PR DESCRIPTION
## Ticket

[API-38](http://192.168.2.100:7123/irrigo/browse/API-38/) Configure weather integration via environment variables

## Summary

- `getWeatherData()` now reads `OPEN_METEO_ENABLED` at call time — when set to `false`, it throws immediately so the daemon's per-zone error handler catches it without hitting the network
- When `OPEN_METEO_API_KEY` is set, requests are routed to `customer-api.open-meteo.com` with the key appended as `?apikey=<value>`; the free-tier endpoint is used otherwise
- Both vars documented in `.env.example`