### PR TITLE
[API-42] GET /zones — list zones with depletion, RAW, last fire

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, type ScheduleApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
+import type { ZoneSummary } from '@/daemon/zones';
 import { BusyError, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
 
@@ -615,6 +616,89 @@ describe('buildApp /replan route', () => {
         const res = await app.inject({ method: 'POST', url: '/replan' });
 
         expect(res.statusCode).toBe(404);
+        await app.close();
+    });
+});
+
+describe('buildApp GET /zones', () => {
+    function buildSummary(overrides?: Partial<ZoneSummary>): ZoneSummary {
+        return {
+            id: 'zone-001',
+            slug: 'north',
+            name: 'North',
+            isEnabled: true,
+            grassType: { name: 'Kentucky Bluegrass' },
+            soilType: { name: 'Clay Loam' },
+            areaM2: 80,
+            rootDepthM: 0.3,
+            allowableDepletionFraction: 0.5,
+            irrigationEfficiency: 0.675,
+            microclimateFactor: 0.85,
+            precipitationRateMmPerHr: null,
+            currentDepletionMm: 12.4,
+            rawMm: 21,
+            lastFiredAt: '2026-05-13',
+            lastAppliedMm: 14,
+            homeAssistantEntityId: 'switch.sprinkler_controller_north_zone',
+            patch: 'a',
+            ...overrides,
+        };
+    }
+
+    it('returns 200 with the wrapped zones array from the loader', async () => {
+        const summaries = [
+            buildSummary({ id: 'zone-001', slug: 'north', name: 'North' }),
+            buildSummary({ id: 'zone-002', slug: 'south', name: 'South', patch: 'b' }),
+        ];
+        const app = buildApp({
+            getStatus: () => buildStatus(),
+            zonesSummary: async () => summaries,
+        });
+
+        const res = await app.inject({ method: 'GET', url: '/zones' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({ zones: summaries });
+        await app.close();
+    });
+
+    it('returns 200 with an empty array when no zones exist', async () => {
+        const app = buildApp({
+            getStatus: () => buildStatus(),
+            zonesSummary: async () => [],
+        });
+
+        const res = await app.inject({ method: 'GET', url: '/zones' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual({ zones: [] });
+        await app.close();
+    });
+
+    it('does not register the route when zonesSummary is omitted', async () => {
+        const app = buildApp({ getStatus: () => buildStatus() });
+
+        const res = await app.inject({ method: 'GET', url: '/zones' });
+
+        expect(res.statusCode).toBe(404);
+        await app.close();
+    });
+
+    it('re-evaluates the loader on each request rather than memoizing', async () => {
+        let counter = 0;
+        const app = buildApp({
+            getStatus: () => buildStatus(),
+            zonesSummary: async () => {
+                counter++;
+                return [buildSummary({ id: `call-${counter}` })];
+            },
+        });
+
+        const first = await app.inject({ method: 'GET', url: '/zones' });
+        const second = await app.inject({ method: 'GET', url: '/zones' });
+
+        expect(first.json()).toMatchObject({ zones: [{ id: 'call-1' }] });
+        expect(second.json()).toMatchObject({ zones: [{ id: 'call-2' }] });
         await app.close();
     });
 });

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -18,12 +18,21 @@ import { computeNextRePlanAt, start, type DaemonDb } from '.';
 import {
     countZones,
     loadEnabledZones,
+    loadLatestScheduleEntries,
     loadZoneById,
+    loadZoneJoinedRowsForSummary,
+    loadZoneSummaries,
+    mapJoinedRowToSummary,
     mapJoinedRowsToZones,
+    type LatestEntriesDb,
+    type LatestZoneFire,
     type SelectJoinChain,
+    type SummaryJoinDb,
+    type SummaryJoinedRow,
     type ZoneCountDb,
     type ZoneJoinedRow,
     type ZoneLoaderDb,
+    type ZoneSummaryDb,
 } from './zones';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
 import { noopNotifier, type NotificationContext, type NotificationEvent, type Notifier } from '@/notifications';
@@ -333,6 +342,250 @@ describe('loadZoneById', () => {
         const result = await loadZoneById(db, 'zone-missing');
 
         expect(result).toBeNull();
+    });
+});
+
+function buildSummaryRow(overrides?: {
+    zone?: Partial<SummaryJoinedRow['zone']>;
+    grassType?: Partial<SummaryJoinedRow['grassType']>;
+    soilType?: Partial<SummaryJoinedRow['soilType']>;
+}): SummaryJoinedRow {
+    const joined = buildJoinedRow({
+        zone: overrides?.zone,
+        grassType: overrides?.grassType,
+        soilType: overrides?.soilType,
+    });
+    return { zone: joined.zone, grassType: joined.grassType, soilType: joined.soilType };
+}
+
+function createSummaryJoinStub(rows: SummaryJoinedRow[]) {
+    const whereCalls: WhereCall[] = [];
+    let selectColumns: unknown;
+
+    const db: SummaryJoinDb = {
+        select(columns) {
+            selectColumns = columns;
+            return { from: () => buildJoinChainStub(whereCalls, rows) };
+        },
+    };
+
+    return { db, whereCalls, getSelectColumns: () => selectColumns };
+}
+
+function createLatestEntriesStub(rows: LatestZoneFire[]) {
+    const orderByCalls: Array<ReadonlyArray<unknown>> = [];
+    const onCalls: Array<ReadonlyArray<unknown>> = [];
+
+    const db: LatestEntriesDb = {
+        selectDistinctOn(on, _columns) {
+            onCalls.push(on);
+            return {
+                from: () => ({
+                    orderBy: (...exprs) => {
+                        orderByCalls.push(exprs);
+                        return Promise.resolve(rows);
+                    },
+                }),
+            };
+        },
+    };
+
+    return { db, orderByCalls, onCalls };
+}
+
+function buildSummaryDb(rows: SummaryJoinedRow[], entries: LatestZoneFire[]): ZoneSummaryDb {
+    const { db: joinDb } = createSummaryJoinStub(rows);
+    const { db: entriesDb } = createLatestEntriesStub(entries);
+    return { ...joinDb, ...entriesDb };
+}
+
+describe('mapJoinedRowToSummary', () => {
+    it('computes rawMm as AWHC × rootDepthM × allowableDepletionFraction (rounded to 2 decimals)', () => {
+        const row = buildSummaryRow({
+            zone: { rootDepthM: 0.3, allowableDepletionFraction: 0.5 },
+            soilType: { availableWaterHoldingCapacityMmPerM: 140 },
+        });
+
+        const summary = mapJoinedRowToSummary(row, null);
+
+        // 140 × 0.3 × 0.5 = 21
+        expect(summary.rawMm).toBe(21);
+    });
+
+    it('rounds rawMm to two decimal places', () => {
+        const row = buildSummaryRow({
+            zone: { rootDepthM: 0.27, allowableDepletionFraction: 0.45 },
+            soilType: { availableWaterHoldingCapacityMmPerM: 137 },
+        });
+
+        const summary = mapJoinedRowToSummary(row, null);
+
+        // 137 × 0.27 × 0.45 = 16.6455 → 16.65
+        expect(summary.rawMm).toBe(16.65);
+    });
+
+    it('emits null lastFiredAt and lastAppliedMm when no fire entry is supplied', () => {
+        const summary = mapJoinedRowToSummary(buildSummaryRow(), null);
+
+        expect(summary.lastFiredAt).toBeNull();
+        expect(summary.lastAppliedMm).toBeNull();
+    });
+
+    it('formats lastFiredAt as YYYY-MM-DD and passes through lastAppliedMm', () => {
+        const summary = mapJoinedRowToSummary(buildSummaryRow(), {
+            zoneId: 'zone-001',
+            date: '2026-05-13',
+            appliedDepthMm: 14,
+        });
+
+        expect(summary.lastFiredAt).toBe('2026-05-13');
+        expect(summary.lastAppliedMm).toBe(14);
+    });
+
+    it('passes the patch variant through from the zone row', () => {
+        const summary = mapJoinedRowToSummary(buildSummaryRow({ zone: { patch: 'b' } }), null);
+
+        expect(summary.patch).toBe('b');
+    });
+
+    it('flattens grass and soil into a name-only nested shape', () => {
+        const summary = mapJoinedRowToSummary(buildSummaryRow({
+            grassType: { name: 'Bermudagrass' },
+            soilType: { name: 'Sandy Loam' },
+        }), null);
+
+        expect(summary.grassType).toEqual({ name: 'Bermudagrass' });
+        expect(summary.soilType).toEqual({ name: 'Sandy Loam' });
+    });
+
+    it('preserves identity, depletion, and HA fields verbatim', () => {
+        const summary = mapJoinedRowToSummary(buildSummaryRow({
+            zone: {
+                id: 'zone-007',
+                slug: 'back-yard',
+                name: 'Back Yard',
+                isEnabled: false,
+                currentDepletionMm: 18.4,
+                homeAssistantEntityId: 'switch.back_yard',
+                precipitationRateMmPerHr: 12.5,
+            },
+        }), null);
+
+        expect(summary.id).toBe('zone-007');
+        expect(summary.slug).toBe('back-yard');
+        expect(summary.name).toBe('Back Yard');
+        expect(summary.isEnabled).toBe(false);
+        expect(summary.currentDepletionMm).toBe(18.4);
+        expect(summary.homeAssistantEntityId).toBe('switch.back_yard');
+        expect(summary.precipitationRateMmPerHr).toBe(12.5);
+    });
+
+    it('emits null for missing homeAssistantEntityId and precipitationRateMmPerHr', () => {
+        const summary = mapJoinedRowToSummary(buildSummaryRow({
+            zone: { homeAssistantEntityId: null, precipitationRateMmPerHr: null },
+        }), null);
+
+        expect(summary.homeAssistantEntityId).toBeNull();
+        expect(summary.precipitationRateMmPerHr).toBeNull();
+    });
+});
+
+describe('loadZoneJoinedRowsForSummary', () => {
+    it('returns the rows produced by the chained join', async () => {
+        const rows = [buildSummaryRow({ zone: { id: 'a' } }), buildSummaryRow({ zone: { id: 'b' } })];
+        const { db } = createSummaryJoinStub(rows);
+
+        const result = await loadZoneJoinedRowsForSummary(db);
+
+        expect(result.map(r => r.zone.id)).toEqual(['a', 'b']);
+    });
+
+    it('selects from zones with grass and soil columns', async () => {
+        const { db, getSelectColumns } = createSummaryJoinStub([]);
+
+        await loadZoneJoinedRowsForSummary(db);
+
+        const cols = getSelectColumns() as Record<string, unknown>;
+        expect(cols['zone']).toBe(zones);
+        expect(cols['grassType']).toBe(grassTypes);
+        expect(cols['soilType']).toBe(soilTypes);
+    });
+});
+
+describe('loadLatestScheduleEntries', () => {
+    it('returns the rows produced by the distinct-on query', async () => {
+        const entries: LatestZoneFire[] = [
+            { zoneId: 'zone-1', date: '2026-05-13', appliedDepthMm: 14 },
+            { zoneId: 'zone-2', date: '2026-05-12', appliedDepthMm: 9 },
+        ];
+        const { db } = createLatestEntriesStub(entries);
+
+        const result = await loadLatestScheduleEntries(db);
+
+        expect(result).toEqual(entries);
+    });
+
+    it('groups the distinct-on result by zoneId and orders descending by date', async () => {
+        const { db, onCalls, orderByCalls } = createLatestEntriesStub([]);
+
+        await loadLatestScheduleEntries(db);
+
+        expect(onCalls).toHaveLength(1);
+        expect(onCalls[0]).toHaveLength(1);
+        expect(orderByCalls).toHaveLength(1);
+        // First arg is the zoneId column expression, second is the desc(date) expression.
+        expect(orderByCalls[0]).toHaveLength(2);
+    });
+});
+
+describe('loadZoneSummaries', () => {
+    it('returns the full summary list with rawMm and last-fire merged in by zone id', async () => {
+        const rows = [
+            buildSummaryRow({
+                zone: { id: 'zone-1', name: 'North', rootDepthM: 0.3, allowableDepletionFraction: 0.5 },
+                soilType: { availableWaterHoldingCapacityMmPerM: 140 },
+            }),
+            buildSummaryRow({
+                zone: { id: 'zone-2', name: 'South', rootDepthM: 0.2, allowableDepletionFraction: 0.45 },
+                soilType: { availableWaterHoldingCapacityMmPerM: 140 },
+            }),
+        ];
+        const entries: LatestZoneFire[] = [
+            { zoneId: 'zone-1', date: '2026-05-13', appliedDepthMm: 14 },
+        ];
+        const db = buildSummaryDb(rows, entries);
+
+        const result = await loadZoneSummaries(db);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]?.name).toBe('North');
+        expect(result[0]?.rawMm).toBe(21);
+        expect(result[0]?.lastFiredAt).toBe('2026-05-13');
+        expect(result[0]?.lastAppliedMm).toBe(14);
+
+        expect(result[1]?.name).toBe('South');
+        // zone-2 has no fire entry → null fields
+        expect(result[1]?.lastFiredAt).toBeNull();
+        expect(result[1]?.lastAppliedMm).toBeNull();
+    });
+
+    it('returns an empty array when no zones exist', async () => {
+        const db = buildSummaryDb([], []);
+
+        const result = await loadZoneSummaries(db);
+
+        expect(result).toEqual([]);
+    });
+
+    it('emits null last-fire fields for every zone when no entries exist', async () => {
+        const rows = [buildSummaryRow({ zone: { id: 'zone-1' } })];
+        const db = buildSummaryDb(rows, []);
+
+        const result = await loadZoneSummaries(db);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.lastFiredAt).toBeNull();
+        expect(result[0]?.lastAppliedMm).toBeNull();
     });
 });
 

--- a/api/daemon/zones.ts
+++ b/api/daemon/zones.ts
@@ -1,5 +1,6 @@
-import { eq, sql } from 'drizzle-orm';
-import { grassTypes, sites, soilTypes, zones } from '@/db/schema';
+import dayjs from 'dayjs';
+import { desc, eq, sql } from 'drizzle-orm';
+import { grassTypes, scheduleEntries, sites, soilTypes, zones } from '@/db/schema';
 import type { Zone } from '@/models';
 
 /**
@@ -174,5 +175,197 @@ export function joinedRowToZone(row: ZoneJoinedRow): Zone {
         location: { lat, lon },
         homeAssistantEntityId: row.zone.homeAssistantEntityId ?? undefined,
         microclimateFactor: row.zone.microclimateFactor,
+    };
+}
+
+/**
+ * DTO shape returned by `GET /zones`. Drives the mobile app's Home zone-tile
+ * list and seeds the Zone detail header. The shape is deliberately distinct
+ * from the daemon-internal `Zone` model — it carries pre-computed `rawMm`,
+ * patch-variant slug, and last-fire summary, all flattened for direct
+ * rendering by the client.
+ */
+export type ZoneSummary = {
+    id: string;
+    slug: string;
+    name: string;
+    isEnabled: boolean;
+    grassType: { name: string };
+    soilType: { name: string };
+    areaM2: number;
+    rootDepthM: number;
+    allowableDepletionFraction: number;
+    irrigationEfficiency: number;
+    microclimateFactor: number;
+    precipitationRateMmPerHr: number | null;
+    currentDepletionMm: number;
+    rawMm: number;
+    lastFiredAt: string | null;
+    lastAppliedMm: number | null;
+    homeAssistantEntityId: string | null;
+    patch: string;
+};
+
+/**
+ * Latest schedule-entry row per zone, as returned by `loadLatestScheduleEntries`.
+ * `date` is the entry-date column (Postgres `date`, day-granularity) serialised
+ * as a `YYYY-MM-DD` string. `appliedDepthMm` is the gross depth that was applied
+ * to the zone on that date.
+ */
+export type LatestZoneFire = {
+    zoneId: string;
+    date: string;
+    appliedDepthMm: number;
+};
+
+/**
+ * Minimal db interface for the zones × grass × soil join used by the summary
+ * loader. Mirrors `ZoneLoaderDb` but without the site join — the summary
+ * payload doesn't expose site-level fields, so the extra join would be dead
+ * weight on every request.
+ */
+export type SummaryJoinedRow = {
+    zone: typeof zones.$inferSelect;
+    grassType: typeof grassTypes.$inferSelect;
+    soilType: typeof soilTypes.$inferSelect;
+};
+
+export type SummaryJoinDb = {
+    select: (columns: {
+        zone: typeof zones;
+        grassType: typeof grassTypes;
+        soilType: typeof soilTypes;
+    }) => {
+        from: (table: typeof zones) => SelectJoinChain<SummaryJoinedRow>;
+    };
+};
+
+/**
+ * Minimal db interface for the latest-entry-per-zone query. The Drizzle
+ * runtime client satisfies it directly via `selectDistinctOn`; tests pass a
+ * recording stub.
+ */
+export type LatestEntriesDb = {
+    selectDistinctOn: (
+        on: ReadonlyArray<unknown>,
+        columns: {
+            zoneId: typeof scheduleEntries.zoneId;
+            date: typeof scheduleEntries.date;
+            appliedDepthMm: typeof scheduleEntries.appliedDepthMm;
+        },
+    ) => {
+        from: (table: typeof scheduleEntries) => {
+            orderBy: (...exprs: ReadonlyArray<unknown>) => Promise<LatestZoneFire[]>;
+        };
+    };
+};
+
+/**
+ * Composite db interface for the full summary path. The production Drizzle
+ * `db` exposes both surfaces; tests can compose stubs by spreading two
+ * recording objects.
+ */
+export type ZoneSummaryDb = SummaryJoinDb & LatestEntriesDb;
+
+/**
+ * Loads the zones × grass_types × soil_types join with no filter — both enabled
+ * and disabled zones are returned so the operator can still see disabled zones
+ * (greyed out) in the mobile app. Terminates with a no-op `where (true)` so the
+ * existing `SelectJoinChain` shape can be reused as a test surface.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns All zones with their grass and soil rows joined in.
+ */
+export async function loadZoneJoinedRowsForSummary(db: SummaryJoinDb): Promise<SummaryJoinedRow[]> {
+    return db
+        .select({ zone: zones, grassType: grassTypes, soilType: soilTypes })
+        .from(zones)
+        .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
+        .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
+        .where(sql`true`);
+}
+
+/**
+ * Loads the most-recent `schedule_entries` row per zone via `DISTINCT ON`. The
+ * result contains at most one row per zone — zones that have never fired are
+ * absent from the result entirely. Callers should consult the returned map by
+ * zone id and fall back to null when no entry is present.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns Array of latest fires, one row per zone that has fired at least once.
+ */
+export async function loadLatestScheduleEntries(db: LatestEntriesDb): Promise<LatestZoneFire[]> {
+    return db
+        .selectDistinctOn([scheduleEntries.zoneId], {
+            zoneId: scheduleEntries.zoneId,
+            date: scheduleEntries.date,
+            appliedDepthMm: scheduleEntries.appliedDepthMm,
+        })
+        .from(scheduleEntries)
+        .orderBy(scheduleEntries.zoneId, desc(scheduleEntries.date));
+}
+
+/**
+ * Loads the full `ZoneSummary` list for the mobile app's Home screen and Zone
+ * detail header. Fans out two queries in parallel — the zones×grass×soil join
+ * and the latest-fire-per-zone DISTINCT ON — then merges them in JS by zone id.
+ * The two-query approach keeps both stubs (and both production queries) simple.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns The list of `ZoneSummary` DTOs, one per zone in the database.
+ */
+export async function loadZoneSummaries(db: ZoneSummaryDb): Promise<ZoneSummary[]> {
+    const [rows, latest] = await Promise.all([
+        loadZoneJoinedRowsForSummary(db),
+        loadLatestScheduleEntries(db),
+    ]);
+    const latestByZone = new Map<string, LatestZoneFire>(latest.map(entry => [entry.zoneId, entry]));
+    const summaries = rows.map(row => mapJoinedRowToSummary(row, latestByZone.get(row.zone.id) ?? null));
+    console.log(`api: loadZoneSummaries returned ${summaries.length} zone(s).`);
+    return summaries;
+}
+
+/**
+ * Pure mapping: turns a joined zones × grass × soil row plus an optional
+ * latest-fire entry into the `ZoneSummary` DTO. Computes `rawMm =
+ * AWHC × rootDepthM × allowableDepletionFraction` server-side and rounds to two
+ * decimals so the wire payload stays compact and stable (the floating-point
+ * tail otherwise leaks 17 digits). When `lastFire` is null, both `lastFiredAt`
+ * and `lastAppliedMm` are emitted as `null`.
+ *
+ * @param row - Joined row from `loadZoneJoinedRowsForSummary`.
+ * @param lastFire - Latest schedule-entry for this zone, or null when the zone
+ *   has never fired.
+ * @returns A fully-formed `ZoneSummary` DTO.
+ */
+export function mapJoinedRowToSummary(
+    row: SummaryJoinedRow,
+    lastFire: LatestZoneFire | null,
+): ZoneSummary {
+    const rawMmRaw =
+        row.soilType.availableWaterHoldingCapacityMmPerM *
+        row.zone.rootDepthM *
+        row.zone.allowableDepletionFraction;
+    const rawMm = Math.round(rawMmRaw * 100) / 100;
+
+    return {
+        id: row.zone.id,
+        slug: row.zone.slug,
+        name: row.zone.name,
+        isEnabled: row.zone.isEnabled,
+        grassType: { name: row.grassType.name },
+        soilType: { name: row.soilType.name },
+        areaM2: row.zone.areaM2,
+        rootDepthM: row.zone.rootDepthM,
+        allowableDepletionFraction: row.zone.allowableDepletionFraction,
+        irrigationEfficiency: row.zone.irrigationEfficiency,
+        microclimateFactor: row.zone.microclimateFactor,
+        precipitationRateMmPerHr: row.zone.precipitationRateMmPerHr,
+        currentDepletionMm: row.zone.currentDepletionMm,
+        rawMm,
+        lastFiredAt: lastFire ? dayjs(lastFire.date).format('YYYY-MM-DD') : null,
+        lastAppliedMm: lastFire ? lastFire.appliedDepthMm : null,
+        homeAssistantEntityId: row.zone.homeAssistantEntityId,
+        patch: row.zone.patch,
     };
 }

--- a/api/data/seeds/.test.ts
+++ b/api/data/seeds/.test.ts
@@ -135,6 +135,22 @@ describe('parseZones', () => {
     it('rejects entries where a numeric field has the wrong type', () => {
         expect(() => parseZones([{ ...validZone, areaM2: 'big' }])).toThrow(/areaM2/);
     });
+
+    it('accepts a zone with a patch value of "a", "b", or "c"', () => {
+        for (const patch of ['a', 'b', 'c'] as const) {
+            const rows = parseZones([{ ...validZone, patch }]);
+            expect(rows[0]?.patch).toBe(patch);
+        }
+    });
+
+    it('parses successfully when patch is omitted (optional)', () => {
+        const rows = parseZones([validZone]);
+        expect(rows[0]?.patch).toBeUndefined();
+    });
+
+    it('rejects entries with a patch value outside the a/b/c enum', () => {
+        expect(() => parseZones([{ ...validZone, patch: 'd' }])).toThrow(/patch/);
+    });
 });
 
 describe('grass-types.json fixture', () => {

--- a/api/data/seeds/index.ts
+++ b/api/data/seeds/index.ts
@@ -64,6 +64,7 @@ export const ZoneSeedSchema = z.object({
     longitude: z.number().optional(),
     homeAssistantEntityId: z.string().optional(),
     microclimateFactor: z.number().optional(),
+    patch: z.enum(['a', 'b', 'c']).optional(),
 });
 
 export type GrassTypeSeed = z.infer<typeof GrassTypeSeedSchema>;

--- a/api/data/seeds/zones.json
+++ b/api/data/seeds/zones.json
@@ -11,7 +11,8 @@
         "flowRateLPerMin": 25,
         "areaM2": 80,
         "microclimateFactor": 0.85,
-        "homeAssistantEntityId": "switch.sprinkler_controller_north_zone"
+        "homeAssistantEntityId": "switch.sprinkler_controller_north_zone",
+        "patch": "a"
     },
     {
         "slug": "south",
@@ -25,7 +26,8 @@
         "flowRateLPerMin": 25,
         "areaM2": 60,
         "microclimateFactor": 1.1,
-        "homeAssistantEntityId": "switch.sprinkler_controller_south_zone"
+        "homeAssistantEntityId": "switch.sprinkler_controller_south_zone",
+        "patch": "b"
     },
     {
         "slug": "east",
@@ -39,6 +41,7 @@
         "flowRateLPerMin": 25,
         "areaM2": 120,
         "microclimateFactor": 1.0,
-        "homeAssistantEntityId": "switch.sprinkler_controller_east_zone"
+        "homeAssistantEntityId": "switch.sprinkler_controller_east_zone",
+        "patch": "c"
     }
 ]

--- a/api/db/schema/zones.ts
+++ b/api/db/schema/zones.ts
@@ -1,4 +1,5 @@
-import { boolean, doublePrecision, pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { boolean, check, doublePrecision, pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
 import { grassTypes } from './grass-types';
 import { sites } from './sites';
@@ -23,5 +24,6 @@ export const zones = pgTable('zones', {
     longitude: doublePrecision('longitude'),
     homeAssistantEntityId: text('home_assistant_entity_id'),
     microclimateFactor: real('microclimate_factor').notNull().default(1),
+    patch: text('patch').notNull().default('a'),
     ...auditColumns,
-});
+}, (table) => [check('zones_patch_check', sql`${table.patch} in ('a', 'b', 'c')`)]);

--- a/api/drizzle/0008_new_sage.sql
+++ b/api/drizzle/0008_new_sage.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "zones" ADD COLUMN "patch" text DEFAULT 'a' NOT NULL;--> statement-breakpoint
+ALTER TABLE "zones" ADD CONSTRAINT "zones_patch_check" CHECK ("zones"."patch" in ('a', 'b', 'c'));

--- a/api/drizzle/meta/0008_snapshot.json
+++ b/api/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,745 @@
+{
+  "id": "3d70d4cf-c35a-4cd2-8d1a-df352c677fe9",
+  "prevId": "e1d86cac-9447-458f-b881-3eb9380b0d27",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778640910071,
       "tag": "0007_lying_charles_xavier",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1779249612119,
+      "tag": "0008_new_sage",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -7,7 +7,7 @@ import {
     type Schedule,
     type ScheduleManagerDb,
 } from '@/daemon/schedule-manager';
-import { loadZoneById } from '@/daemon/zones';
+import { loadZoneById, loadZoneSummaries, type ZoneSummary, type ZoneSummaryDb } from '@/daemon/zones';
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import { BusyError, createManualController, type ManualController } from '@/manual';
@@ -76,6 +76,15 @@ export type BuildAppOptions = {
      * `daemon.rePlan` here.
      */
     replan?: () => Promise<void>;
+
+    /**
+     * Optional. When supplied, registers `GET /zones` which returns the
+     * mobile-app zone summary list. The loader fans out to two read queries
+     * (zones × grass × soil, and the latest schedule-entry per zone) so
+     * production callers should pass the Drizzle `db`. Routes that don't
+     * need this surface can omit the field.
+     */
+    zonesSummary?: () => Promise<ZoneSummary[]>;
 };
 
 /**
@@ -115,7 +124,28 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerReplanRoute(app, opts.replan, opts.getStatus);
     }
 
+    if (opts.zonesSummary) {
+        registerZonesSummaryRoute(app, opts.zonesSummary);
+    }
+
     return app;
+}
+
+function registerZonesSummaryRoute(
+    app: FastifyInstance,
+    zonesSummary: () => Promise<ZoneSummary[]>,
+): void {
+    /**
+     * `GET /zones` — returns the zone summary list driving the mobile app's
+     * Home zone-tile list and Zone detail header. Each entry includes grass
+     * and soil names, computed `rawMm`, the latest fire summary, and the
+     * `patch` variant. Errors propagate as Fastify's default 500 — there is
+     * no external dependency to wrap as a 502 here.
+     */
+    app.get('/zones', async (_req, reply) => {
+        const zones = await zonesSummary();
+        return reply.code(200).send({ zones });
+    });
 }
 
 function registerReplanRoute(app: FastifyInstance, replan: () => Promise<void>, getStatus: () => DaemonStatus): void {
@@ -358,6 +388,7 @@ if (import.meta.main) {
         zoneById: zoneId => loadZoneById(db as unknown as Parameters<typeof loadZoneById>[0], zoneId),
         schedule: wrapScheduleWithReplan(baseSchedule, () => daemon.rePlan()),
         replan: () => daemon.rePlan(),
+        zonesSummary: () => loadZoneSummaries(db as unknown as ZoneSummaryDb),
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/scripts/seed.test.ts
+++ b/api/scripts/seed.test.ts
@@ -87,6 +87,24 @@ describe('seed zone upsert', () => {
         expect(zoneConflictSets).toHaveLength(1);
         expect('currentDepletionMm' in zoneConflictSets[0]!).toBe(false);
     });
+
+    it('includes the patch variant in zone insert values, sourced from the seed JSON', async () => {
+        const { db, zoneInsertValues } = makeSeedDb();
+
+        await seed({ db, dataDir: SEEDS_DIR });
+
+        const rows = zoneInsertValues[0]!;
+        const patches = rows.map(row => row['patch']);
+        expect(patches).toEqual(['a', 'b', 'c']);
+    });
+
+    it('refreshes the patch column on ON CONFLICT so re-seed picks up JSON edits', async () => {
+        const { db, zoneConflictSets } = makeSeedDb();
+
+        await seed({ db, dataDir: SEEDS_DIR });
+
+        expect('patch' in zoneConflictSets[0]!).toBe(true);
+    });
 });
 
 describe('seed schedule upsert', () => {

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -252,6 +252,7 @@ async function upsertZones(db: SeedDb, rows: ZoneSeed[], lookups: ZoneLookups): 
                 longitude: sql`excluded.longitude`,
                 homeAssistantEntityId: sql`excluded.home_assistant_entity_id`,
                 microclimateFactor: sql`excluded.microclimate_factor`,
+                patch: sql`excluded.patch`,
             },
         })
         .returning({ id: zones.id, slug: zones.slug });
@@ -327,6 +328,7 @@ function resolveZone(row: ZoneSeed, lookups: ZoneLookups) {
         longitude: row.longitude ?? null,
         homeAssistantEntityId: row.homeAssistantEntityId ?? null,
         microclimateFactor: row.microclimateFactor ?? 1,
+        patch: row.patch ?? 'a',
     };
 }
 


### PR DESCRIPTION
## Ticket

[API-42](http://192.168.2.100:7123/irrigo/browse/API-42/) — GET /zones — list zones with current depletion, RAW, last fire

## Summary

- Adds a `patch` column (`text not null default 'a'`, check `in ('a','b','c')`) to the `zones` table so the mobile app can pick the LawnPatch SVG variant per zone. Seed JSON sets `north=a`, `south=b`, `east=c`.
- Adds `loadZoneSummaries(db)` in `api/daemon/zones.ts` returning a `ZoneSummary[]` DTO with embedded grass/soil names, computed `rawMm = AWHC × rootDepthM × allowableDepletionFraction`, and the latest schedule-entry per zone for `lastFiredAt` / `lastAppliedMm`.
- Registers `GET /zones` in `api/index.ts` that returns `{ zones: ZoneSummary[] }`. Production startup wires the loader against the Drizzle `db`.
- Drizzle migration `0008_new_sage.sql` ships the schema change. Apply via `docker compose run --rm api bun run db:migrate`.

## Test plan

- Schema: `bunx tsc --noEmit` clean across the api.
- Seed parser: 3 new `parseZones` cases cover `patch` valid (a/b/c), missing (optional), invalid (`'d'` rejected).
- Seed script: 2 new cases assert `patch` is in the insert values and the ON CONFLICT set.
- `mapJoinedRowToSummary`: 8 cases cover rawMm formula + rounding, null vs populated last-fire, patch passthrough, grass/soil flatten, identity preservation, null HA/precip.
- `loadZoneJoinedRowsForSummary` / `loadLatestScheduleEntries` / `loadZoneSummaries`: 7 cases cover the joins, distinct-on ordering, merge-by-zone-id, empty-input behavior.
- `GET /zones`: 4 cases cover populated response, empty array, missing-loader 404, per-request re-evaluation.
- Full suite: 530 pass, 0 fail.