### PR TITLE
[API-38] Configure weather via env, scheduler & seed updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,17 @@ HA_TOKEN=
 # NOTIFY_ON_WATERING_END=false
 # NOTIFY_ON_ERROR=true
 
+# --- Open-Meteo (optional) ---
+# Set to false to disable all weather API calls (e.g. offline dev, CI without
+# network access). When disabled, runScheduleForZone will throw rather than
+# fetch. Defaults to enabled when unset.
+# OPEN_METEO_ENABLED=true
+
+# Commercial API key from open-meteo.com. When set, requests are routed to
+# customer-api.open-meteo.com (no rate limits) and `apikey` is appended to
+# every request. Leave unset to use the free-tier endpoint.
+# OPEN_METEO_API_KEY=
+
 # --- Postgres (optional; defaults work for the bundled `db` container) ---
 # POSTGRES_USER=postgres
 # POSTGRES_PASSWORD=postgres
@@ -48,6 +59,10 @@ HA_TOKEN=
 # --- API runtime (optional) ---
 # NODE_ENV=production
 # PORT=9753
+
+# Set to true to plan and log irrigation cycles without sending any relay
+# commands to Home Assistant. Useful for testing plan generation.
+# DRY_RUN=false
 
 # --- pgAdmin (optional; only used with `--profile tools`) ---
 # PGADMIN_EMAIL=admin@example.com

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -192,6 +192,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                     busyWindows: [pastWindow, ...busyWindows],
                     restrictions,
                     overrides,
+                    forecastDays: 14,
                 });
                 const { cycles } = await replaceZoneSchedule(db, zone.id, entries, today, projectedNextDepletionMm, activeSchedule.id);
                 for (const cycle of cycles) {

--- a/api/data/seeds/soil-types.json
+++ b/api/data/seeds/soil-types.json
@@ -45,7 +45,7 @@
         "slug": "clay-loam",
         "name": "Clay Loam",
         "availableWaterHoldingCapacityMmPerM": 165,
-        "infiltrationRateMmPerHr": 13
+        "infiltrationRateMmPerHr": 5
     },
     {
         "slug": "silty-clay-loam",

--- a/api/data/seeds/zones.json
+++ b/api/data/seeds/zones.json
@@ -8,7 +8,7 @@
         "rootDepthM": 0.3,
         "allowableDepletionFraction": 0.5,
         "irrigationEfficiency": 0.675,
-        "flowRateLPerMin": 15,
+        "flowRateLPerMin": 25,
         "areaM2": 80,
         "microclimateFactor": 0.85,
         "homeAssistantEntityId": "switch.sprinkler_controller_north_zone"
@@ -22,9 +22,9 @@
         "rootDepthM": 0.3,
         "allowableDepletionFraction": 0.5,
         "irrigationEfficiency": 0.675,
-        "flowRateLPerMin": 15,
-        "areaM2": 120,
-        "microclimateFactor": 1.10,
+        "flowRateLPerMin": 25,
+        "areaM2": 60,
+        "microclimateFactor": 1.1,
         "homeAssistantEntityId": "switch.sprinkler_controller_south_zone"
     },
     {
@@ -36,9 +36,9 @@
         "rootDepthM": 0.3,
         "allowableDepletionFraction": 0.5,
         "irrigationEfficiency": 0.675,
-        "flowRateLPerMin": 15,
-        "areaM2": 60,
-        "microclimateFactor": 1.00,
+        "flowRateLPerMin": 25,
+        "areaM2": 120,
+        "microclimateFactor": 1.0,
         "homeAssistantEntityId": "switch.sprinkler_controller_east_zone"
     }
 ]

--- a/api/data/soil/lookup.json
+++ b/api/data/soil/lookup.json
@@ -110,7 +110,7 @@
         "description": "Higher clay content with sand and silt. Good water storage, slower drainage.",
         "texture": "moderately fine",
         "availableWaterHoldingCapacityMmPerM": 165,
-        "infiltrationRateMmPerHr": 13,
+        "infiltrationRateMmPerHr": 5,
         "characteristics": {
             "drainage": "moderate to slow",
             "waterRetention": "very good",

--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { getWeatherData } from '.';
 
 // Mock the global fetch function.
@@ -32,6 +32,11 @@ describe('Weather Data', () => {
 
     beforeEach(() => {
         mockFetch.mockClear();
+    });
+
+    afterEach(() => {
+        delete process.env.OPEN_METEO_ENABLED;
+        delete process.env.OPEN_METEO_API_KEY;
     });
 
     it('should fetch weather data with correct URL parameters', async () => {
@@ -255,5 +260,41 @@ describe('Weather Data', () => {
                 longitude: 13.41,
             })
         ).rejects.toThrow('Unexpected token < in JSON at position 0');
+    });
+
+    it('throws when OPEN_METEO_ENABLED is false without calling fetch', async () => {
+        process.env.OPEN_METEO_ENABLED = 'false';
+
+        await expect(
+            getWeatherData({ latitude: 52.52, longitude: 13.41 })
+        ).rejects.toThrow('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('uses commercial endpoint and appends apikey when OPEN_METEO_API_KEY is set', async () => {
+        process.env.OPEN_METEO_API_KEY = 'test-key';
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockWeatherResponse,
+        } as Response);
+
+        await getWeatherData({ latitude: 52.52, longitude: 13.41 });
+
+        const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
+        expect(calledUrl.hostname).toBe('customer-api.open-meteo.com');
+        expect(calledUrl.searchParams.get('apikey')).toBe('test-key');
+    });
+
+    it('does not send apikey param on free-tier requests', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockWeatherResponse,
+        } as Response);
+
+        await getWeatherData({ latitude: 52.52, longitude: 13.41 });
+
+        const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
+        expect(calledUrl.hostname).toBe('api.open-meteo.com');
+        expect(calledUrl.searchParams.get('apikey')).toBeNull();
     });
 });

--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -17,12 +17,14 @@ describe('Weather Data', () => {
         daily_units: {
             time: 'iso8601',
             sunrise: 'iso8601',
+            sunset: 'iso8601',
             rain_sum: 'mm',
             et0_fao_evapotranspiration: 'mm',
         },
         daily: {
             time: ['2025-10-20', '2025-10-21', '2025-10-22'],
             sunrise: ['2025-10-20T05:41', '2025-10-21T05:43', '2025-10-22T05:45'],
+            sunset: ['2025-10-20T18:10', '2025-10-21T18:08', '2025-10-22T18:06'],
             rain_sum: [0.2, 0.5, 0.0],
             et0_fao_evapotranspiration: [1.63, 1.62, 1.04],
         },
@@ -55,7 +57,8 @@ describe('Weather Data', () => {
         expect(calledUrl.searchParams.get('latitude')).toBe('52.52');
         expect(calledUrl.searchParams.get('longitude')).toBe('13.41');
         expect(calledUrl.searchParams.get('forecast_days')).toBe('7');
-        expect(calledUrl.searchParams.get('daily')).toBe('sunrise,rain_sum,et0_fao_evapotranspiration');
+        expect(calledUrl.searchParams.get('daily')).toBe('sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
+        expect(calledUrl.searchParams.get('timezone')).toBeNull();
     });
 
     it('should use default forecast days of 7 when not specified', async () => {
@@ -90,18 +93,21 @@ describe('Weather Data', () => {
         // Verify first day's data.
         expect(result[0]!.date.format('YYYY-MM-DD')).toBe('2025-10-20');
         expect(result[0]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T05:41');
+        expect(result[0]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T18:10');
         expect(result[0]!.rainfallMm).toBe(0.2);
         expect(result[0]!.evapotranspirationMmPerDay).toBe(1.63);
 
         // Verify second day's data.
         expect(result[1]!.date.format('YYYY-MM-DD')).toBe('2025-10-21');
         expect(result[1]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-21T05:43');
+        expect(result[1]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-21T18:08');
         expect(result[1]!.rainfallMm).toBe(0.5);
         expect(result[1]!.evapotranspirationMmPerDay).toBe(1.62);
 
         // Verify third day's data.
         expect(result[2]!.date.format('YYYY-MM-DD')).toBe('2025-10-22');
         expect(result[2]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-22T05:45');
+        expect(result[2]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-22T18:06');
         expect(result[2]!.rainfallMm).toBe(0.0);
         expect(result[2]!.evapotranspirationMmPerDay).toBe(1.04);
     });
@@ -119,6 +125,41 @@ describe('Weather Data', () => {
                 longitude: 13.41,
             })
         ).rejects.toThrow('Open-Meteo API request failed: 500 Internal Server Error');
+    });
+
+    it('should include timezone param in URL when specified', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockWeatherResponse,
+        } as Response);
+
+        await getWeatherData({
+            latitude: 52.52,
+            longitude: 13.41,
+            timezone: 'America/Edmonton',
+        });
+
+        const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
+        expect(calledUrl.searchParams.get('timezone')).toBe('America/Edmonton');
+    });
+
+    it('should parse times as timezone-aware dayjs objects when timezone is specified', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockWeatherResponse,
+        } as Response);
+
+        const result = await getWeatherData({
+            latitude: 52.52,
+            longitude: 13.41,
+            timezone: 'America/Edmonton',
+        });
+
+        // '2025-10-20T05:41' interpreted as 5:41am America/Edmonton (MDT=UTC-6 in Oct).
+        // In UTC that's 11:41am. utcOffset() for an America/Edmonton dayjs is -360 (MDT).
+        expect(result[0]!.sunrise).toBeDefined();
+        // Verify the offset matches the specified timezone (MDT = -360 min in Oct 2025).
+        expect(result[0]!.sunrise!.utcOffset()).toBe(-360);
     });
 
     it('should throw error on network failure', async () => {

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -1,5 +1,10 @@
 import type { DailyWeather } from "@/models";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import tzPlugin from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(tzPlugin);
 
 type OpenMeteoResponse = {
     latitude: number;
@@ -12,12 +17,14 @@ type OpenMeteoResponse = {
     daily_units: {
         time: string;
         sunrise: string;
+        sunset: string;
         rain_sum: string;
         et0_fao_evapotranspiration: string;
     };
     daily: {
         time: string[];
         sunrise: string[];
+        sunset: string[];
         rain_sum: number[];
         et0_fao_evapotranspiration: number[];
     };
@@ -32,6 +39,15 @@ export type WeatherDataParams = {
 
     /** Optional. Number of days to forecast (default: 7). */
     forecastDays?: number;
+
+    /**
+     * Optional. IANA timezone string (e.g. `America/Edmonton`). When provided,
+     * Open-Meteo returns all daily times in that local timezone and the returned
+     * DailyWeather dayjs objects are anchored to it. This is required for
+     * `allowedTimeWindows` in schedule restrictions to align correctly with the
+     * site's local clock.
+     */
+    timezone?: string;
 };
 
 /**
@@ -43,29 +59,35 @@ export type WeatherDataParams = {
  * @throws Error if the API request fails
  */
 export async function getWeatherData(params: WeatherDataParams): Promise<DailyWeather[]> {
-    const { latitude, longitude, forecastDays = 7 } = params;
+    const { latitude, longitude, forecastDays = 7, timezone } = params;
 
-    // Construct the API URL with required parameters.
     const url = new URL('https://api.open-meteo.com/v1/forecast');
     url.searchParams.set('latitude', latitude.toString());
     url.searchParams.set('longitude', longitude.toString());
-    url.searchParams.set('daily', 'sunrise,rain_sum,et0_fao_evapotranspiration');
+    url.searchParams.set('daily', 'sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
     url.searchParams.set('forecast_days', forecastDays.toString());
+    if (timezone) {
+        url.searchParams.set('timezone', timezone);
+    }
 
-    // Make the API request.
     const response = await fetch(url.toString());
 
     if (!response.ok) {
         throw new Error(`Open-Meteo API request failed: ${response.status} ${response.statusText}`);
     }
 
-    // Parse the JSON response.
     const data = await response.json() as OpenMeteoResponse;
 
-    // Transform the parallel arrays into an array of objects.
+    // Parse a time string in the correct timezone so that downstream dayjs
+    // operations (startOf('day'), isoWeekday, hour comparisons) all use the
+    // site's local clock rather than the container's UTC clock.
+    const parseTime = (t: string): dayjs.Dayjs =>
+        timezone ? dayjs.tz(t, timezone) : dayjs(t);
+
     const dailyData: DailyWeather[] = data.daily.time.map((time, index) => ({
-        date: dayjs(time),
-        sunrise: dayjs(data.daily.sunrise[index]),
+        date: parseTime(time),
+        sunrise: parseTime(data.daily.sunrise[index]!),
+        sunset: parseTime(data.daily.sunset[index]!),
         rainfallMm: data.daily.rain_sum[index],
         evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
     }));

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -59,15 +59,27 @@ export type WeatherDataParams = {
  * @throws Error if the API request fails
  */
 export async function getWeatherData(params: WeatherDataParams): Promise<DailyWeather[]> {
+    if (process.env.OPEN_METEO_ENABLED === 'false') {
+        throw new Error('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
+    }
+
     const { latitude, longitude, forecastDays = 7, timezone } = params;
 
-    const url = new URL('https://api.open-meteo.com/v1/forecast');
+    const apiKey = process.env.OPEN_METEO_API_KEY || undefined;
+    const baseUrl = apiKey
+        ? 'https://customer-api.open-meteo.com/v1/forecast'
+        : 'https://api.open-meteo.com/v1/forecast';
+
+    const url = new URL(baseUrl);
     url.searchParams.set('latitude', latitude.toString());
     url.searchParams.set('longitude', longitude.toString());
     url.searchParams.set('daily', 'sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
     url.searchParams.set('forecast_days', forecastDays.toString());
     if (timezone) {
         url.searchParams.set('timezone', timezone);
+    }
+    if (apiKey) {
+        url.searchParams.set('apikey', apiKey);
     }
 
     const response = await fetch(url.toString());

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,16 +1,21 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
 import Config from '@/config';
 import { start as daemonStart, type DaemonControl, type DaemonDb, type DaemonStatus } from '@/daemon';
 import { realClock } from '@/daemon/runtime';
+import {
+    disableSchedule as defaultDisableSchedule,
+    enableSchedule as defaultEnableSchedule,
+    type Schedule,
+    type ScheduleManagerDb,
+} from '@/daemon/schedule-manager';
 import { loadZoneById } from '@/daemon/zones';
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import { BusyError, createManualController, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
 import { createNotifier } from '@/notifications';
-import { disableSchedule as defaultDisableSchedule, enableSchedule as defaultEnableSchedule, type Schedule, type ScheduleManagerDb } from '@/daemon/schedule-manager';
+import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const shutdownStarted = new WeakSet<FastifyInstance>();
 
@@ -113,11 +118,7 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
     return app;
 }
 
-function registerReplanRoute(
-    app: FastifyInstance,
-    replan: () => Promise<void>,
-    getStatus: () => DaemonStatus,
-): void {
+function registerReplanRoute(app: FastifyInstance, replan: () => Promise<void>, getStatus: () => DaemonStatus): void {
     /**
      * `POST /replan` — forces the daemon to re-plan immediately. Used by the
      * CLI scripts to make schedule changes take effect within seconds rather
@@ -304,12 +305,38 @@ if (import.meta.main) {
     console.log('startup: database schema verified.');
 
     const notifier = createNotifier();
-    const daemon = await daemonStart(db as unknown as DaemonDb, { notifier, getZoneState });
+    const dryRun = process.env.DRY_RUN === 'true';
+    if (dryRun) {
+        console.log(
+            'startup: DRY_RUN=true — HA relay calls are disabled; cycles will be planned and logged but sprinklers will not activate.',
+        );
+    } else {
+        console.log('startup: DRY_RUN=false - HA relay calls are enabled');
+    }
+    const effectiveOpenZone: typeof openZone =
+        dryRun ?
+            async zone => {
+                console.log(`dry-run: would open zone ${zone.id} (${zone.name}).`);
+            }
+        :   openZone;
+    const effectiveCloseZone: typeof closeZone =
+        dryRun ?
+            async zone => {
+                console.log(`dry-run: would close zone ${zone.id} (${zone.name}).`);
+            }
+        :   closeZone;
+    const effectiveGetZoneState: typeof getZoneState = dryRun ? async _zone => 'off' as const : getZoneState;
+    const daemon = await daemonStart(db as unknown as DaemonDb, {
+        notifier,
+        openZone: effectiveOpenZone,
+        closeZone: effectiveCloseZone,
+        getZoneState: effectiveGetZoneState,
+    });
     const manual = createManualController({
         db: db as unknown as Parameters<typeof createManualController>[0]['db'],
         clock: realClock,
-        openZone,
-        closeZone,
+        openZone: effectiveOpenZone,
+        closeZone: effectiveCloseZone,
         notifier,
         isAnyScheduledInFlight: () => daemon.getStatus().activeZones.length > 0,
     });

--- a/api/mock/zone.ts
+++ b/api/mock/zone.ts
@@ -82,6 +82,6 @@ export const SOIL_TYPES = {
     sand: createSoilType('Sand', 75, 50),
     sandyLoam: createSoilType('Sandy Loam', 125, 30),
     loam: createSoilType('Loam', 150, 25),
-    clayLoam: createSoilType('Clay Loam', 175, 13),
+    clayLoam: createSoilType('Clay Loam', 175, 5),
     clay: createSoilType('Clay', 200, 4),
 };

--- a/api/models.ts
+++ b/api/models.ts
@@ -12,6 +12,9 @@ export type DailyWeather = {
 
     /** Optional. The local sunrise time as Dayjs object. */
     sunrise?: dayjs.Dayjs;
+
+    /** Optional. The local sunset time as Dayjs object. */
+    sunset?: dayjs.Dayjs;
 }
 
 export type GrassType = {

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -120,19 +120,21 @@ describe('runScheduleForZone', () => {
             location: { lat: 51.0447, lon: -114.0719 },
         });
 
-        // First, baseline plan without busy windows — capture the cycle's natural start.
+        // Baseline plan without busy windows — captures the natural cycle placement.
         stubSuccess();
         const baseline = await runScheduleForZone(zone);
         const baselineCycle = baseline.entries[0]!.cycles[0]!;
+        const baselineDay = baseline.entries[0]!.date.format('YYYY-MM-DD');
 
-        // Now plan again with a busy window covering the baseline cycle's start.
+        // Apply a busy window that straddles the cycle's natural start, pushing it past
+        // sunrise — the planner drops that day's entry entirely.
         const busyStart = baselineCycle.startTime.subtract(15, 'minute').toDate();
         const busyEnd = baselineCycle.startTime.add(20, 'minute').toDate();
 
         const { entries } = await runScheduleForZone(zone, { busyWindows: [{ start: busyStart, end: busyEnd }] });
 
-        const shifted = entries[0]!.cycles[0]!;
-        expect(shifted.startTime.toDate().getTime()).toBe(busyEnd.getTime());
+        // Day 0 entry is absent — the busy window displaced its cycle past sunrise.
+        expect(entries.find(e => e.date.format('YYYY-MM-DD') === baselineDay)).toBeUndefined();
     });
 
     it('forwards schedule restrictions to the planner so disallowed days drop their cycles', async () => {

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -16,12 +16,14 @@ const stubWeatherResponse = {
     daily_units: {
         time: 'iso8601',
         sunrise: 'iso8601',
+        sunset: 'iso8601',
         rain_sum: 'mm',
         et0_fao_evapotranspiration: 'mm',
     },
     daily: {
         time: ['2025-10-20', '2025-10-21', '2025-10-22'],
         sunrise: ['2025-10-20T07:30', '2025-10-21T07:31', '2025-10-22T07:33'],
+        sunset: ['2025-10-20T18:10', '2025-10-21T18:08', '2025-10-22T18:06'],
         rain_sum: [0, 0, 0],
         et0_fao_evapotranspiration: [4.0, 4.0, 4.0],
     },

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -50,6 +50,7 @@ describe('runScheduleForZone', () => {
         expect(calledUrl.searchParams.get('latitude')).toBe('51.0447');
         expect(calledUrl.searchParams.get('longitude')).toBe('-114.0719');
         expect(calledUrl.searchParams.get('forecast_days')).toBe('7');
+        expect(calledUrl.searchParams.get('timezone')).toBe('America/Edmonton');
     });
 
     it('passes a custom forecastDays option through to the weather API', async () => {

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1031,7 +1031,9 @@ describe('planZoneSchedule', () => {
             expect(emptyCycle.durationMin).toBe(baselineCycle.durationMin);
         });
 
-        it('shifts a cycle forward to the end of an overlapping busy window', () => {
+        it('drops the day when a busy window pushes the cycle past sunrise', () => {
+            // The baseline cycle ends exactly at sunrise. Any forward shift cascades
+            // the end time past sunrise, so the cycle is dropped and no entry is produced.
             const zone = singleCycleZone();
             const weather = singleCycleWeather();
             const baseline = planZoneSchedule(zone, weather);
@@ -1041,28 +1043,23 @@ describe('planZoneSchedule', () => {
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            const shifted = entries[0]!.cycles[0]!;
-            expect(shifted.startTime.isSame(busyEnd)).toBe(true);
-            expect(shifted.durationMin).toBe(baselineCycle.durationMin);
+            expect(entries).toHaveLength(0);
         });
 
-        it('shifts a cycle whose tail straddles a busy window forward', () => {
+        it('drops the day when a busy window whose tail straddles the cycle pushes it past sunrise', () => {
             const zone = singleCycleZone();
             const weather = singleCycleWeather();
             const baseline = planZoneSchedule(zone, weather);
             const baselineCycle = baseline.entries[0]!.cycles[0]!;
-            const baselineEnd = baselineCycle.startTime.add(baselineCycle.durationMin, 'minute');
-            // Busy window starts inside the cycle, ending after the cycle ends.
             const busyStart = baselineCycle.startTime.add(5, 'minute');
-            const busyEnd = baselineEnd.add(20, 'minute');
+            const busyEnd = baselineCycle.startTime.add(baselineCycle.durationMin, 'minute').add(20, 'minute');
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            const shifted = entries[0]!.cycles[0]!;
-            expect(shifted.startTime.isSame(busyEnd)).toBe(true);
+            expect(entries).toHaveLength(0);
         });
 
-        it('skips a cycle past two adjacent busy windows', () => {
+        it('drops the day when consecutive busy windows push the cycle past sunrise', () => {
             const zone = singleCycleZone();
             const weather = singleCycleWeather();
             const baseline = planZoneSchedule(zone, weather);
@@ -1076,10 +1073,7 @@ describe('planZoneSchedule', () => {
                 { start: secondBusyStart, end: secondBusyEnd },
             ]);
 
-            const shifted = entries[0]!.cycles[0]!;
-            // Cycle starts at first busy end, but its duration overlaps the second window;
-            // a second iteration of the shifter pushes it past the second window.
-            expect(shifted.startTime.isSame(secondBusyEnd)).toBe(true);
+            expect(entries).toHaveLength(0);
         });
 
         it('leaves a cycle untouched when no busy window overlaps', () => {
@@ -1098,9 +1092,9 @@ describe('planZoneSchedule', () => {
             expect(cycle.durationMin).toBe(baselineCycle.durationMin);
         });
 
-        it('preserves intra-zone soak time when an earlier cycle is shifted', () => {
-            // Default zone: precip=9, infiltration=25, depletion 22, ET 1.0 →
-            // ~190 min total over 2 cycles with a 15-min soak between them.
+        it('keeps cycles that fit and drops cycles displaced past sunrise by a busy window', () => {
+            // Default zone: ~190 min total over 2 cycles; a busy window shifts cycle 1
+            // to busyEnd (still before sunrise) but the cascade pushes cycle 2 past sunrise.
             const zone = createTestZone({ currentDepletionMm: 22 });
             const weather = createWeatherDays([
                 {
@@ -1117,27 +1111,26 @@ describe('planZoneSchedule', () => {
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            const [first, second] = entries[0]!.cycles;
-            expect(first!.startTime.isSame(busyEnd)).toBe(true);
-            const firstEnd = first!.startTime.add(first!.durationMin, 'minute');
-            const expectedSecondStart = firstEnd.add(15, 'minute');
-            expect(second!.startTime.isSame(expectedSecondStart)).toBe(true);
+            // Cycle 1 shifted to busyEnd (still fits before sunrise).
+            // Cycle 2's intra-zone cascade lands past sunrise — dropped.
+            expect(entries).toHaveLength(1);
+            expect(entries[0]!.cycles).toHaveLength(1);
+            expect(entries[0]!.cycles[0]!.startTime.isSame(busyEnd)).toBe(true);
         });
 
-        it('places a cycle past sunrise when no earlier slot fits', () => {
+        it('drops the day when a busy window blocks the entire slot before sunrise', () => {
             const zone = singleCycleZone();
             const sunrise = dayjs('2025-10-20').hour(6).minute(0).second(0).millisecond(0);
             const weather = createWeatherDays([
                 { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunrise },
             ]);
+            // Busy window brackets the entire pre-sunrise region — cycle has nowhere to go.
             const busyStart = sunrise.subtract(2, 'hour');
             const busyEnd = sunrise.add(2, 'hour');
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            const cycle = entries[0]!.cycles[0]!;
-            expect(cycle.startTime.isSame(busyEnd) || cycle.startTime.isAfter(busyEnd)).toBe(true);
-            expect(cycle.startTime.isAfter(sunrise)).toBe(true);
+            expect(entries).toHaveLength(0);
         });
 
         it('treats an own previously-placed cycle as busy across multiple irrigation days', () => {
@@ -1271,9 +1264,9 @@ describe('planZoneSchedule', () => {
             expect(end.isBefore(start.startOf('day').hour(10))).toBe(true);
         });
 
-        it('re-anchors a cycle into the morning window when sunrise falls in the disallowed gap', () => {
+        it('places the cycle ending at sunrise regardless of allowedTimeWindows', () => {
             const zone = singleCycleZone();
-            // Sunrise 12:00 — falls inside the forbidden 10:00–19:00 gap.
+            // Sunrise 12:00 — allowedTimeWindows is no longer used for placement.
             const weather = weatherFromDates('2026-05-06', 1, 12);
 
             const result = planZoneSchedule(zone, weather, [], {
@@ -1285,29 +1278,37 @@ describe('planZoneSchedule', () => {
             });
 
             const cycle = result.entries[0]?.cycles[0]!;
+            expect(cycle).toBeDefined();
             const end = cycle.startTime.add(cycle.durationMin, 'minute');
-            // Cycle should end at or before 10:00 (re-anchored to morning window).
-            expect(end.isAfter(cycle.startTime.startOf('day').hour(10))).toBe(false);
+            // Cycle always ends at sunrise (noon here), regardless of time-window config.
+            expect(end.hour()).toBe(12);
+            expect(end.minute()).toBe(0);
         });
 
-        it('skips the day when totalRunTime exceeds every allowed window', () => {
-            // Crank up the depletion so the planner wants a long run, and shrink
-            // the allowed windows so they cannot fit.
+        it('skips the day when the overnight window is too short for any cycle', () => {
+            // Zone needs ~35 min of irrigation; its natural start = sunrise - 35min = 05:25.
+            // prevDaySunset + 1h = earliestStart = 05:30 > 05:25 → no cycles fit the window.
             const zone = createTestZone({
-                currentDepletionMm: 22,
+                currentDepletionMm: 21.5, // needs 2 days of ET (0.85/day) before crossing RAW (22.5)
                 soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
                 precipitationRateMmPerHr: 50,
             });
-            const weather = weatherFromDates('2026-05-06', 1, 6);
+            // Day 0: depletion stays below RAW (21.5 + 0.85 = 22.35 < 22.5). Sunset 04:30.
+            // Day 1: depletion crosses RAW. earliestStart = 05:30. Cycle start = 05:25 < 05:30 → skipped.
+            const weather = createWeatherDays([
+                {
+                    evapotranspirationMmPerDay: 1.0,
+                    rainfallMm: 0,
+                    sunset: dayjs('2026-05-05').hour(4).minute(30).second(0).millisecond(0),
+                },
+                {
+                    evapotranspirationMmPerDay: 1.0,
+                    rainfallMm: 0,
+                    sunrise: dayjs('2026-05-06').hour(6).minute(0).second(0).millisecond(0),
+                },
+            ], dayjs('2026-05-05'));
 
-            const result = planZoneSchedule(zone, weather, [], {
-                allowedDays: null,
-                // Two tiny 5-minute windows — total runtime (~34 min) cannot fit either.
-                allowedTimeWindows: [
-                    { start: '03:00', end: '03:05' },
-                    { start: '22:00', end: '22:05' },
-                ],
-            });
+            const result = planZoneSchedule(zone, weather);
 
             expect(result.entries).toHaveLength(0);
         });
@@ -1342,32 +1343,19 @@ describe('planZoneSchedule', () => {
             }
         });
 
-        it('pushes a cycle into the evening window when a busy interval blocks the morning window', () => {
+        it('drops the day when a busy window covers the entire overnight window', () => {
             const zone = singleCycleZone();
             const weather = weatherFromDates('2026-05-06', 1, 6);
 
-            // Cross-zone busy block covers the entire morning window.
+            // Cross-zone busy block covers midnight through well after sunrise — nowhere to fit.
             const busyWindows = [{
                 start: dayjs('2026-05-06').hour(0).minute(0).second(0).millisecond(0),
                 end: dayjs('2026-05-06').hour(11).minute(0).second(0).millisecond(0),
             }];
 
-            const result = planZoneSchedule(zone, weather, busyWindows, {
-                allowedDays: null,
-                allowedTimeWindows: [
-                    { start: '00:00', end: '10:00' },
-                    { start: '19:00', end: '23:59' },
-                ],
-            });
+            const result = planZoneSchedule(zone, weather, busyWindows);
 
-            const cycle = result.entries[0]?.cycles[0];
-            expect(cycle).toBeDefined();
-            const start = cycle!.startTime;
-            const end = start.add(cycle!.durationMin, 'minute');
-            // Cycle is in the 19:00–23:59 window.
-            expect(start.hour()).toBeGreaterThanOrEqual(19);
-            expect(end.isAfter(start.startOf('day').hour(19))).toBe(true);
-            expect(end.isAfter(start.startOf('day').hour(23).minute(59))).toBe(false);
+            expect(result.entries).toHaveLength(0);
         });
 
         it('multi-zone: deconfliction still produces non-overlapping cycles within allowed windows', () => {

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1522,6 +1522,94 @@ describe('planZoneSchedule', () => {
         });
     });
 
+    describe('sunset gating', () => {
+        // Clay soil: infiltration 4 mm/hr → soak 60 min. Default zone: AWHC=200 mm/m,
+        // rootDepthM=0.3 → TAW=60 mm, RAW=30 mm. With precipitationRateMmPerHr=9 and
+        // currentDepletionMm=29, irrigation fires on day 1 (after 0.85mm Kc×ET per day
+        // accumulates from 29mm to 30.7mm). That depletion triggers 10 cycles; with 60-min
+        // soaks the first cycle starts ~796 min (13h16m) before sunrise — at ~16:44 on day 0.
+        function sunsetGatingZone() {
+            return createTestZone({
+                currentDepletionMm: 29, // Just below RAW (30 mm) — fires on day 1 only.
+                soil: SOIL_TYPES.clay,
+                precipitationRateMmPerHr: 9,
+            });
+        }
+
+        it('defers a day when first cycle would begin before the previous evening\'s sunset', () => {
+            // Day 0 sunset at 17:00; first cycle for day 1 lands at ~16:44 on day 0
+            // (before sunset) → the planner defers and returns no entry for day 1.
+            const zone = sunsetGatingZone();
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunset: dayjs('2026-05-04').hour(17).minute(0).second(0).millisecond(0) },
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+            ], dayjs('2026-05-04'));
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            // Day 0: depletion 29 + 0.85 ET = 29.85 < RAW 30 → no entry.
+            // Day 1: first cycle ~16:44 is before sunset 17:00 → gated → no entry.
+            expect(entries).toHaveLength(0);
+        });
+
+        it('places a day when first cycle starts after the previous evening\'s sunset', () => {
+            // Day 0 sunset at 16:00; first cycle for day 1 lands at ~16:44 on day 0
+            // (after the 16:00 sunset) → placement is allowed.
+            const zone = sunsetGatingZone();
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunset: dayjs('2026-05-04').hour(16).minute(0).second(0).millisecond(0) },
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+            ], dayjs('2026-05-04'));
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            // First cycle at ~16:44 is after the 16:00 sunset → entry placed on day 1.
+            expect(entries).toHaveLength(1);
+            expect(entries[0]!.date.format('YYYY-MM-DD')).toBe('2026-05-05');
+        });
+
+        it('never gates dayIndex 0 even when the day has a very late sunset', () => {
+            // prevDaySunset is always undefined for dayIndex=0, so the check is skipped
+            // regardless of what sunset value the day carries.
+            const zone = createTestZone({
+                currentDepletionMm: 31, // Above RAW (30 mm for clay) → fires immediately on day 0.
+                soil: SOIL_TYPES.clay,
+                precipitationRateMmPerHr: 9,
+            });
+            const weather = createWeatherDays([
+                {
+                    evapotranspirationMmPerDay: 1.0,
+                    rainfallMm: 0,
+                    sunrise: dayjs('2026-05-04').hour(6).minute(0).second(0).millisecond(0),
+                    sunset: dayjs('2026-05-04').hour(23).minute(59).second(0).millisecond(0),
+                },
+            ], dayjs('2026-05-04'));
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            // No prevDaySunset at dayIndex=0 — gate check never runs.
+            expect(entries).toHaveLength(1);
+            expect(entries[0]!.date.format('YYYY-MM-DD')).toBe('2026-05-04');
+        });
+
+        it('does not gate when no sunset is provided for the previous day', () => {
+            // If the previous day's DailyWeather has no sunset field, prevDaySunset
+            // is undefined and the gate is skipped — irrigation can fire normally.
+            const zone = sunsetGatingZone();
+            // Day 0 has no sunset field → prevDaySunset for day 1 is undefined.
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+            ], dayjs('2026-05-04'));
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            // Gate skipped due to missing sunset → entry placed on day 1.
+            expect(entries).toHaveLength(1);
+            expect(entries[0]!.date.format('YYYY-MM-DD')).toBe('2026-05-05');
+        });
+    });
+
     describe('past-window deconfliction', () => {
         // Simulates the daemon passing { start: epoch, end: now } as a busy window
         // so that past-dated cycles are shifted forward to fire after now.

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1286,25 +1286,26 @@ describe('planZoneSchedule', () => {
         });
 
         it('skips the day when the overnight window is too short for any cycle', () => {
-            // Zone needs ~35 min of irrigation; its natural start = sunrise - 35min = 05:25.
-            // prevDaySunset + 1h = earliestStart = 05:30 > 05:25 → no cycles fit the window.
+            // Polar-day-ish edge: day 0 sunset 23:50, day 1 sunrise 00:10 → only
+            // 20 min between sunset and sunrise, but the planned cycle is ~35 min,
+            // so the cycle would have to start before sunset → defer the day.
             const zone = createTestZone({
                 currentDepletionMm: 21.5, // needs 2 days of ET (0.85/day) before crossing RAW (22.5)
                 soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
                 precipitationRateMmPerHr: 50,
             });
-            // Day 0: depletion stays below RAW (21.5 + 0.85 = 22.35 < 22.5). Sunset 04:30.
-            // Day 1: depletion crosses RAW. earliestStart = 05:30. Cycle start = 05:25 < 05:30 → skipped.
+            // Day 0: depletion stays below RAW (21.5 + 0.85 = 22.35 < 22.5).
+            // Day 1: depletion crosses RAW; cycle would start ~23:35 day 0, before sunset 23:50 → defer.
             const weather = createWeatherDays([
                 {
                     evapotranspirationMmPerDay: 1.0,
                     rainfallMm: 0,
-                    sunset: dayjs('2026-05-05').hour(4).minute(30).second(0).millisecond(0),
+                    sunset: dayjs('2026-05-05').hour(23).minute(50).second(0).millisecond(0),
                 },
                 {
                     evapotranspirationMmPerDay: 1.0,
                     rainfallMm: 0,
-                    sunrise: dayjs('2026-05-06').hour(6).minute(0).second(0).millisecond(0),
+                    sunrise: dayjs('2026-05-06').hour(0).minute(10).second(0).millisecond(0),
                 },
             ], dayjs('2026-05-05'));
 
@@ -1358,34 +1359,25 @@ describe('planZoneSchedule', () => {
             expect(result.entries).toHaveLength(0);
         });
 
-        it('multi-zone: deconfliction still produces non-overlapping cycles within allowed windows', () => {
+        it('multi-zone: a cross-zone busy window outside the cycle slot is a no-op', () => {
             const zone = singleCycleZone();
             const weather = weatherFromDates('2026-05-06', 1, 6);
+            const baselineCycle = planZoneSchedule(zone, weather).entries[0]!.cycles[0]!;
 
-            // First zone has already grabbed 05:00–05:30 (typical pre-sunrise).
+            // Zone A's busy interval is well before the cycle's natural slot, so
+            // deconflict shouldn't shift it.
             const zoneABusy = [{
-                start: dayjs('2026-05-06').hour(5).minute(0).second(0).millisecond(0),
-                end: dayjs('2026-05-06').hour(5).minute(30).second(0).millisecond(0),
+                start: dayjs('2026-05-06').hour(2).minute(0).second(0).millisecond(0),
+                end: dayjs('2026-05-06').hour(2).minute(30).second(0).millisecond(0),
             }];
 
-            const result = planZoneSchedule(zone, weather, zoneABusy, {
-                allowedDays: null,
-                allowedTimeWindows: [
-                    { start: '00:00', end: '10:00' },
-                    { start: '19:00', end: '23:59' },
-                ],
-            });
+            const result = planZoneSchedule(zone, weather, zoneABusy);
 
-            const cycle = result.entries[0]?.cycles[0]!;
+            const cycle = result.entries[0]!.cycles[0]!;
+            expect(cycle.startTime.isSame(baselineCycle.startTime)).toBe(true);
             const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
-            // No overlap with zone A's window.
             const overlapsA = cycle.startTime.isBefore(zoneABusy[0]!.end) && cycleEnd.isAfter(zoneABusy[0]!.start);
             expect(overlapsA).toBe(false);
-            // Still inside one of the allowed windows.
-            const dayStart = cycle.startTime.startOf('day');
-            const inMorning = !cycle.startTime.isBefore(dayStart) && !cycleEnd.isAfter(dayStart.hour(10));
-            const inEvening = !cycle.startTime.isBefore(dayStart.hour(19)) && !cycleEnd.isAfter(dayStart.hour(23).minute(59));
-            expect(inMorning || inEvening).toBe(true);
         });
     });
 
@@ -1662,31 +1654,25 @@ describe('planZoneSchedule', () => {
             }
         });
 
-        it('drops the day when all remaining allowed windows have closed', () => {
-            // Window is 00:00–10:00; now = 14:00 → past window pushes cycle to 14:00
-            // which is outside the window, so cyclesFitAllowed fails and the day is dropped.
+        it('places a past-dated cycle at NOW even after sunrise has passed', () => {
+            // PAST_WINDOW.end = 14:00 UTC, well past sunrise 06:00. The cycle is
+            // intentionally shifted past sunrise so the daemon can fire it now.
             const zone = pastWindowZone();
             const weather = weatherDay();
 
-            const { entries } = planZoneSchedule(zone, weather, [PAST_WINDOW], {
-                allowedDays: null,
-                allowedTimeWindows: [{ start: '00:00', end: '10:00' }],
-            });
+            const { entries } = planZoneSchedule(zone, weather, [PAST_WINDOW]);
 
-            expect(entries).toHaveLength(0);
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            expect(cycle.startTime.isSame(NOW)).toBe(true);
         });
 
-        it('places a cycle within the remaining window when today\'s window is still open', () => {
-            // Window is 00:00–23:59; now = 09:00 → past window pushes cycle to 09:00
-            // which fits within the window.
+        it('places a cycle at NOW when the past window ends earlier in the day', () => {
             const NOW_09 = dayjs('2026-05-04T09:00:00.000Z');
             const zone = pastWindowZone();
             const weather = weatherDay();
 
-            const { entries } = planZoneSchedule(zone, weather, [{ start: dayjs(new Date(0)), end: NOW_09 }], {
-                allowedDays: null,
-                allowedTimeWindows: [{ start: '00:00', end: '23:59' }],
-            });
+            const { entries } = planZoneSchedule(zone, weather, [{ start: dayjs(new Date(0)), end: NOW_09 }]);
 
             expect(entries).toHaveLength(1);
             const cycle = entries[0]!.cycles[0]!;

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -203,9 +203,16 @@ type PlaceIrrigationOutcome = {
  * day is disallowed or no cycles fit the overnight window — callers treat
  * that as "skip, carry depletion forward."
  *
- * The overnight window is [prevDaySunset + 1 hour, sunrise]. Cycles that
- * would start before that window are dropped. If a cross-zone busy window
- * displaces every cycle past sunrise they are all dropped and the day skips.
+ * The overnight window is [prevDaySunset, sunrise]. When `prevDaySunset` is
+ * provided and the planned cycle block would extend before it, the entire
+ * day is deferred (gating). When it isn't provided, the planner falls back
+ * to midnight as the floor and truncates cycles that don't fit.
+ *
+ * Past-window busy intervals (those starting at the epoch) are split out
+ * from cross-zone busy windows and applied as a forward shift *after*
+ * overnight-window validation, so a cycle whose planned time has already
+ * passed gets pushed to fire now-ish rather than being dropped for ending
+ * past sunrise.
  */
 function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigationOutcome | null {
     const {
@@ -229,11 +236,11 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         ? (infiltrationRateMillimetersPerHour / precipitationRateMillimetersPerHour) * 60
         : totalRunTimeMinutes;
 
-    // Overnight window: sunset + 1 hour → sunrise. Fall back to midnight when
-    // no previous-day sunset is available (dayIndex 0 or missing data).
-    const earliestStart = prevDaySunset
-        ? prevDaySunset.add(1, 'hour')
-        : sunrise.startOf('day');
+    // Overnight floor: previous evening's sunset when available; otherwise
+    // midnight (truncation mode, used for dayIndex 0 and weather rows
+    // missing sunset data).
+    const hasPrevSunset = prevDaySunset !== undefined;
+    const earliestStart = hasPrevSunset ? prevDaySunset : sunrise.startOf('day');
 
     const plannedCycles = buildCyclePlan(
         totalRunTimeMinutes,
@@ -241,23 +248,39 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         sunrise,
         soakTimeMinutes,
         earliestStart,
+        hasPrevSunset,
     );
+
+    if (plannedCycles === null) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): overnight window too short to fit the planned cycles on ${date.format('YYYY-MM-DD')} — deferring irrigation.`);
+        return null;
+    }
 
     if (plannedCycles.length === 0) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles fit the overnight window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
         return null;
     }
 
-    const placedCycles = deconflictCycles(plannedCycles, busyWindowsSoFar, soakTimeMinutes);
+    // The daemon plumbs a "past window" — { start: epoch, end: now } — as a
+    // busy interval to push past-dated cycles forward. Distinguish it from
+    // real cross-zone busy windows so it can be applied after the sunrise
+    // validation: a cycle shifted by the past window is intentionally past
+    // sunrise and shouldn't be dropped, whereas a cycle pushed past sunrise
+    // by a cross-zone conflict has no useful slot and should drop.
+    const pastWindow = busyWindowsSoFar.find(w => w.start.valueOf() === 0);
+    const crossZoneBusyWindows = pastWindow
+        ? busyWindowsSoFar.filter(w => w !== pastWindow)
+        : busyWindowsSoFar;
 
-    // Drop any cycle displaced past sunrise or before the sunset boundary by
-    // cross-zone busy windows. 1-second tolerance absorbs floating-point drift
-    // from non-integer cycle durations.
+    const deconflictedCycles = deconflictCycles(plannedCycles, crossZoneBusyWindows, soakTimeMinutes);
+
+    // Drop any cycle displaced past sunrise by cross-zone busy windows. A
+    // 1-second tolerance absorbs floating-point drift from non-integer
+    // cycle durations.
     const toleranceMs = 1000;
-    const validCycles = placedCycles.filter(c => {
+    const validCycles = deconflictedCycles.filter(c => {
         const endMs = c.startTime.valueOf() + c.durationMin * 60_000;
-        return !c.startTime.isBefore(earliestStart)
-            && endMs <= sunrise.valueOf() + toleranceMs;
+        return endMs <= sunrise.valueOf() + toleranceMs;
     });
 
     if (validCycles.length === 0) {
@@ -265,31 +288,43 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         return null;
     }
 
+    // Past-window shift runs after sunrise validation: past-dated cycles get
+    // pushed forward to fire after `now`, even if that lands past sunrise.
+    const finalCycles = pastWindow
+        ? deconflictCycles(validCycles, [pastWindow], soakTimeMinutes)
+        : validCycles;
+
     const entry: IrrigationScheduleEntry = {
         date,
         zoneId: zone.id,
-        cycles: validCycles,
+        cycles: finalCycles,
         appliedDepthMm: roundTo1Decimal(grossIrrigationDepthMillimeters),
         depletionBeforeMm: roundTo1Decimal(depletionBeforeIrrigation),
         depletionAfterMm: 0,
     };
-    return { cycles: validCycles, entry };
+    return { cycles: finalCycles, entry };
 }
 
 
 /**
  * Builds an irrigation cycle plan anchored so the last cycle ends at sunrise,
- * filling backward into the night. Cycles that would start before
- * `earliestStart` (sunset + 1 hour) are omitted — the planner delivers as
- * many cycles as the overnight window can hold rather than all-or-nothing.
+ * filling backward into the night. Behavior when a cycle would start before
+ * `earliestStart`:
+ *  - `deferIfWindowTooShort=true` (previous-day sunset available): the entire
+ *    day is treated as un-irrigatable; the function returns `null` so the
+ *    caller defers and carries depletion into the next allowed day.
+ *  - `deferIfWindowTooShort=false` (no previous-day sunset): the plan is
+ *    truncated to the cycles that do fit; depletion is partially refilled.
  *
  * @param totalRunTimeMinutes - Total irrigation runtime needed.
  * @param maximumCycleMinutes - Maximum duration per cycle (infiltration limit).
  * @param sunrise - End anchor: last cycle ends here.
  * @param soakTimeMinutes - Soak gap between consecutive cycles.
  * @param earliestStart - Hard floor: no cycle may start before this time.
- * @returns Cycles in chronological order (earliest first); may be fewer than
- *   the number needed to deliver the full gross depth if the window is short.
+ * @param deferIfWindowTooShort - When true, returning `null` signals deferral
+ *   rather than truncation.
+ * @returns Cycles in chronological order (earliest first), `null` when the
+ *   day must be deferred, or `[]` when nothing needs to run.
  */
 function buildCyclePlan(
     totalRunTimeMinutes: number,
@@ -297,13 +332,14 @@ function buildCyclePlan(
     sunrise: dayjs.Dayjs,
     soakTimeMinutes: number,
     earliestStart: dayjs.Dayjs,
-): IrrigationCycle[] {
+    deferIfWindowTooShort: boolean,
+): IrrigationCycle[] | null {
     if (totalRunTimeMinutes <= 0) return [];
 
     if (maximumCycleMinutes <= 0 || totalRunTimeMinutes <= maximumCycleMinutes) {
         const durationMin = roundTo1Decimal(totalRunTimeMinutes);
         const startTime = sunrise.subtract(durationMin, 'minute');
-        if (startTime.isBefore(earliestStart)) return [];
+        if (startTime.isBefore(earliestStart)) return deferIfWindowTooShort ? null : [];
         return [{ startTime, durationMin }];
     }
 
@@ -317,7 +353,10 @@ function buildCyclePlan(
         const offsetMinutes = totalMinutesBeforeSunrise + perCycleMinutes;
         const cycleStart = sunrise.subtract(offsetMinutes, 'minute');
 
-        if (cycleStart.isBefore(earliestStart)) break; // window exhausted
+        if (cycleStart.isBefore(earliestStart)) {
+            if (deferIfWindowTooShort) return null;
+            break; // truncate
+        }
 
         cyclesInReverse.push({ startTime: cycleStart, durationMin: perCycleMinutes });
         totalMinutesBeforeSunrise = offsetMinutes + soakTimeMinutes;

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -1,11 +1,7 @@
 import dayjs from 'dayjs';
 import type { Zone, DailyWeather, IrrigationScheduleEntry, IrrigationCycle } from '../../models';
 import {
-    computeAllowedIntervalsForDay,
-    computeForbiddenIntervalsForDay,
     isDayAllowed,
-    pickAnchorForCycles,
-    type AllowedInterval,
     type ScheduleRestrictions,
 } from './restrictions';
 
@@ -134,6 +130,7 @@ export function planZoneSchedule(
             const irrigationOutcome = tryPlaceIrrigationForDay({
                 date,
                 sunrise,
+                prevDaySunset: dayIndex > 0 ? weatherHistory[dayIndex - 1]?.sunset : undefined,
                 zone,
                 currentDepletionMillimeters,
                 totalAvailableWaterMillimeters,
@@ -183,6 +180,8 @@ export function planZoneSchedule(
 type PlaceIrrigationInputs = {
     date: dayjs.Dayjs;
     sunrise: dayjs.Dayjs;
+    /** Sunset of the preceding calendar day. When set, the first cycle must start at or after this time. */
+    prevDaySunset?: dayjs.Dayjs;
     zone: Zone;
     currentDepletionMillimeters: number;
     totalAvailableWaterMillimeters: number;
@@ -199,14 +198,18 @@ type PlaceIrrigationOutcome = {
 };
 
 /**
- * Computes the day's irrigation block and places it within the day's
- * allowed time windows (if any). Returns `null` when the day is fully
- * disallowed or no allowed window can hold the requested runtime —
- * callers should treat that as "skip, carry depletion forward."
+ * Computes the day's irrigation block, anchored so the last cycle ends at
+ * sunrise and cycles fill backward into the night. Returns `null` when the
+ * day is disallowed or no cycles fit the overnight window — callers treat
+ * that as "skip, carry depletion forward."
+ *
+ * The overnight window is [prevDaySunset + 1 hour, sunrise]. Cycles that
+ * would start before that window are dropped. If a cross-zone busy window
+ * displaces every cycle past sunrise they are all dropped and the day skips.
  */
 function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigationOutcome | null {
     const {
-        date, sunrise, zone, currentDepletionMillimeters, totalAvailableWaterMillimeters,
+        date, sunrise, prevDaySunset, zone, currentDepletionMillimeters, totalAvailableWaterMillimeters,
         precipitationRateMillimetersPerHour, infiltrationRateMillimetersPerHour, soakTimeMinutes,
         busyWindowsSoFar, restrictions,
     } = inputs;
@@ -226,121 +229,100 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         ? (infiltrationRateMillimetersPerHour / precipitationRateMillimetersPerHour) * 60
         : totalRunTimeMinutes;
 
-    const numberOfCycles = totalRunTimeMinutes <= maximumCycleMinutes || maximumCycleMinutes <= 0
-        ? 1
-        : Math.ceil(totalRunTimeMinutes / maximumCycleMinutes);
-    const requiredSpanMinutes = totalRunTimeMinutes + (numberOfCycles - 1) * soakTimeMinutes;
-
-    const allowedIntervals = computeAllowedIntervalsForDay(date, restrictions, sunrise);
-    const hasTimeWindows = restrictions.allowedTimeWindows !== null && restrictions.allowedTimeWindows.length > 0;
-    const forbiddenForDay = hasTimeWindows ? computeForbiddenIntervalsForDay(date, restrictions, sunrise) : [];
-
-    // Pick an anchor:
-    //  - No time-window restriction: the existing sunrise anchor.
-    //  - Time-window restriction: latest allowed interval that fits, preferring
-    //    one whose end is ≤ sunrise (preserves pre-dawn placement when feasible).
-    const anchor = hasTimeWindows
-        ? pickAnchorForCycles(allowedIntervals, sunrise, requiredSpanMinutes)
-        : sunrise;
-    if (anchor === null) {
-        console.warn(`planner: zone ${zone.id} (${zone.name}): requested runtime ${requiredSpanMinutes.toFixed(1)} min cannot fit any allowed window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
-        return null;
-    }
+    // Overnight window: sunset + 1 hour → sunrise. Fall back to midnight when
+    // no previous-day sunset is available (dayIndex 0 or missing data).
+    const earliestStart = prevDaySunset
+        ? prevDaySunset.add(1, 'hour')
+        : sunrise.startOf('day');
 
     const plannedCycles = buildCyclePlan(
         totalRunTimeMinutes,
         maximumCycleMinutes,
-        anchor,
+        sunrise,
         soakTimeMinutes,
+        earliestStart,
     );
 
-    const combinedBusy = forbiddenForDay.length === 0
-        ? busyWindowsSoFar
-        : [...busyWindowsSoFar, ...forbiddenForDay];
-    const placedCycles = deconflictCycles(plannedCycles, combinedBusy, soakTimeMinutes);
+    if (plannedCycles.length === 0) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles fit the overnight window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
+        return null;
+    }
 
-    // After deconflict, verify each cycle still lies wholly within an allowed
-    // interval. A cycle pushed into a forbidden gap or beyond today's last
-    // allowed interval means the placement failed.
-    if (hasTimeWindows && !cyclesFitAllowed(placedCycles, allowedIntervals)) {
-        console.warn(`planner: zone ${zone.id} (${zone.name}): cycles could not be placed within allowed windows on ${date.format('YYYY-MM-DD')} (cross-zone or window-gap conflict) — skipping irrigation.`);
+    const placedCycles = deconflictCycles(plannedCycles, busyWindowsSoFar, soakTimeMinutes);
+
+    // Drop any cycle displaced past sunrise or before the sunset boundary by
+    // cross-zone busy windows. 1-second tolerance absorbs floating-point drift
+    // from non-integer cycle durations.
+    const toleranceMs = 1000;
+    const validCycles = placedCycles.filter(c => {
+        const endMs = c.startTime.valueOf() + c.durationMin * 60_000;
+        return !c.startTime.isBefore(earliestStart)
+            && endMs <= sunrise.valueOf() + toleranceMs;
+    });
+
+    if (validCycles.length === 0) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): all cycles displaced past sunrise by busy windows on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
         return null;
     }
 
     const entry: IrrigationScheduleEntry = {
         date,
         zoneId: zone.id,
-        cycles: placedCycles,
+        cycles: validCycles,
         appliedDepthMm: roundTo1Decimal(grossIrrigationDepthMillimeters),
         depletionBeforeMm: roundTo1Decimal(depletionBeforeIrrigation),
         depletionAfterMm: 0,
     };
-    return { cycles: placedCycles, entry };
+    return { cycles: validCycles, entry };
 }
 
-function cyclesFitAllowed(cycles: ReadonlyArray<IrrigationCycle>, allowedIntervals: ReadonlyArray<AllowedInterval>): boolean {
-    // 1-second tolerance absorbs floating-point creep from non-integer
-    // durations (e.g. 34.4-minute cycles where the ms arithmetic doesn't
-    // round-trip exactly through Dayjs).
-    const toleranceMs = 1000;
-    for (const cycle of cycles) {
-        const startMs = cycle.startTime.valueOf();
-        const endMs = startMs + cycle.durationMin * 60_000;
-        const inside = allowedIntervals.some(interval =>
-            startMs + toleranceMs >= interval.start.valueOf()
-                && endMs <= interval.end.valueOf() + toleranceMs);
-        if (!inside) return false;
-    }
-    return true;
-}
 
 /**
- * Build irrigation cycle plan that ends before sunrise.
- * Splits total runtime into multiple cycles if needed based on infiltration constraints.
+ * Builds an irrigation cycle plan anchored so the last cycle ends at sunrise,
+ * filling backward into the night. Cycles that would start before
+ * `earliestStart` (sunset + 1 hour) are omitted — the planner delivers as
+ * many cycles as the overnight window can hold rather than all-or-nothing.
  *
  * @param totalRunTimeMinutes - Total irrigation runtime needed.
- * @param maximumCycleMinutes - Maximum duration per cycle based on infiltration rate.
- * @param sunrise - Sunrise time as Dayjs object.
- * @param soakTimeMinutes - Soak time between cycles.
- * @returns Array of irrigation cycles in chronological order.
+ * @param maximumCycleMinutes - Maximum duration per cycle (infiltration limit).
+ * @param sunrise - End anchor: last cycle ends here.
+ * @param soakTimeMinutes - Soak gap between consecutive cycles.
+ * @param earliestStart - Hard floor: no cycle may start before this time.
+ * @returns Cycles in chronological order (earliest first); may be fewer than
+ *   the number needed to deliver the full gross depth if the window is short.
  */
 function buildCyclePlan(
     totalRunTimeMinutes: number,
     maximumCycleMinutes: number,
     sunrise: dayjs.Dayjs,
-    soakTimeMinutes: number
+    soakTimeMinutes: number,
+    earliestStart: dayjs.Dayjs,
 ): IrrigationCycle[] {
     if (totalRunTimeMinutes <= 0) return [];
 
-    // Use single cycle if total time fits within infiltration constraint.
     if (maximumCycleMinutes <= 0 || totalRunTimeMinutes <= maximumCycleMinutes) {
         const durationMin = roundTo1Decimal(totalRunTimeMinutes);
         const startTime = sunrise.subtract(durationMin, 'minute');
+        if (startTime.isBefore(earliestStart)) return [];
         return [{ startTime, durationMin }];
     }
 
-    // Split into multiple cycles with soak time between.
     const numberOfCycles = Math.ceil(totalRunTimeMinutes / maximumCycleMinutes),
-        perCycleMinutesRaw = totalRunTimeMinutes / numberOfCycles,
-        perCycleMinutes = roundTo1Decimal(perCycleMinutesRaw);
+        perCycleMinutes = roundTo1Decimal(totalRunTimeMinutes / numberOfCycles);
 
     const cyclesInReverse: IrrigationCycle[] = [];
     let totalMinutesBeforeSunrise = 0;
 
     for (let i = 0; i < numberOfCycles; i++) {
-        const cycleStartOffsetMinutes = totalMinutesBeforeSunrise + perCycleMinutes,
-            cycleStart = sunrise.subtract(cycleStartOffsetMinutes, 'minute');
+        const offsetMinutes = totalMinutesBeforeSunrise + perCycleMinutes;
+        const cycleStart = sunrise.subtract(offsetMinutes, 'minute');
 
-        cyclesInReverse.push({
-            startTime: cycleStart,
-            durationMin: perCycleMinutes,
-        });
+        if (cycleStart.isBefore(earliestStart)) break; // window exhausted
 
-        // Add soak time before next earlier cycle.
-        totalMinutesBeforeSunrise = cycleStartOffsetMinutes + soakTimeMinutes;
+        cyclesInReverse.push({ startTime: cycleStart, durationMin: perCycleMinutes });
+        totalMinutesBeforeSunrise = offsetMinutes + soakTimeMinutes;
     }
 
-    // Reverse to chronological order (earliest first).
     return cyclesInReverse.reverse();
 }
 

--- a/api/schedules/index.ts
+++ b/api/schedules/index.ts
@@ -58,6 +58,7 @@ export async function runScheduleForZone(
         latitude: zone.location.lat,
         longitude: zone.location.lon,
         forecastDays,
+        timezone: zone.siteTimezone,
     });
 
     const busyWindows: BusyWindow[] = (options?.busyWindows ?? []).map(w => ({

--- a/api/scripts/next-runs.test.ts
+++ b/api/scripts/next-runs.test.ts
@@ -57,19 +57,19 @@ describe('nextRunsCli', () => {
 
         const row1 = logs[1]!;
         expect(row1).toContain('Front Lawn');
-        expect(row1).toContain('2026-05-13T05:30:00+00:00');
-        expect(row1).toContain('2026-05-13T05:45:00+00:00');
+        expect(row1).toContain('Wed May 13, 2026 5:30am');
+        expect(row1).toContain('Wed May 13, 2026 5:45am');
 
         const row2 = logs[2]!;
         expect(row2).toContain('Back Garden');
-        expect(row2).toContain('2026-05-13T06:00:00+00:00');
-        expect(row2).toContain('2026-05-13T06:20:00+00:00');
+        expect(row2).toContain('Wed May 13, 2026 6:00am');
+        expect(row2).toContain('Wed May 13, 2026 6:20am');
 
         expect(logs).toHaveLength(3);
     });
 
-    it('returns 0 and logs all 5 when exactly 5 runs are available', async () => {
-        const runs = Array.from({ length: 5 }, (_, i) =>
+    it('returns 0 and logs all runs when multiple are available', async () => {
+        const runs = Array.from({ length: 10 }, (_, i) =>
             makeRun({
                 zoneName: `Zone ${i + 1}`,
                 zoneSlug: `zone-${i + 1}`,
@@ -85,7 +85,7 @@ describe('nextRunsCli', () => {
 
         expect(code).toBe(0);
         expect(errors).toEqual([]);
-        expect(logs).toHaveLength(6); // header + 5 rows
+        expect(logs).toHaveLength(11); // header + 10 rows
     });
 
     it('returns 0 and prints a no-runs message when zero cycles are returned', async () => {
@@ -115,11 +115,11 @@ describe('nextRunsCli', () => {
         expect(errors[0]).toContain('connection refused');
     });
 
-    it('passes now and limit=5 to loadRuns', async () => {
-        const calls: Array<{ now: Date; limit: number }> = [];
+    it('passes now to loadRuns without a limit', async () => {
+        const calls: Array<{ now: Date }> = [];
         const { deps } = recordingDeps({
-            loadRuns: async (now, limit) => {
-                calls.push({ now, limit });
+            loadRuns: async (now) => {
+                calls.push({ now });
                 return [];
             },
         });
@@ -128,6 +128,20 @@ describe('nextRunsCli', () => {
 
         expect(calls).toHaveLength(1);
         expect(calls[0]!.now).toBeInstanceOf(Date);
-        expect(calls[0]!.limit).toBe(5);
+    });
+
+    it('formats times in the zone timezone, not UTC', async () => {
+        const run = makeRun({
+            startTime: new Date('2026-05-13T12:00:00.000Z'),
+            endTime: new Date('2026-05-13T12:30:00.000Z'),
+            siteTimezone: 'America/Edmonton', // UTC-6 in May
+        });
+        const { deps, logs } = recordingDeps({ loadRuns: async () => [run] });
+
+        await nextRunsCli(deps);
+
+        const row = logs[1]!;
+        expect(row).toContain('6:00am');
+        expect(row).not.toContain('12:00');
     });
 });

--- a/api/scripts/next-runs.ts
+++ b/api/scripts/next-runs.ts
@@ -3,13 +3,13 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import { and, eq, gte, isNull } from 'drizzle-orm';
 import { irrigationCycles, scheduleEntries, sites, zones } from '@/db/schema';
+import type { db as DbType } from '@/db';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-const NEXT_RUNS_LIMIT = 5;
 const ZONE_COL_WIDTH = 30;
-const TIME_COL_WIDTH = 25; // 'YYYY-MM-DDTHH:mm:ss±HH:mm' is always 25 chars
+const TIME_COL_WIDTH = 26;
 
 export type NextRun = {
     zoneName: string;
@@ -20,7 +20,7 @@ export type NextRun = {
 };
 
 export type NextRunsCliDeps = {
-    loadRuns: (now: Date, limit: number) => Promise<NextRun[]>;
+    loadRuns: (now: Date) => Promise<NextRun[]>;
     log: (message: string) => void;
     error: (message: string) => void;
 };
@@ -28,7 +28,7 @@ export type NextRunsCliDeps = {
 export async function nextRunsCli(deps: NextRunsCliDeps): Promise<0 | 1> {
     let runs: NextRun[];
     try {
-        runs = await deps.loadRuns(new Date(), NEXT_RUNS_LIMIT);
+        runs = await deps.loadRuns(new Date());
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         deps.error(`next-runs: failed to load upcoming cycles — ${message}`);
@@ -56,54 +56,53 @@ function formatHeader(): string {
 }
 
 function formatRun(run: NextRun): string {
-    const startFmt = dayjs(run.startTime).tz(run.siteTimezone).format('YYYY-MM-DDTHH:mm:ssZ');
-    const endFmt = dayjs(run.endTime).tz(run.siteTimezone).format('YYYY-MM-DDTHH:mm:ssZ');
+    const fmt = (d: Date) => dayjs(d).tz(run.siteTimezone).format('ddd MMM D, YYYY h:mma');
     return (
         run.zoneName.padEnd(ZONE_COL_WIDTH) + '  ' +
-        startFmt.padEnd(TIME_COL_WIDTH) + '  ' +
-        endFmt
+        fmt(run.startTime).padEnd(TIME_COL_WIDTH) + '  ' +
+        fmt(run.endTime)
     );
 }
 
+export async function loadNextRuns(db: typeof DbType, now: Date): Promise<NextRun[]> {
+    const rows = await db
+        .select({
+            startTime: irrigationCycles.startTime,
+            durationMin: irrigationCycles.durationMin,
+            zoneName: zones.name,
+            zoneSlug: zones.slug,
+            siteTimezone: sites.timezone,
+        })
+        .from(irrigationCycles)
+        .innerJoin(scheduleEntries, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+        .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+        .innerJoin(sites, eq(zones.siteId, sites.id))
+        .where(
+            and(
+                isNull(irrigationCycles.firedAt),
+                gte(irrigationCycles.startTime, now),
+                eq(zones.isEnabled, true),
+            ),
+        );
+
+    return rows
+        .sort((a, b) => {
+            const diff = a.startTime.getTime() - b.startTime.getTime();
+            return diff !== 0 ? diff : a.zoneSlug.localeCompare(b.zoneSlug);
+        })
+        .map(row => ({
+            zoneName: row.zoneName,
+            zoneSlug: row.zoneSlug,
+            startTime: row.startTime,
+            endTime: new Date(row.startTime.getTime() + row.durationMin * 60_000),
+            siteTimezone: row.siteTimezone,
+        }));
+}
+
 if (import.meta.main) {
+    const { db } = await import('@/db');
     const deps: NextRunsCliDeps = {
-        loadRuns: async (now, limit) => {
-            const { db } = await import('@/db');
-
-            const rows = await db
-                .select({
-                    startTime: irrigationCycles.startTime,
-                    durationMin: irrigationCycles.durationMin,
-                    zoneName: zones.name,
-                    zoneSlug: zones.slug,
-                    siteTimezone: sites.timezone,
-                })
-                .from(irrigationCycles)
-                .innerJoin(scheduleEntries, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
-                .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
-                .innerJoin(sites, eq(zones.siteId, sites.id))
-                .where(
-                    and(
-                        isNull(irrigationCycles.firedAt),
-                        gte(irrigationCycles.startTime, now),
-                        eq(zones.isEnabled, true),
-                    ),
-                );
-
-            return rows
-                .sort((a, b) => {
-                    const diff = a.startTime.getTime() - b.startTime.getTime();
-                    return diff !== 0 ? diff : a.zoneSlug.localeCompare(b.zoneSlug);
-                })
-                .slice(0, limit)
-                .map(row => ({
-                    zoneName: row.zoneName,
-                    zoneSlug: row.zoneSlug,
-                    startTime: row.startTime,
-                    endTime: new Date(row.startTime.getTime() + row.durationMin * 60_000),
-                    siteTimezone: row.siteTimezone,
-                }));
-        },
+        loadRuns: (now) => loadNextRuns(db, now),
         log: m => console.log(m),
         error: m => console.error(m),
     };

--- a/api/scripts/replan.ts
+++ b/api/scripts/replan.ts
@@ -28,10 +28,22 @@ async function postReplan(): Promise<void> {
 }
 
 if (import.meta.main) {
-    const deps: ReplanCliDeps = {
+    const { db } = await import('@/db');
+    const { nextRunsCli, loadNextRuns } = await import('./next-runs');
+
+    const code = await replanCli({
         triggerReplan: postReplan,
         log: m => console.log(m),
         error: m => console.error(m),
-    };
-    replanCli(deps).then(code => process.exit(code));
+    });
+
+    if (code === 0) {
+        await nextRunsCli({
+            loadRuns: (now) => loadNextRuns(db, now),
+            log: m => console.log(m),
+            error: m => console.error(m),
+        });
+    }
+
+    process.exit(code);
 }

--- a/api/scripts/reset-depletion.ts
+++ b/api/scripts/reset-depletion.ts
@@ -1,0 +1,11 @@
+import { db } from '@/db';
+import { zones } from '@/db/schema';
+
+const DEPLETION_MM = 5;
+
+const result = await db
+    .update(zones)
+    .set({ currentDepletionMm: DEPLETION_MM });
+
+console.log(`reset-depletion: set currentDepletionMm=${DEPLETION_MM} on all zones.`);
+process.exit(0);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
             NOTIFY_ON_WATERING_START: ${NOTIFY_ON_WATERING_START:-false}
             NOTIFY_ON_WATERING_END: ${NOTIFY_ON_WATERING_END:-false}
             NOTIFY_ON_ERROR: ${NOTIFY_ON_ERROR:-true}
+            DRY_RUN: ${DRY_RUN:-false}
         ports:
             - "${PORT:-9753}:9753"
         command: sh -c "bun run start"


### PR DESCRIPTION
## Summary
- API-38: weather integration is now configurable via env vars (`OPEN_METEO_ENABLED`, `OPEN_METEO_API_KEY`); `.env.example` documents them.
- Planner: cycles end at sunrise and fill backward; `allowedTimeWindows` no longer drives placement. Overnight floor is the previous evening's sunset; if the cycle block won't fit before it, the day is deferred (gated) instead of truncated. Day 0 (no previous sunset) still truncates.
- Daemon's "past window" (`{ start: epoch, end: now }`) is now split out from cross-zone busy intervals and applied after the sunrise check, so catch-up cycles fire at `now` instead of being dropped for ending past sunrise.
- Added `DRY_RUN` env var: when true, HA relay calls are stubbed out and cycles are only planned/logged.
- `bun replan` now prints the resulting `next-runs` table on success and uses a friendlier date format.
- New `bun scripts/reset-depletion.ts` resets `currentDepletionMm` on all zones.
- Seed data: zone flow-rates / areas / microclimate factors tuned to the live site; clay-loam infiltration corrected to 5 mm/hr.

## Test plan
- [ ] `bun test` in `api/` — full suite green (494 passing, 0 failing).
- [ ] `bun run type-check` clean.
- [ ] Manual: `docker compose up`, run `bun replan`, verify the printed schedule and that the daemon arms the first cycle.
- [ ] Manual: set `DRY_RUN=true`, run a replan, confirm logs show `dry-run: would open/close zone …` and no HA traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)