### PR TITLE
[API-39] Labeled logging and Open-Meteo-prefixed error messages

### DIFF
--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { getWeatherData } from '.';
 
 // Mock the global fetch function.
@@ -6,6 +6,8 @@ const mockFetch = mock(() => Promise.resolve({} as Response));
 (global as any).fetch = mockFetch;
 
 describe('Weather Data', () => {
+    let errorSpy: ReturnType<typeof spyOn>;
+
     const mockWeatherResponse = {
         latitude: 52.52,
         longitude: 13.419998,
@@ -32,9 +34,11 @@ describe('Weather Data', () => {
 
     beforeEach(() => {
         mockFetch.mockClear();
+        errorSpy = spyOn(console, 'error').mockImplementation(() => {});
     });
 
     afterEach(() => {
+        errorSpy.mockRestore();
         delete process.env.OPEN_METEO_ENABLED;
         delete process.env.OPEN_METEO_API_KEY;
     });
@@ -130,6 +134,9 @@ describe('Weather Data', () => {
                 longitude: 13.41,
             })
         ).rejects.toThrow('Open-Meteo API request failed: 500 Internal Server Error');
+        expect(errorSpy).toHaveBeenCalledWith(
+            'weather: Open-Meteo API request failed: 500 Internal Server Error',
+        );
     });
 
     it('should include timezone param in URL when specified', async () => {
@@ -175,7 +182,8 @@ describe('Weather Data', () => {
                 latitude: 52.52,
                 longitude: 13.41,
             })
-        ).rejects.toThrow('Network error');
+        ).rejects.toThrow('Open-Meteo network error: Network error');
+        expect(errorSpy).toHaveBeenCalledWith('weather: Open-Meteo network error: Network error');
     });
 
     it('should handle empty response arrays', async () => {
@@ -214,12 +222,14 @@ describe('Weather Data', () => {
             json: async () => malformedResponse,
         } as Response);
 
-        expect(
+        await expect(
             getWeatherData({
                 latitude: 52.52,
                 longitude: 13.41,
             })
-        ).rejects.toThrow();
+        ).rejects.toThrow(/^Open-Meteo response parse error: /);
+        expect(errorSpy).toHaveBeenCalled();
+        expect(errorSpy.mock.calls[0]![0]).toMatch(/^weather: Open-Meteo response could not be parsed: /);
     });
 
     it('should throw error when daily arrays are missing in response', async () => {
@@ -243,7 +253,9 @@ describe('Weather Data', () => {
                 latitude: 52.52,
                 longitude: 13.41,
             })
-        ).rejects.toThrow();
+        ).rejects.toThrow(/^Open-Meteo response parse error: /);
+        expect(errorSpy).toHaveBeenCalled();
+        expect(errorSpy.mock.calls[0]![0]).toMatch(/^weather: Open-Meteo response could not be parsed: /);
     });
 
     it('should throw error when API returns non-JSON response', async () => {
@@ -259,7 +271,10 @@ describe('Weather Data', () => {
                 latitude: 52.52,
                 longitude: 13.41,
             })
-        ).rejects.toThrow('Unexpected token < in JSON at position 0');
+        ).rejects.toThrow('Open-Meteo response parse error: Unexpected token < in JSON at position 0');
+        expect(errorSpy).toHaveBeenCalledWith(
+            'weather: Open-Meteo response could not be parsed: Unexpected token < in JSON at position 0',
+        );
     });
 
     it('throws when OPEN_METEO_ENABLED is false without calling fetch', async () => {
@@ -269,6 +284,8 @@ describe('Weather Data', () => {
             getWeatherData({ latitude: 52.52, longitude: 13.41 })
         ).rejects.toThrow('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
         expect(mockFetch).not.toHaveBeenCalled();
+        // Configuration short-circuit, not a failure — no error log expected.
+        expect(errorSpy).not.toHaveBeenCalled();
     });
 
     it('uses commercial endpoint and appends apikey when OPEN_METEO_API_KEY is set', async () => {

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -82,13 +82,20 @@ export async function getWeatherData(params: WeatherDataParams): Promise<DailyWe
         url.searchParams.set('apikey', apiKey);
     }
 
-    const response = await fetch(url.toString());
-
-    if (!response.ok) {
-        throw new Error(`Open-Meteo API request failed: ${response.status} ${response.statusText}`);
+    let response: Response;
+    try {
+        response = await fetch(url.toString());
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(`weather: Open-Meteo network error: ${detail}`);
+        throw new Error(`Open-Meteo network error: ${detail}`);
     }
 
-    const data = await response.json() as OpenMeteoResponse;
+    if (!response.ok) {
+        const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
+        console.error(`weather: ${message}`);
+        throw new Error(message);
+    }
 
     // Parse a time string in the correct timezone so that downstream dayjs
     // operations (startOf('day'), isoWeekday, hour comparisons) all use the
@@ -96,13 +103,19 @@ export async function getWeatherData(params: WeatherDataParams): Promise<DailyWe
     const parseTime = (t: string): dayjs.Dayjs =>
         timezone ? dayjs.tz(t, timezone) : dayjs(t);
 
-    const dailyData: DailyWeather[] = data.daily.time.map((time, index) => ({
-        date: parseTime(time),
-        sunrise: parseTime(data.daily.sunrise[index]!),
-        sunset: parseTime(data.daily.sunset[index]!),
-        rainfallMm: data.daily.rain_sum[index],
-        evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
-    }));
+    try {
+        const data = await response.json() as OpenMeteoResponse;
 
-    return dailyData;
+        return data.daily.time.map((time, index) => ({
+            date: parseTime(time),
+            sunrise: parseTime(data.daily.sunrise[index]!),
+            sunset: parseTime(data.daily.sunset[index]!),
+            rainfallMm: data.daily.rain_sum[index],
+            evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
+        }));
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(`weather: Open-Meteo response could not be parsed: ${detail}`);
+        throw new Error(`Open-Meteo response parse error: ${detail}`);
+    }
 }


### PR DESCRIPTION
## Ticket

[API-39](http://192.168.2.100:7123/irrigo/browse/API-39/) — Add labeled logging and HA error notification for Open-Meteo failures.

## Summary

- Wrap the `fetch` and JSON-parse paths in `getWeatherData` ([api/data/weather/index.ts](api/data/weather/index.ts)) so every failure mode (network rejection, non-2xx, malformed response) emits a `weather: Open-Meteo …` `console.error` before rethrowing.
- Normalize the rethrown error messages so they all start with `Open-Meteo`. That string flows through the daemon's per-zone catch at [api/daemon/index.ts:208-214](api/daemon/index.ts#L208-L214) into the `reason` field of `notifier('error', …)`, so the existing HA error notification (gated by `NOTIFY_ON_ERROR`) now clearly identifies Open-Meteo failures — no daemon-side change needed.
- The `OPEN_METEO_ENABLED=false` short-circuit stays silent (configuration choice, not a failure).
- Updated the five failure-mode tests in `api/data/weather/.test.ts` to assert the labeled log and message; added a no-log assertion to the disabled-via-env case.

## Test plan

- [x] `bun --cwd api run type-check`
- [x] `bun --cwd api test` — 494 / 494 pass