### PR TITLE
[API-48] GET /alerts — current active issues (weather/HA/missed-close)

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import type { AlertDto } from '@/alerts';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, type ScheduleApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
 import type { ZoneSummary } from '@/daemon/zones';
@@ -700,5 +701,116 @@ describe('buildApp GET /zones', () => {
         expect(first.json()).toMatchObject({ zones: [{ id: 'call-1' }] });
         expect(second.json()).toMatchObject({ zones: [{ id: 'call-2' }] });
         await app.close();
+    });
+});
+
+describe('buildApp alert routes', () => {
+    function buildAlert(overrides?: Partial<AlertDto>): AlertDto {
+        return {
+            id: 'alert-001',
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed',
+            sub: 'North · ECONNREFUSED',
+            when: '2026-05-20T12:00:00.000Z',
+            zoneId: 'zone-001',
+            ack: false,
+            ...overrides,
+        };
+    }
+
+    describe('GET /alerts', () => {
+        it('returns 200 with the wrapped alerts array from the loader', async () => {
+            const list = [buildAlert(), buildAlert({ id: 'alert-002', class: 'weather-stale', tone: 'warn', title: 'Weather API stale', zoneId: null })];
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: { list: async () => list, ack: async () => 'not-found' },
+            });
+
+            const res = await app.inject({ method: 'GET', url: '/alerts' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ alerts: list });
+            await app.close();
+        });
+
+        it('returns 200 with an empty array when there are no active alerts', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: { list: async () => [], ack: async () => 'not-found' },
+            });
+
+            const res = await app.inject({ method: 'GET', url: '/alerts' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ alerts: [] });
+            await app.close();
+        });
+
+        it('returns 404 when the alerts handler is not registered', async () => {
+            const app = buildApp({ getStatus: () => buildStatus() });
+
+            const res = await app.inject({ method: 'GET', url: '/alerts' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+    });
+
+    describe('POST /alerts/:id/ack', () => {
+        it('returns 200 with status "acked" when the alert was flipped', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: { list: async () => [], ack: async () => 'acked' },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/alerts/alert-001/ack' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ status: 'acked' });
+            await app.close();
+        });
+
+        it('returns 200 with status "already-acked" when the alert was previously acked (idempotent)', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: { list: async () => [], ack: async () => 'already-acked' },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/alerts/alert-001/ack' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ status: 'already-acked' });
+            await app.close();
+        });
+
+        it('returns 404 when the alert id is unknown', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: { list: async () => [], ack: async () => 'not-found' },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/alerts/alert-missing/ack' });
+
+            expect(res.statusCode).toBe(404);
+            expect(res.json()).toMatchObject({ error: 'not-found' });
+            await app.close();
+        });
+
+        it('passes the route param verbatim to the ack handler', async () => {
+            const acked: string[] = [];
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: {
+                    list: async () => [],
+                    ack: async (id) => { acked.push(id); return 'acked'; },
+                },
+            });
+
+            await app.inject({ method: 'POST', url: '/alerts/my-id-here/ack' });
+
+            expect(acked).toEqual(['my-id-here']);
+            await app.close();
+        });
     });
 });

--- a/api/alerts/.test.ts
+++ b/api/alerts/.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { alerts } from '@/db/schema';
+import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
 import {
     acknowledgeAlert,
     clearAlertsByClass,
@@ -146,6 +147,64 @@ describe('createAlertRecorder', () => {
         await createAlertRecorder(db)(event());
 
         expect(calls.selects).toHaveLength(2);
+    });
+
+    describe('with notifier wired in', () => {
+        function recordingNotifier(): { notifier: Notifier; calls: Array<{ event: NotificationEvent; context?: NotificationContext }> } {
+            const calls: Array<{ event: NotificationEvent; context?: NotificationContext }> = [];
+            return { notifier: async (event, context) => { calls.push({ event, context }); }, calls };
+        }
+
+        it('fires the notifier with operation=class and reason=sub on a brand-new insert', async () => {
+            const { db } = createRecorderStub([]);
+            const { notifier, calls: notifications } = recordingNotifier();
+
+            await createAlertRecorder(db, notifier)(event({ zoneName: 'North' }));
+
+            expect(notifications).toHaveLength(1);
+            expect(notifications[0]).toEqual({
+                event: 'error',
+                context: {
+                    zoneName: 'North',
+                    operation: 'ha-call-failed',
+                    reason: 'North · ECONNREFUSED',
+                },
+            });
+        });
+
+        it('falls back to title when sub is omitted', async () => {
+            const { db } = createRecorderStub([]);
+            const { notifier, calls: notifications } = recordingNotifier();
+
+            await createAlertRecorder(db, notifier)(event({ sub: undefined, title: 'HA open failed' }));
+
+            expect(notifications[0]?.context?.reason).toBe('HA open failed');
+        });
+
+        it('omits zoneName from the context when the event has none (global alert)', async () => {
+            const { db } = createRecorderStub([]);
+            const { notifier, calls: notifications } = recordingNotifier();
+
+            await createAlertRecorder(db, notifier)(event({ zoneName: undefined, zoneId: undefined }));
+
+            expect(notifications[0]?.context).not.toHaveProperty('zoneName');
+            expect(notifications[0]?.context?.operation).toBe('ha-call-failed');
+        });
+
+        it('does NOT fire the notifier when an existing unacked alert is updated (dedup hit)', async () => {
+            const { db } = createRecorderStub([{ id: 'existing-001' }]);
+            const { notifier, calls: notifications } = recordingNotifier();
+
+            await createAlertRecorder(db, notifier)(event());
+
+            expect(notifications).toEqual([]);
+        });
+
+        it('still works (no error) when notifier is omitted at construction', async () => {
+            const { db } = createRecorderStub([]);
+
+            await expect(createAlertRecorder(db)(event())).resolves.toBeUndefined();
+        });
     });
 });
 

--- a/api/alerts/.test.ts
+++ b/api/alerts/.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from 'bun:test';
+import { alerts } from '@/db/schema';
+import {
+    acknowledgeAlert,
+    clearAlertsByClass,
+    createAlertRecorder,
+    listActiveAlerts,
+    noopAlertRecorder,
+    type AlertEvent,
+    type AlertsDb,
+} from '.';
+
+type AlertRow = typeof alerts.$inferSelect;
+
+const NOW = new Date('2026-05-20T12:00:00.000Z');
+
+function buildRow(overrides?: Partial<AlertRow>): AlertRow {
+    return {
+        id: 'alert-001',
+        class: 'ha-call-failed',
+        tone: 'danger',
+        title: 'HA close failed',
+        sub: 'North · ECONNREFUSED',
+        whenAt: NOW,
+        zoneId: 'zone-001',
+        ack: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+type RecorderCalls = {
+    selects: Array<{ table: unknown; cond: unknown; limit: number }>;
+    inserts: Array<{ table: unknown; values: Record<string, unknown> }>;
+    updates: Array<{ table: unknown; set: Record<string, unknown>; cond: unknown }>;
+};
+
+function createRecorderStub(existingMatches: ReadonlyArray<{ id: string }>): {
+    db: AlertsDb;
+    calls: RecorderCalls;
+} {
+    const calls: RecorderCalls = { selects: [], inserts: [], updates: [] };
+
+    const db: AlertsDb = {
+        select: (..._args) => ({
+            from: (table: unknown) => ({
+                where: (cond: unknown) => ({
+                    limit: (n: number) => {
+                        calls.selects.push({ table, cond, limit: n });
+                        return Promise.resolve(existingMatches);
+                    },
+                }),
+            }),
+        }) as unknown as ReturnType<AlertsDb['select']>,
+        insert: (table: unknown) => ({
+            values: (values: Record<string, unknown>) => {
+                calls.inserts.push({ table, values });
+                return Promise.resolve(undefined);
+            },
+        }) as unknown as ReturnType<AlertsDb['insert']>,
+        update: (table: unknown) => ({
+            set: (set: Record<string, unknown>) => ({
+                where: (cond: unknown) => {
+                    calls.updates.push({ table, set, cond });
+                    return Promise.resolve(undefined);
+                },
+            }),
+        }) as unknown as ReturnType<AlertsDb['update']>,
+    };
+
+    return { db, calls };
+}
+
+describe('noopAlertRecorder', () => {
+    it('resolves without doing anything', async () => {
+        await expect(noopAlertRecorder({ class: 'ha-call-failed', tone: 'danger', title: 'x' })).resolves.toBeUndefined();
+    });
+});
+
+describe('createAlertRecorder', () => {
+    function event(overrides?: Partial<AlertEvent>): AlertEvent {
+        return {
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed',
+            sub: 'North · ECONNREFUSED',
+            zoneId: 'zone-001',
+            ...overrides,
+        };
+    }
+
+    it('inserts a new row when no matching unacked alert exists', async () => {
+        const { db, calls } = createRecorderStub([]);
+
+        await createAlertRecorder(db)(event());
+
+        expect(calls.inserts).toHaveLength(1);
+        expect(calls.inserts[0]!.values).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed',
+            sub: 'North · ECONNREFUSED',
+            zoneId: 'zone-001',
+        });
+        expect(calls.updates).toHaveLength(0);
+    });
+
+    it('coerces an undefined sub to null on insert', async () => {
+        const { db, calls } = createRecorderStub([]);
+
+        await createAlertRecorder(db)(event({ sub: undefined }));
+
+        expect(calls.inserts[0]!.values['sub']).toBeNull();
+    });
+
+    it('coerces an undefined zoneId to null on insert (global alert)', async () => {
+        const { db, calls } = createRecorderStub([]);
+
+        await createAlertRecorder(db)(event({ zoneId: undefined }));
+
+        expect(calls.inserts[0]!.values['zoneId']).toBeNull();
+    });
+
+    it('updates the existing row when a matching unacked alert is found', async () => {
+        const { db, calls } = createRecorderStub([{ id: 'existing-001' }]);
+
+        await createAlertRecorder(db)(event({ title: 'HA close failed (retry exhausted)' }));
+
+        expect(calls.inserts).toHaveLength(0);
+        expect(calls.updates).toHaveLength(1);
+        expect(calls.updates[0]!.set).toMatchObject({
+            title: 'HA close failed (retry exhausted)',
+            sub: 'North · ECONNREFUSED',
+            tone: 'danger',
+        });
+        // whenAt is set via sql`now()` — assert the key is present without
+        // depending on Drizzle's internal SQL representation.
+        expect('whenAt' in calls.updates[0]!.set).toBe(true);
+    });
+
+    it('issues exactly one SELECT per recorded event', async () => {
+        const { db, calls } = createRecorderStub([]);
+
+        await createAlertRecorder(db)(event());
+        await createAlertRecorder(db)(event());
+
+        expect(calls.selects).toHaveLength(2);
+    });
+});
+
+type ReaderCalls = {
+    selects: number;
+    where: Array<unknown>;
+    orderBy: Array<ReadonlyArray<unknown>>;
+};
+
+function createReaderStub(rows: AlertRow[]): { db: AlertsDb; calls: ReaderCalls } {
+    const calls: ReaderCalls = { selects: 0, where: [], orderBy: [] };
+
+    const db: AlertsDb = {
+        select: (..._args) => {
+            calls.selects += 1;
+            return {
+                from: (_table: unknown) => ({
+                    where: (cond: unknown) => {
+                        calls.where.push(cond);
+                        return {
+                            orderBy: (...exprs: unknown[]) => {
+                                calls.orderBy.push(exprs);
+                                return Promise.resolve(rows);
+                            },
+                            limit: (_n: number) => Promise.resolve(rows.map(r => ({ id: r.id }))),
+                        };
+                    },
+                }),
+            } as unknown as ReturnType<AlertsDb['select']>;
+        },
+        insert: (..._args) => ({ values: async () => undefined }) as unknown as ReturnType<AlertsDb['insert']>,
+        update: (..._args) => ({
+            set: () => ({ where: async () => undefined }),
+        }) as unknown as ReturnType<AlertsDb['update']>,
+    };
+
+    return { db, calls };
+}
+
+describe('listActiveAlerts', () => {
+    it('maps every row to its DTO and preserves the input order', async () => {
+        const a = buildRow({ id: 'a', whenAt: new Date('2026-05-20T13:00:00.000Z') });
+        const b = buildRow({ id: 'b', whenAt: new Date('2026-05-20T11:00:00.000Z'), class: 'weather-stale', tone: 'warn', title: 'Weather API stale', sub: null, zoneId: null });
+        const { db } = createReaderStub([a, b]);
+
+        const result = await listActiveAlerts(db);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({
+            id: 'a',
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed',
+            sub: 'North · ECONNREFUSED',
+            when: '2026-05-20T13:00:00.000Z',
+            zoneId: 'zone-001',
+            ack: false,
+        });
+        expect(result[1]).toEqual({
+            id: 'b',
+            class: 'weather-stale',
+            tone: 'warn',
+            title: 'Weather API stale',
+            sub: null,
+            when: '2026-05-20T11:00:00.000Z',
+            zoneId: null,
+            ack: false,
+        });
+    });
+
+    it('returns an empty array when there are no unacked alerts', async () => {
+        const { db } = createReaderStub([]);
+
+        const result = await listActiveAlerts(db);
+
+        expect(result).toEqual([]);
+    });
+
+    it('issues a single select with a where and an orderBy', async () => {
+        const { db, calls } = createReaderStub([]);
+
+        await listActiveAlerts(db);
+
+        expect(calls.selects).toBe(1);
+        expect(calls.where).toHaveLength(1);
+        expect(calls.orderBy).toHaveLength(1);
+        // orderBy receives the descending-whenAt expression.
+        expect(calls.orderBy[0]).toHaveLength(1);
+    });
+});
+
+type AckCalls = {
+    updateReturning: Array<{ set: Record<string, unknown>; cond: unknown }>;
+    selectExisting: Array<{ cond: unknown }>;
+};
+
+function createAckStub(opts: {
+    updatedIds: ReadonlyArray<string>;
+    existingIds: ReadonlyArray<string>;
+}): { db: AlertsDb; calls: AckCalls } {
+    const calls: AckCalls = { updateReturning: [], selectExisting: [] };
+
+    const db: AlertsDb = {
+        update: (_table: unknown) => ({
+            set: (set: Record<string, unknown>) => ({
+                where: (cond: unknown) => ({
+                    returning: (_cols: unknown) => {
+                        calls.updateReturning.push({ set, cond });
+                        return Promise.resolve(opts.updatedIds.map(id => ({ id })));
+                    },
+                    then: (resolve: (value: unknown) => unknown) => Promise.resolve(undefined).then(resolve),
+                }),
+            }),
+        }) as unknown as ReturnType<AlertsDb['update']>,
+        select: (..._args) => ({
+            from: (_table: unknown) => ({
+                where: (cond: unknown) => ({
+                    limit: (_n: number) => {
+                        calls.selectExisting.push({ cond });
+                        return Promise.resolve(opts.existingIds.map(id => ({ id })));
+                    },
+                }),
+            }),
+        }) as unknown as ReturnType<AlertsDb['select']>,
+        insert: (..._args) => ({ values: async () => undefined }) as unknown as ReturnType<AlertsDb['insert']>,
+    };
+
+    return { db, calls };
+}
+
+describe('acknowledgeAlert', () => {
+    it('returns "acked" when the row went from unacked to acked', async () => {
+        const { db, calls } = createAckStub({ updatedIds: ['alert-001'], existingIds: [] });
+
+        const result = await acknowledgeAlert(db, 'alert-001');
+
+        expect(result).toBe('acked');
+        expect(calls.updateReturning).toHaveLength(1);
+        expect(calls.updateReturning[0]!.set).toEqual({ ack: true });
+        // No fallback select needed when the update returned a row.
+        expect(calls.selectExisting).toHaveLength(0);
+    });
+
+    it('returns "already-acked" when the row exists but was already acked', async () => {
+        const { db, calls } = createAckStub({ updatedIds: [], existingIds: ['alert-001'] });
+
+        const result = await acknowledgeAlert(db, 'alert-001');
+
+        expect(result).toBe('already-acked');
+        expect(calls.selectExisting).toHaveLength(1);
+    });
+
+    it('returns "not-found" when no row matches the id', async () => {
+        const { db } = createAckStub({ updatedIds: [], existingIds: [] });
+
+        const result = await acknowledgeAlert(db, 'alert-missing');
+
+        expect(result).toBe('not-found');
+    });
+});
+
+describe('clearAlertsByClass', () => {
+    it('issues an update against the alerts table setting ack=true', async () => {
+        const updates: Array<{ set: Record<string, unknown>; cond: unknown }> = [];
+        const db: AlertsDb = {
+            update: (_table: unknown) => ({
+                set: (set: Record<string, unknown>) => ({
+                    where: (cond: unknown) => {
+                        updates.push({ set, cond });
+                        return Promise.resolve(undefined);
+                    },
+                }),
+            }) as unknown as ReturnType<AlertsDb['update']>,
+            select: (..._args) => ({}) as unknown as ReturnType<AlertsDb['select']>,
+            insert: (..._args) => ({}) as unknown as ReturnType<AlertsDb['insert']>,
+        };
+
+        await clearAlertsByClass(db, 'weather-stale');
+
+        expect(updates).toHaveLength(1);
+        expect(updates[0]!.set).toEqual({ ack: true });
+    });
+
+    it('is idempotent when no unacked rows of the class exist (update no-ops)', async () => {
+        const db: AlertsDb = {
+            update: (_table: unknown) => ({
+                set: () => ({ where: () => Promise.resolve(undefined) }),
+            }) as unknown as ReturnType<AlertsDb['update']>,
+            select: (..._args) => ({}) as unknown as ReturnType<AlertsDb['select']>,
+            insert: (..._args) => ({}) as unknown as ReturnType<AlertsDb['insert']>,
+        };
+
+        await expect(clearAlertsByClass(db, 'weather-stale')).resolves.toBeUndefined();
+    });
+});

--- a/api/alerts/.test.ts
+++ b/api/alerts/.test.ts
@@ -4,9 +4,9 @@ import type { NotificationContext, NotificationEvent, Notifier } from '@/notific
 import {
     acknowledgeAlert,
     clearAlertsByClass,
-    createAlertRecorder,
+    createAlerter,
     listActiveAlerts,
-    noopAlertRecorder,
+    noopAlerter,
     type AlertEvent,
     type AlertsDb,
 } from '.';
@@ -73,13 +73,13 @@ function createRecorderStub(existingMatches: ReadonlyArray<{ id: string }>): {
     return { db, calls };
 }
 
-describe('noopAlertRecorder', () => {
+describe('noopAlerter', () => {
     it('resolves without doing anything', async () => {
-        await expect(noopAlertRecorder({ class: 'ha-call-failed', tone: 'danger', title: 'x' })).resolves.toBeUndefined();
+        await expect(noopAlerter({ class: 'ha-call-failed', tone: 'danger', title: 'x' })).resolves.toBeUndefined();
     });
 });
 
-describe('createAlertRecorder', () => {
+describe('createAlerter', () => {
     function event(overrides?: Partial<AlertEvent>): AlertEvent {
         return {
             class: 'ha-call-failed',
@@ -94,7 +94,7 @@ describe('createAlertRecorder', () => {
     it('inserts a new row when no matching unacked alert exists', async () => {
         const { db, calls } = createRecorderStub([]);
 
-        await createAlertRecorder(db)(event());
+        await createAlerter(db)(event());
 
         expect(calls.inserts).toHaveLength(1);
         expect(calls.inserts[0]!.values).toMatchObject({
@@ -110,7 +110,7 @@ describe('createAlertRecorder', () => {
     it('coerces an undefined sub to null on insert', async () => {
         const { db, calls } = createRecorderStub([]);
 
-        await createAlertRecorder(db)(event({ sub: undefined }));
+        await createAlerter(db)(event({ sub: undefined }));
 
         expect(calls.inserts[0]!.values['sub']).toBeNull();
     });
@@ -118,7 +118,7 @@ describe('createAlertRecorder', () => {
     it('coerces an undefined zoneId to null on insert (global alert)', async () => {
         const { db, calls } = createRecorderStub([]);
 
-        await createAlertRecorder(db)(event({ zoneId: undefined }));
+        await createAlerter(db)(event({ zoneId: undefined }));
 
         expect(calls.inserts[0]!.values['zoneId']).toBeNull();
     });
@@ -126,7 +126,7 @@ describe('createAlertRecorder', () => {
     it('updates the existing row when a matching unacked alert is found', async () => {
         const { db, calls } = createRecorderStub([{ id: 'existing-001' }]);
 
-        await createAlertRecorder(db)(event({ title: 'HA close failed (retry exhausted)' }));
+        await createAlerter(db)(event({ title: 'HA close failed (retry exhausted)' }));
 
         expect(calls.inserts).toHaveLength(0);
         expect(calls.updates).toHaveLength(1);
@@ -143,8 +143,8 @@ describe('createAlertRecorder', () => {
     it('issues exactly one SELECT per recorded event', async () => {
         const { db, calls } = createRecorderStub([]);
 
-        await createAlertRecorder(db)(event());
-        await createAlertRecorder(db)(event());
+        await createAlerter(db)(event());
+        await createAlerter(db)(event());
 
         expect(calls.selects).toHaveLength(2);
     });
@@ -159,7 +159,7 @@ describe('createAlertRecorder', () => {
             const { db } = createRecorderStub([]);
             const { notifier, calls: notifications } = recordingNotifier();
 
-            await createAlertRecorder(db, notifier)(event({ zoneName: 'North' }));
+            await createAlerter(db, notifier)(event({ zoneName: 'North' }));
 
             expect(notifications).toHaveLength(1);
             expect(notifications[0]).toEqual({
@@ -176,7 +176,7 @@ describe('createAlertRecorder', () => {
             const { db } = createRecorderStub([]);
             const { notifier, calls: notifications } = recordingNotifier();
 
-            await createAlertRecorder(db, notifier)(event({ sub: undefined, title: 'HA open failed' }));
+            await createAlerter(db, notifier)(event({ sub: undefined, title: 'HA open failed' }));
 
             expect(notifications[0]?.context?.reason).toBe('HA open failed');
         });
@@ -185,7 +185,7 @@ describe('createAlertRecorder', () => {
             const { db } = createRecorderStub([]);
             const { notifier, calls: notifications } = recordingNotifier();
 
-            await createAlertRecorder(db, notifier)(event({ zoneName: undefined, zoneId: undefined }));
+            await createAlerter(db, notifier)(event({ zoneName: undefined, zoneId: undefined }));
 
             expect(notifications[0]?.context).not.toHaveProperty('zoneName');
             expect(notifications[0]?.context?.operation).toBe('ha-call-failed');
@@ -195,7 +195,7 @@ describe('createAlertRecorder', () => {
             const { db } = createRecorderStub([{ id: 'existing-001' }]);
             const { notifier, calls: notifications } = recordingNotifier();
 
-            await createAlertRecorder(db, notifier)(event());
+            await createAlerter(db, notifier)(event());
 
             expect(notifications).toEqual([]);
         });
@@ -203,7 +203,7 @@ describe('createAlertRecorder', () => {
         it('still works (no error) when notifier is omitted at construction', async () => {
             const { db } = createRecorderStub([]);
 
-            await expect(createAlertRecorder(db)(event())).resolves.toBeUndefined();
+            await expect(createAlerter(db)(event())).resolves.toBeUndefined();
         });
     });
 });

--- a/api/alerts/index.ts
+++ b/api/alerts/index.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { alerts } from '@/db/schema';
+import type { Notifier } from '@/notifications';
 
 /**
  * Operator-facing failure classes recorded by the daemon. The set is closed:
@@ -19,6 +20,11 @@ export type AlertTone = 'warn' | 'danger';
  * Payload supplied by writers when a failure is detected. `zoneId` is
  * optional: zone-scoped failures pin to a zone, global failures (weather
  * stale) omit it. Dedup uses `(class, zoneId)` as the key.
+ *
+ * `zoneName` is transport-only context for the optional HA push fired by the
+ * recorder — it is not persisted on the alert row (the same name is already
+ * baked into `sub` for the UI to render). Callers pass it alongside `zoneId`
+ * when they have a `Zone` in hand at the failure site.
  */
 export type AlertEvent = {
     class: AlertClass;
@@ -26,6 +32,7 @@ export type AlertEvent = {
     title: string;
     sub?: string;
     zoneId?: string;
+    zoneName?: string;
 };
 
 /**
@@ -97,10 +104,17 @@ function rowToDto(row: AlertRow): AlertDto {
  * rows are left alone so the next failure creates a fresh row visible to the
  * UI again.
  *
+ * If `notifier` is supplied, the recorder also fires an HA push notification
+ * — but **only on insert** (a brand-new alert), not on update (a duplicate of
+ * an active condition). This keeps push notifications "loud once, quiet until
+ * acked," matching the design's *"loud when present, gone when not"* intent
+ * and avoiding the spam loop that prompted API-40.
+ *
  * @param db - Drizzle client (typed loosely so tests can supply a recording stub).
+ * @param notifier - Optional HA push channel. Fires on new alerts only.
  * @returns An `AlertRecorder` closure that persists to the `alerts` table.
  */
-export function createAlertRecorder(db: AlertsDb): AlertRecorder {
+export function createAlertRecorder(db: AlertsDb, notifier?: Notifier): AlertRecorder {
     return async event => {
         const matchExisting = and(
             eq(alerts.class, event.class),
@@ -137,6 +151,14 @@ export function createAlertRecorder(db: AlertsDb): AlertRecorder {
             zoneId: event.zoneId ?? null,
         });
         console.log(`alerts: inserted new ${event.class} alert.`);
+
+        if (notifier) {
+            await notifier('error', {
+                ...(event.zoneName !== undefined ? { zoneName: event.zoneName } : {}),
+                operation: event.class,
+                reason: event.sub ?? event.title,
+            });
+        }
     };
 }
 

--- a/api/alerts/index.ts
+++ b/api/alerts/index.ts
@@ -1,0 +1,248 @@
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { alerts } from '@/db/schema';
+
+/**
+ * Operator-facing failure classes recorded by the daemon. The set is closed:
+ * the schema has a `check (class in ('weather-stale', 'ha-call-failed',
+ * 'missed-close'))` constraint, so widening the union requires both a code
+ * change here and a new migration.
+ */
+export type AlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close';
+
+/**
+ * Visual severity used by the mobile app to colour the alert row. `warn`
+ * paints amber; `danger` paints red. The schema also constrains this set.
+ */
+export type AlertTone = 'warn' | 'danger';
+
+/**
+ * Payload supplied by writers when a failure is detected. `zoneId` is
+ * optional: zone-scoped failures pin to a zone, global failures (weather
+ * stale) omit it. Dedup uses `(class, zoneId)` as the key.
+ */
+export type AlertEvent = {
+    class: AlertClass;
+    tone: AlertTone;
+    title: string;
+    sub?: string;
+    zoneId?: string;
+};
+
+/**
+ * Writer function signature. The daemon threads one of these alongside the
+ * existing notifier so failure paths fire alerts via dependency injection.
+ * Resolves whether or not persistence succeeded — callers fire-and-forget.
+ */
+export type AlertRecorder = (event: AlertEvent) => Promise<void>;
+
+/**
+ * No-op recorder used as the daemon default and by tests that don't care
+ * about alert side-effects. Never throws, never logs.
+ */
+export const noopAlertRecorder: AlertRecorder = async () => {};
+
+/**
+ * Outcome of an ack attempt. `'acked'` means the row went from unacked to
+ * acked. `'already-acked'` means the row was already acked (a no-op,
+ * idempotent for the HTTP layer). `'not-found'` means no row matched.
+ */
+export type AckResult = 'acked' | 'already-acked' | 'not-found';
+
+/**
+ * Wire shape served by `GET /alerts`. `when` is ISO-8601 UTC; the underlying
+ * `whenAt` column is a `timestamptz`. `sub` and `zoneId` are nullable on the
+ * wire — `null` rather than missing-key so the JSON parser doesn't need
+ * special-cased presence checks.
+ */
+export type AlertDto = {
+    id: string;
+    class: AlertClass;
+    tone: AlertTone;
+    title: string;
+    sub: string | null;
+    when: string;
+    zoneId: string | null;
+    ack: boolean;
+};
+
+type AlertRow = typeof alerts.$inferSelect;
+
+/**
+ * Composite db interface for all four alert operations. The production
+ * Drizzle `db` satisfies this directly; tests pass a recording stub.
+ */
+export type AlertsDb = {
+    select: (...args: unknown[]) => unknown;
+    insert: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+};
+
+function rowToDto(row: AlertRow): AlertDto {
+    return {
+        id: row.id,
+        class: row.class as AlertClass,
+        tone: row.tone as AlertTone,
+        title: row.title,
+        sub: row.sub,
+        when: row.whenAt.toISOString(),
+        zoneId: row.zoneId,
+        ack: row.ack,
+    };
+}
+
+/**
+ * Builds the production `AlertRecorder` bound to the supplied Drizzle client.
+ * Dedupes by `(class, zoneId)`: if an unacked row already exists for that key
+ * the recorder updates `whenAt = now()`, `title`, `sub`, and `tone`. Acked
+ * rows are left alone so the next failure creates a fresh row visible to the
+ * UI again.
+ *
+ * @param db - Drizzle client (typed loosely so tests can supply a recording stub).
+ * @returns An `AlertRecorder` closure that persists to the `alerts` table.
+ */
+export function createAlertRecorder(db: AlertsDb): AlertRecorder {
+    return async event => {
+        const matchExisting = and(
+            eq(alerts.class, event.class),
+            eq(alerts.ack, false),
+            event.zoneId !== undefined ? eq(alerts.zoneId, event.zoneId) : isNull(alerts.zoneId),
+        );
+
+        const existing = await (db as unknown as AlertRecorderDb)
+            .select({ id: alerts.id })
+            .from(alerts)
+            .where(matchExisting)
+            .limit(1);
+
+        if (existing.length > 0) {
+            const id = existing[0]!.id;
+            await (db as unknown as AlertRecorderDb)
+                .update(alerts)
+                .set({
+                    whenAt: sql`now()`,
+                    title: event.title,
+                    sub: event.sub ?? null,
+                    tone: event.tone,
+                })
+                .where(eq(alerts.id, id));
+            console.log(`alerts: refreshed ${event.class} alert ${id}.`);
+            return;
+        }
+
+        await (db as unknown as AlertRecorderDb).insert(alerts).values({
+            class: event.class,
+            tone: event.tone,
+            title: event.title,
+            sub: event.sub ?? null,
+            zoneId: event.zoneId ?? null,
+        });
+        console.log(`alerts: inserted new ${event.class} alert.`);
+    };
+}
+
+/**
+ * Returns every unacked alert as a DTO, newest first. Used by the
+ * `GET /alerts` endpoint.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns The list of `AlertDto`s.
+ */
+export async function listActiveAlerts(db: AlertsDb): Promise<AlertDto[]> {
+    const rows = await (db as unknown as AlertReaderDb)
+        .select()
+        .from(alerts)
+        .where(eq(alerts.ack, false))
+        .orderBy(desc(alerts.whenAt));
+    return rows.map(rowToDto);
+}
+
+/**
+ * Flips `ack = true` on the matching row and reports whether the row existed
+ * and whether it was already acked. Lets the HTTP route map outcomes to
+ * status codes — 200 for acked / already-acked (idempotent), 404 for
+ * not-found.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param id - The alert UUID.
+ * @returns `'acked'`, `'already-acked'`, or `'not-found'`.
+ */
+export async function acknowledgeAlert(db: AlertsDb, id: string): Promise<AckResult> {
+    const updated = await (db as unknown as AlertAckDb)
+        .update(alerts)
+        .set({ ack: true })
+        .where(and(eq(alerts.id, id), eq(alerts.ack, false)))
+        .returning({ id: alerts.id });
+    if (updated.length > 0) return 'acked';
+
+    const existing = await (db as unknown as AlertAckDb)
+        .select({ id: alerts.id })
+        .from(alerts)
+        .where(eq(alerts.id, id))
+        .limit(1);
+    return existing.length > 0 ? 'already-acked' : 'not-found';
+}
+
+/**
+ * Marks every unacked row of `class` as acked. Used by the weather-recovery
+ * path so the alert region collapses automatically when the next successful
+ * forecast lands.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param klass - Which alert class to clear.
+ */
+export async function clearAlertsByClass(db: AlertsDb, klass: AlertClass): Promise<void> {
+    await (db as unknown as AlertAckDb)
+        .update(alerts)
+        .set({ ack: true })
+        .where(and(eq(alerts.class, klass), eq(alerts.ack, false)));
+}
+
+/**
+ * Narrow db interfaces used internally. The composite `AlertsDb` covers them
+ * all; these aliases describe the per-operation surface for clarity in tests
+ * and for anyone tracing query shapes.
+ */
+export type AlertRecorderDb = {
+    select: (cols: { id: typeof alerts.id }) => {
+        from: (table: typeof alerts) => {
+            where: (cond: unknown) => {
+                limit: (n: number) => Promise<Array<{ id: string }>>;
+            };
+        };
+    };
+    insert: (table: typeof alerts) => {
+        values: (row: Record<string, unknown>) => Promise<unknown>;
+    };
+    update: (table: typeof alerts) => {
+        set: (values: Record<string, unknown>) => {
+            where: (cond: unknown) => Promise<unknown>;
+        };
+    };
+};
+
+export type AlertReaderDb = {
+    select: () => {
+        from: (table: typeof alerts) => {
+            where: (cond: unknown) => {
+                orderBy: (...exprs: unknown[]) => Promise<AlertRow[]>;
+            };
+        };
+    };
+};
+
+export type AlertAckDb = {
+    update: (table: typeof alerts) => {
+        set: (values: Record<string, unknown>) => {
+            where: (cond: unknown) => {
+                returning: (cols: { id: typeof alerts.id }) => Promise<Array<{ id: string }>>;
+            } & Promise<unknown>;
+        };
+    };
+    select: (cols: { id: typeof alerts.id }) => {
+        from: (table: typeof alerts) => {
+            where: (cond: unknown) => {
+                limit: (n: number) => Promise<Array<{ id: string }>>;
+            };
+        };
+    };
+};

--- a/api/alerts/index.ts
+++ b/api/alerts/index.ts
@@ -22,7 +22,7 @@ export type AlertTone = 'warn' | 'danger';
  * stale) omit it. Dedup uses `(class, zoneId)` as the key.
  *
  * `zoneName` is transport-only context for the optional HA push fired by the
- * recorder — it is not persisted on the alert row (the same name is already
+ * alerter — it is not persisted on the alert row (the same name is already
  * baked into `sub` for the UI to render). Callers pass it alongside `zoneId`
  * when they have a `Zone` in hand at the failure site.
  */
@@ -40,13 +40,13 @@ export type AlertEvent = {
  * existing notifier so failure paths fire alerts via dependency injection.
  * Resolves whether or not persistence succeeded — callers fire-and-forget.
  */
-export type AlertRecorder = (event: AlertEvent) => Promise<void>;
+export type Alerter = (event: AlertEvent) => Promise<void>;
 
 /**
- * No-op recorder used as the daemon default and by tests that don't care
+ * No-op alerter used as the daemon default and by tests that don't care
  * about alert side-effects. Never throws, never logs.
  */
-export const noopAlertRecorder: AlertRecorder = async () => {};
+export const noopAlerter: Alerter = async () => {};
 
 /**
  * Outcome of an ack attempt. `'acked'` means the row went from unacked to
@@ -98,13 +98,13 @@ function rowToDto(row: AlertRow): AlertDto {
 }
 
 /**
- * Builds the production `AlertRecorder` bound to the supplied Drizzle client.
+ * Builds the production `Alerter` bound to the supplied Drizzle client.
  * Dedupes by `(class, zoneId)`: if an unacked row already exists for that key
- * the recorder updates `whenAt = now()`, `title`, `sub`, and `tone`. Acked
+ * the alerter updates `whenAt = now()`, `title`, `sub`, and `tone`. Acked
  * rows are left alone so the next failure creates a fresh row visible to the
  * UI again.
  *
- * If `notifier` is supplied, the recorder also fires an HA push notification
+ * If `notifier` is supplied, the alerter also fires an HA push notification
  * — but **only on insert** (a brand-new alert), not on update (a duplicate of
  * an active condition). This keeps push notifications "loud once, quiet until
  * acked," matching the design's *"loud when present, gone when not"* intent
@@ -112,9 +112,9 @@ function rowToDto(row: AlertRow): AlertDto {
  *
  * @param db - Drizzle client (typed loosely so tests can supply a recording stub).
  * @param notifier - Optional HA push channel. Fires on new alerts only.
- * @returns An `AlertRecorder` closure that persists to the `alerts` table.
+ * @returns An `Alerter` closure that persists to the `alerts` table.
  */
-export function createAlertRecorder(db: AlertsDb, notifier?: Notifier): AlertRecorder {
+export function createAlerter(db: AlertsDb, notifier?: Notifier): Alerter {
     return async event => {
         const matchExisting = and(
             eq(alerts.class, event.class),
@@ -122,7 +122,7 @@ export function createAlertRecorder(db: AlertsDb, notifier?: Notifier): AlertRec
             event.zoneId !== undefined ? eq(alerts.zoneId, event.zoneId) : isNull(alerts.zoneId),
         );
 
-        const existing = await (db as unknown as AlertRecorderDb)
+        const existing = await (db as unknown as AlerterDb)
             .select({ id: alerts.id })
             .from(alerts)
             .where(matchExisting)
@@ -130,7 +130,7 @@ export function createAlertRecorder(db: AlertsDb, notifier?: Notifier): AlertRec
 
         if (existing.length > 0) {
             const id = existing[0]!.id;
-            await (db as unknown as AlertRecorderDb)
+            await (db as unknown as AlerterDb)
                 .update(alerts)
                 .set({
                     whenAt: sql`now()`,
@@ -143,7 +143,7 @@ export function createAlertRecorder(db: AlertsDb, notifier?: Notifier): AlertRec
             return;
         }
 
-        await (db as unknown as AlertRecorderDb).insert(alerts).values({
+        await (db as unknown as AlerterDb).insert(alerts).values({
             class: event.class,
             tone: event.tone,
             title: event.title,
@@ -224,7 +224,7 @@ export async function clearAlertsByClass(db: AlertsDb, klass: AlertClass): Promi
  * all; these aliases describe the per-operation surface for clarity in tests
  * and for anyone tracing query shapes.
  */
-export type AlertRecorderDb = {
+export type AlerterDb = {
     select: (cols: { id: typeof alerts.id }) => {
         from: (table: typeof alerts) => {
             where: (cond: unknown) => {

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, it, expect, spyOn } from 'bun:test';
+import { noopAlertRecorder, type AlertEvent, type AlertRecorder } from '@/alerts';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import {
+    alerts,
     grassTypes,
     irrigationCycles,
     scheduleEntries,
     sites,
     soilTypes,
+    weatherState,
     zones,
 } from '@/db/schema';
 
@@ -1213,7 +1216,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
 
         await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
 
@@ -1240,7 +1243,7 @@ describe('armCycle', () => {
         const openZone = async () => { throw new Error('HA down'); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(closes).toEqual([]);
@@ -1261,7 +1264,7 @@ describe('armCycle', () => {
         const openZone = async () => { /* success */ };
         const closeZone = async () => { throw new Error('close failed'); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(updates).toHaveLength(1);
@@ -1284,7 +1287,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async () => { /* success */ };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
         await advanceTo(new Date('2026-05-04T12:05:01.000Z'));
 
         expect(opens).toHaveLength(1);
@@ -1304,6 +1307,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
+            alertRecorder: noopAlertRecorder,
             scheduleStart: { scheduleNight: '2026-05-04' },
         });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
@@ -1322,7 +1326,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-N', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 12 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, alertRecorder: noopAlertRecorder });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
 
         expect(calls.some(c => c.event === 'schedule-begun')).toBe(false);
@@ -1342,6 +1346,7 @@ describe('armCycle', () => {
             openZone: async () => { throw new Error('HA 502'); },
             closeZone: async () => {},
             notifier,
+            alertRecorder: noopAlertRecorder,
             scheduleStart: { scheduleNight: '2026-05-04' },
         });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
@@ -1371,6 +1376,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
+            alertRecorder: noopAlertRecorder,
             scheduleEnd,
         });
         await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
@@ -1388,7 +1394,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-OK', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, alertRecorder: noopAlertRecorder });
         await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
 
         expect(calls.some(c => c.event === 'schedule-ended')).toBe(false);
@@ -1408,6 +1414,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
+            alertRecorder: noopAlertRecorder,
             scheduleEnd: {
                 scheduleNight: '2026-05-04',
                 perZoneRuntimeMin: { 'Front Lawn': 5 },
@@ -1433,6 +1440,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => { throw new Error('close failed'); },
             notifier,
+            alertRecorder: noopAlertRecorder,
             scheduleEnd: {
                 scheduleNight: '2026-05-04',
                 perZoneRuntimeMin: { 'Front Lawn': 5 },
@@ -1456,7 +1464,7 @@ describe('armCycle', () => {
         const startTime = new Date('2026-05-04T13:00:00.000Z');
         const cycle = buildPersistedCycle({ id: 'cycle-snap', startTime, durationMin });
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier: noopNotifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
         await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
 
         const snapshot = registry.snapshotInFlight();
@@ -1573,7 +1581,7 @@ describe('closeAllInFlight', () => {
         const closes: Zone[] = [];
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
 
         expect(closes.map(z => z.id)).toEqual(['zone-A', 'zone-B']);
         expect(updates.filter(u => u.closedAt instanceof Date)).toHaveLength(2);
@@ -1592,7 +1600,7 @@ describe('closeAllInFlight', () => {
             if (calls === 1) throw new Error('HA flaky');
         };
 
-        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
 
         expect(calls).toBe(2);
         expect(updates).toHaveLength(1); // only the second one updated closedAt
@@ -1605,7 +1613,7 @@ describe('closeAllInFlight', () => {
         const registry = new TimerRegistry();
         const closes: Zone[] = [];
 
-        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); }, notifier: noopNotifier });
+        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); }, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
 
         expect(closes).toEqual([]);
         expect(updates).toEqual([]);
@@ -1624,7 +1632,7 @@ describe('closeAllInFlight', () => {
         registry.addInFlight('cycle-Y', zoneB, 998, new Date(NOW.getTime() + 60 * 60_000));
         const { notifier, calls } = recordingNotifier();
 
-        await closeAllInFlight({ db, clock, registry, closeZone: async () => {}, notifier });
+        await closeAllInFlight({ db, clock, registry, closeZone: async () => {}, notifier, alertRecorder: noopAlertRecorder });
 
         expect(calls).toEqual([]);
     });
@@ -1641,11 +1649,117 @@ describe('closeAllInFlight', () => {
             db, clock, registry,
             closeZone: async () => { throw new Error('HA flaky'); },
             notifier,
+            alertRecorder: noopAlertRecorder,
         });
 
         const errorCall = calls.find(c => c.event === 'error');
         expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'shutdown-close', reason: 'HA flaky' });
         expect(calls.some(c => c.event === 'watering-ended')).toBe(false);
+    });
+});
+
+function recordingAlertRecorder(): { recorder: AlertRecorder; calls: AlertEvent[] } {
+    const calls: AlertEvent[] = [];
+    return { recorder: async (event) => { calls.push(event); }, calls };
+}
+
+describe('armCycle + closeAllInFlight alert recording', () => {
+    it('records a ha-call-failed alert when openZone fails', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-A', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 10 });
+        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+
+        armCycle({
+            db, clock, registry, zone, cycle,
+            openZone: async () => { throw new Error('HA 502'); },
+            closeZone: async () => {},
+            notifier: noopNotifier,
+            alertRecorder: recorder,
+        });
+        await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toEqual({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA open failed',
+            sub: 'Front Lawn · HA 502',
+            zoneId: 'zone-001',
+        });
+    });
+
+    it('records a ha-call-failed alert when closeZone fails after a successful open', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
+        const cycle = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
+        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+
+        armCycle({
+            db, clock, registry, zone, cycle,
+            openZone: async () => {},
+            closeZone: async () => { throw new Error('close failed'); },
+            notifier: noopNotifier,
+            alertRecorder: recorder,
+        });
+        await advanceTo(new Date('2026-05-04T13:06:00.000Z'));
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed',
+            zoneId: 'zone-001',
+        });
+        expect(alertCalls[0]!.sub).toContain('close failed');
+    });
+
+    it('records no alerts when open and close both succeed', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-001' });
+        const cycle = buildPersistedCycle({ id: 'cycle-OK', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
+        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+
+        armCycle({
+            db, clock, registry, zone, cycle,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: noopNotifier,
+            alertRecorder: recorder,
+        });
+        await advanceTo(new Date('2026-05-04T13:06:00.000Z'));
+
+        expect(alertCalls).toEqual([]);
+    });
+
+    it('records a ha-call-failed alert when closeAllInFlight closeZone throws on shutdown', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createRuntimeDbStub();
+        const registry = new TimerRegistry();
+        const zone = buildZoneModel({ id: 'zone-A', name: 'Front Lawn' });
+        registry.addInFlight('cycle-X', zone, 999, new Date(NOW.getTime() + 60 * 60_000));
+        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+
+        await closeAllInFlight({
+            db, clock, registry,
+            closeZone: async () => { throw new Error('HA flaky'); },
+            notifier: noopNotifier,
+            alertRecorder: recorder,
+        });
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed (shutdown)',
+            zoneId: 'zone-A',
+        });
     });
 });
 
@@ -1655,6 +1769,8 @@ type DaemonStubInputs = {
     enabledZones?: ZoneJoinedRow[];
     zoneCounts?: { total: number; enabled: number };
     siteTimezones?: ReadonlyArray<{ timezone: string }>;
+    /** Seed value the weather_state stub returns; `undefined` ⇒ no row ⇒ stale. */
+    lastSuccessfulFetchAt?: Date | null;
     activeSchedules?: ReadonlyArray<{ schedule: {
         id: string;
         siteId: string;
@@ -1694,6 +1810,8 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
     const deletes: DeleteCall[] = [];
     const whereCallsZone: WhereCall[] = [];
     const whereCallsCycles: WhereCall[] = [];
+    const weatherStateUpserts: Array<Record<string, unknown>> = [];
+    const alertTableUpdates: Array<{ set: Record<string, unknown>; cond: unknown }> = [];
     const counts = inputs?.zoneCounts ?? { total: 1, enabled: 1 };
     // Mutable copy of the seed enabledZones so depletion writes from rePlan
     // are reflected by subsequent loadEnabledZones calls (day-N reads day-(N-1)).
@@ -1731,6 +1849,21 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             // SiteTimezoneDb shape: a single `timezone` column, no other keys.
             if ('timezone' in cols && Object.keys(cols).length === 1) {
                 return { from: () => Promise.resolve([...siteTimezoneRows]) } as never;
+            }
+            // WeatherStateDb shape: single `lastSuccessfulFetchAt` column. Returns
+            // the configured timestamp (null → "never fetched, treated as stale").
+            if ('lastSuccessfulFetchAt' in cols && Object.keys(cols).length === 1) {
+                return {
+                    from: () => ({
+                        where: () => ({
+                            limit: () => Promise.resolve(
+                                inputs?.lastSuccessfulFetchAt !== undefined
+                                    ? [{ lastSuccessfulFetchAt: inputs.lastSuccessfulFetchAt }]
+                                    : [],
+                            ),
+                        }),
+                    }),
+                } as never;
             }
             // Schedule manager shape: a single `schedule` column.
             if ('schedule' in cols && Object.keys(cols).length === 1) {
@@ -1770,6 +1903,12 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
         insert(table) {
             return {
                 values(rows) {
+                    // weatherState uses .values(row).onConflictDoUpdate(...) — record and
+                    // resolve. The daemon doesn't read back the result.
+                    if (table === weatherState) {
+                        weatherStateUpserts.push(rows as Record<string, unknown>);
+                        return { onConflictDoUpdate: async () => undefined };
+                    }
                     return {
                         returning() {
                             inserts.push({ table, rows });
@@ -1791,6 +1930,7 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
         },
         update(table) {
             const isZonesUpdate = table === zones;
+            const isAlertsUpdate = table === alerts;
             return {
                 set(values) {
                     return {
@@ -1809,6 +1949,10 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
                                 }
                                 return Promise.resolve(undefined);
                             }
+                            if (isAlertsUpdate) {
+                                alertTableUpdates.push({ set: values, cond });
+                                return Promise.resolve(undefined);
+                            }
                             expect(table).toBe(irrigationCycles);
                             const update: CycleUpdate = { cycleId: extractCycleId(cond) };
                             if (values['firedAt'] instanceof Date) update.firedAt = values['firedAt'];
@@ -1822,7 +1966,7 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
         },
     };
 
-    return { db, updates, zoneUpdates, inserts, deletes };
+    return { db, updates, zoneUpdates, inserts, deletes, weatherStateUpserts, alertTableUpdates };
 }
 
 // Walks an `eq(zones.id, X)` condition the same way `extractCycleId` walks the cycle equivalent.
@@ -1976,6 +2120,84 @@ describe('start', () => {
 
         // Only zone-good should have produced inserts.
         expect(inserts.filter(c => c.table === scheduleEntries)).toHaveLength(1);
+    });
+
+    it('rePlan() marks weather-fetch-successful and clears weather-stale alerts after a successful zone plan', async () => {
+        const enabledRows = [buildJoinedRow({ zone: { id: 'zone-good' } })];
+        const { db, weatherStateUpserts, alertTableUpdates } = createDaemonDbStub({ enabledZones: enabledRows });
+        const { clock } = createFakeClock(NOW);
+        const planned = buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 15 }]);
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => ({ entries: [planned], projectedNextDepletionMm: 0 }),
+            getZoneState: async () => 'off',
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await control.rePlan();
+
+        expect(weatherStateUpserts).toHaveLength(1);
+        expect(weatherStateUpserts[0]).toMatchObject({ id: 'singleton' });
+        expect(weatherStateUpserts[0]!['lastSuccessfulFetchAt']).toBeInstanceOf(Date);
+        // clearAlertsByClass sets ack=true; verify exactly that update fired.
+        expect(alertTableUpdates).toHaveLength(1);
+        expect(alertTableUpdates[0]!.set).toEqual({ ack: true });
+    });
+
+    it('rePlan() records a weather-stale alert when the planner throws and no recent fetch is on record', async () => {
+        const enabledRows = [buildJoinedRow({ zone: { id: 'zone-bad', name: 'North' } })];
+        const { db } = createDaemonDbStub({
+            enabledZones: enabledRows,
+            // lastSuccessfulFetchAt omitted → stale by default.
+        });
+        const { clock } = createFakeClock(NOW);
+        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => { throw new Error('weather: Open-Meteo network error'); },
+            getZoneState: async () => 'off',
+            openZone: async () => {},
+            closeZone: async () => {},
+            alertRecorder: recorder,
+        });
+
+        await control.rePlan();
+
+        const weatherAlerts = alertCalls.filter(a => a.class === 'weather-stale');
+        expect(weatherAlerts).toHaveLength(1);
+        expect(weatherAlerts[0]).toMatchObject({ class: 'weather-stale', tone: 'warn', title: 'Weather API stale' });
+        // Global alert — no zoneId pinned.
+        expect(weatherAlerts[0]!.zoneId).toBeUndefined();
+    });
+
+    it('rePlan() does NOT record a weather-stale alert when a recent successful fetch is on record', async () => {
+        const enabledRows = [buildJoinedRow({ zone: { id: 'zone-bad' } })];
+        const { db } = createDaemonDbStub({
+            enabledZones: enabledRows,
+            // Fetched 60 seconds ago — well within the 24h threshold.
+            lastSuccessfulFetchAt: new Date(NOW.getTime() - 60_000),
+        });
+        const { clock } = createFakeClock(NOW);
+        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+
+        const control = await start(db, {
+            clock,
+            rePlanHourLocal: 4,
+            runPlan: async () => { throw new Error('transient error'); },
+            getZoneState: async () => 'off',
+            openZone: async () => {},
+            closeZone: async () => {},
+            alertRecorder: recorder,
+        });
+
+        await control.rePlan();
+
+        expect(alertCalls.some(a => a.class === 'weather-stale')).toBe(false);
     });
 
     it('shutdown() cancels pending timers and closes any in-flight relay', async () => {

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, it, expect, spyOn } from 'bun:test';
-import { noopAlertRecorder, type AlertEvent, type AlertRecorder } from '@/alerts';
+import { noopAlerter, type AlertEvent, type Alerter } from '@/alerts';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
@@ -1216,7 +1216,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alerter: noopAlerter });
 
         await advanceTo(new Date('2026-05-04T13:30:01.000Z'));
 
@@ -1243,7 +1243,7 @@ describe('armCycle', () => {
         const openZone = async () => { throw new Error('HA down'); };
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alerter: noopAlerter });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(closes).toEqual([]);
@@ -1264,7 +1264,7 @@ describe('armCycle', () => {
         const openZone = async () => { /* success */ };
         const closeZone = async () => { throw new Error('close failed'); };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alerter: noopAlerter });
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         expect(updates).toHaveLength(1);
@@ -1287,7 +1287,7 @@ describe('armCycle', () => {
         const openZone = async (z: Zone) => { opens.push(z); };
         const closeZone = async () => { /* success */ };
 
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier: noopNotifier, alerter: noopAlerter });
         await advanceTo(new Date('2026-05-04T12:05:01.000Z'));
 
         expect(opens).toHaveLength(1);
@@ -1307,7 +1307,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
             scheduleStart: { scheduleNight: '2026-05-04' },
         });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
@@ -1326,7 +1326,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-N', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 12 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, alerter: noopAlerter });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
 
         expect(calls.some(c => c.event === 'schedule-begun')).toBe(false);
@@ -1346,14 +1346,14 @@ describe('armCycle', () => {
             openZone: async () => { throw new Error('HA 502'); },
             closeZone: async () => {},
             notifier,
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
             scheduleStart: { scheduleNight: '2026-05-04' },
         });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
 
         // Open failed, so the schedule-begun notification never fired.
         // The HA-failed error notification is exercised through the alert
-        // recorder's own tests — see api/alerts/.test.ts.
+        // alerter's own tests — see api/alerts/.test.ts.
         expect(calls.some(c => c.event === 'schedule-begun')).toBe(false);
     });
 
@@ -1376,7 +1376,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
             scheduleEnd,
         });
         await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
@@ -1394,7 +1394,7 @@ describe('armCycle', () => {
         const cycle = buildPersistedCycle({ id: 'cycle-OK', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
         const { notifier, calls } = recordingNotifier();
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier, alerter: noopAlerter });
         await advanceTo(new Date('2026-05-04T13:05:30.000Z'));
 
         expect(calls.some(c => c.event === 'schedule-ended')).toBe(false);
@@ -1414,7 +1414,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
             scheduleEnd: {
                 scheduleNight: '2026-05-04',
                 perZoneRuntimeMin: { 'Front Lawn': 5 },
@@ -1440,7 +1440,7 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => { throw new Error('close failed'); },
             notifier,
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
             scheduleEnd: {
                 scheduleNight: '2026-05-04',
                 perZoneRuntimeMin: { 'Front Lawn': 5 },
@@ -1451,7 +1451,7 @@ describe('armCycle', () => {
 
         // Close failed, so schedule-ended never fired even though the marker was set.
         // The HA-failed error notification is exercised through the alert
-        // recorder's own tests — see api/alerts/.test.ts.
+        // alerter's own tests — see api/alerts/.test.ts.
         expect(calls.some(c => c.event === 'schedule-ended')).toBe(false);
     });
 
@@ -1464,7 +1464,7 @@ describe('armCycle', () => {
         const startTime = new Date('2026-05-04T13:00:00.000Z');
         const cycle = buildPersistedCycle({ id: 'cycle-snap', startTime, durationMin });
 
-        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone: async () => {}, closeZone: async () => {}, notifier: noopNotifier, alerter: noopAlerter });
         await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
 
         const snapshot = registry.snapshotInFlight();
@@ -1554,7 +1554,7 @@ describe('armCloseOnly', () => {
             cycle,
             closeZone: async () => { throw new Error('HA timeout'); },
             notifier: noopNotifier,
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
             plannedCloseAt: new Date('2026-05-04T12:30:00.000Z'),
         });
 
@@ -1562,7 +1562,7 @@ describe('armCloseOnly', () => {
 
         // closed_at stays NULL on failure; the registry entry is still cleared so
         // a subsequent shutdown doesn't try to close again. Error notification is
-        // exercised through the alert recorder's own tests.
+        // exercised through the alerter's own tests.
         expect(updates).toHaveLength(0);
         expect(registry.snapshotInFlight()).toHaveLength(0);
     });
@@ -1582,7 +1582,7 @@ describe('closeAllInFlight', () => {
         const closes: Zone[] = [];
         const closeZone = async (z: Zone) => { closes.push(z); };
 
-        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier, alerter: noopAlerter });
 
         expect(closes.map(z => z.id)).toEqual(['zone-A', 'zone-B']);
         expect(updates.filter(u => u.closedAt instanceof Date)).toHaveLength(2);
@@ -1601,7 +1601,7 @@ describe('closeAllInFlight', () => {
             if (calls === 1) throw new Error('HA flaky');
         };
 
-        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier: noopNotifier, alerter: noopAlerter });
 
         expect(calls).toBe(2);
         expect(updates).toHaveLength(1); // only the second one updated closedAt
@@ -1614,7 +1614,7 @@ describe('closeAllInFlight', () => {
         const registry = new TimerRegistry();
         const closes: Zone[] = [];
 
-        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); }, notifier: noopNotifier, alertRecorder: noopAlertRecorder });
+        await closeAllInFlight({ db, clock, registry, closeZone: async (z) => { closes.push(z); }, notifier: noopNotifier, alerter: noopAlerter });
 
         expect(closes).toEqual([]);
         expect(updates).toEqual([]);
@@ -1633,7 +1633,7 @@ describe('closeAllInFlight', () => {
         registry.addInFlight('cycle-Y', zoneB, 998, new Date(NOW.getTime() + 60 * 60_000));
         const { notifier, calls } = recordingNotifier();
 
-        await closeAllInFlight({ db, clock, registry, closeZone: async () => {}, notifier, alertRecorder: noopAlertRecorder });
+        await closeAllInFlight({ db, clock, registry, closeZone: async () => {}, notifier, alerter: noopAlerter });
 
         expect(calls).toEqual([]);
     });
@@ -1649,18 +1649,18 @@ describe('closeAllInFlight', () => {
         await closeAllInFlight({
             db, clock, registry,
             closeZone: async () => { throw new Error('HA flaky'); },
-            alertRecorder: noopAlertRecorder,
+            alerter: noopAlerter,
         });
 
         // The HA-failed error notification is exercised through the alert
-        // recorder's own tests — see api/alerts/.test.ts.
+        // alerter's own tests — see api/alerts/.test.ts.
         expect(calls.some(c => c.event === 'watering-ended')).toBe(false);
     });
 });
 
-function recordingAlertRecorder(): { recorder: AlertRecorder; calls: AlertEvent[] } {
+function recordingAlerter(): { alerter: Alerter; calls: AlertEvent[] } {
     const calls: AlertEvent[] = [];
-    return { recorder: async (event) => { calls.push(event); }, calls };
+    return { alerter: async (event) => { calls.push(event); }, calls };
 }
 
 describe('armCycle + closeAllInFlight alert recording', () => {
@@ -1670,14 +1670,14 @@ describe('armCycle + closeAllInFlight alert recording', () => {
         const registry = new TimerRegistry();
         const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
         const cycle = buildPersistedCycle({ id: 'cycle-A', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 10 });
-        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+        const { alerter, calls: alertCalls } = recordingAlerter();
 
         armCycle({
             db, clock, registry, zone, cycle,
             openZone: async () => { throw new Error('HA 502'); },
             closeZone: async () => {},
             notifier: noopNotifier,
-            alertRecorder: recorder,
+            alerter,
         });
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
 
@@ -1698,14 +1698,14 @@ describe('armCycle + closeAllInFlight alert recording', () => {
         const registry = new TimerRegistry();
         const zone = buildZoneModel({ id: 'zone-001', name: 'Front Lawn' });
         const cycle = buildPersistedCycle({ id: 'cycle-B', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
-        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+        const { alerter, calls: alertCalls } = recordingAlerter();
 
         armCycle({
             db, clock, registry, zone, cycle,
             openZone: async () => {},
             closeZone: async () => { throw new Error('close failed'); },
             notifier: noopNotifier,
-            alertRecorder: recorder,
+            alerter,
         });
         await advanceTo(new Date('2026-05-04T13:06:00.000Z'));
 
@@ -1725,14 +1725,14 @@ describe('armCycle + closeAllInFlight alert recording', () => {
         const registry = new TimerRegistry();
         const zone = buildZoneModel({ id: 'zone-001' });
         const cycle = buildPersistedCycle({ id: 'cycle-OK', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 5 });
-        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+        const { alerter, calls: alertCalls } = recordingAlerter();
 
         armCycle({
             db, clock, registry, zone, cycle,
             openZone: async () => {},
             closeZone: async () => {},
             notifier: noopNotifier,
-            alertRecorder: recorder,
+            alerter,
         });
         await advanceTo(new Date('2026-05-04T13:06:00.000Z'));
 
@@ -1745,13 +1745,13 @@ describe('armCycle + closeAllInFlight alert recording', () => {
         const registry = new TimerRegistry();
         const zone = buildZoneModel({ id: 'zone-A', name: 'Front Lawn' });
         registry.addInFlight('cycle-X', zone, 999, new Date(NOW.getTime() + 60 * 60_000));
-        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+        const { alerter, calls: alertCalls } = recordingAlerter();
 
         await closeAllInFlight({
             db, clock, registry,
             closeZone: async () => { throw new Error('HA flaky'); },
             notifier: noopNotifier,
-            alertRecorder: recorder,
+            alerter,
         });
 
         expect(alertCalls).toHaveLength(1);
@@ -2155,7 +2155,7 @@ describe('start', () => {
             // lastSuccessfulFetchAt omitted → stale by default.
         });
         const { clock } = createFakeClock(NOW);
-        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+        const { alerter, calls: alertCalls } = recordingAlerter();
 
         const control = await start(db, {
             clock,
@@ -2164,7 +2164,7 @@ describe('start', () => {
             getZoneState: async () => 'off',
             openZone: async () => {},
             closeZone: async () => {},
-            alertRecorder: recorder,
+            alerter,
         });
 
         await control.rePlan();
@@ -2184,7 +2184,7 @@ describe('start', () => {
             lastSuccessfulFetchAt: new Date(NOW.getTime() - 60_000),
         });
         const { clock } = createFakeClock(NOW);
-        const { recorder, calls: alertCalls } = recordingAlertRecorder();
+        const { alerter, calls: alertCalls } = recordingAlerter();
 
         const control = await start(db, {
             clock,
@@ -2193,7 +2193,7 @@ describe('start', () => {
             getZoneState: async () => 'off',
             openZone: async () => {},
             closeZone: async () => {},
-            alertRecorder: recorder,
+            alerter,
         });
 
         await control.rePlan();
@@ -2503,7 +2503,7 @@ describe('start', () => {
         expect(ended[1]?.context).not.toHaveProperty('nextIrrigation');
     });
 
-    // Re-plan failures are now surfaced exclusively through the alert recorder
+    // Re-plan failures are now surfaced exclusively through the alerter
     // (see the weather-stale alert tests below). The unconditional notifier('error')
     // call that used to fire on every per-zone planner throw is gone — its HA push
     // is now a side effect of recording a weather-stale alert, which only fires

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -1333,7 +1333,7 @@ describe('armCycle', () => {
         expect(calls.some(c => c.event === 'watering-started')).toBe(false);
     });
 
-    it('emits an error notification when openZone fails', async () => {
+    it('does not emit schedule-begun when openZone fails', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
         const { db } = createRuntimeDbStub();
         const registry = new TimerRegistry();
@@ -1352,9 +1352,9 @@ describe('armCycle', () => {
         await advanceTo(new Date('2026-05-04T13:00:30.000Z'));
 
         // Open failed, so the schedule-begun notification never fired.
+        // The HA-failed error notification is exercised through the alert
+        // recorder's own tests — see api/alerts/.test.ts.
         expect(calls.some(c => c.event === 'schedule-begun')).toBe(false);
-        const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
     });
 
     it('emits schedule-ended on natural close when scheduleEnd marker is set', async () => {
@@ -1427,7 +1427,7 @@ describe('armCycle', () => {
         expect(ended?.context).not.toHaveProperty('nextIrrigation');
     });
 
-    it('emits an error notification when closeZone fails after a successful open', async () => {
+    it('does not emit schedule-ended when closeZone fails after a successful open', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
         const { db } = createRuntimeDbStub();
         const registry = new TimerRegistry();
@@ -1450,9 +1450,9 @@ describe('armCycle', () => {
         await advanceTo(new Date('2026-05-04T13:30:00.000Z'));
 
         // Close failed, so schedule-ended never fired even though the marker was set.
+        // The HA-failed error notification is exercised through the alert
+        // recorder's own tests — see api/alerts/.test.ts.
         expect(calls.some(c => c.event === 'schedule-ended')).toBe(false);
-        const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'close', reason: 'close failed' });
     });
 
     it('snapshotInFlight includes endTime equal to firedAt + durationMin after a successful open', async () => {
@@ -1539,13 +1539,12 @@ describe('armCloseOnly', () => {
         expect(updates[0]?.closedAt).toEqual(NOW);
     });
 
-    it('clears the registry entry and emits an error notification when closeZone rejects', async () => {
+    it('clears the registry entry when closeZone rejects', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
         const { db, updates } = createRuntimeDbStub();
         const registry = new TimerRegistry();
         const zone = buildZoneModel({ id: 'zone-fail', name: 'Fail Zone' });
         const cycle = buildPersistedCycle({ id: 'cycle-fail' });
-        const { notifier, calls } = recordingNotifier();
 
         armCloseOnly({
             db,
@@ -1554,16 +1553,18 @@ describe('armCloseOnly', () => {
             zone,
             cycle,
             closeZone: async () => { throw new Error('HA timeout'); },
-            notifier,
+            notifier: noopNotifier,
+            alertRecorder: noopAlertRecorder,
             plannedCloseAt: new Date('2026-05-04T12:30:00.000Z'),
         });
 
         await advanceTo(new Date('2026-05-04T12:30:30.000Z'));
 
+        // closed_at stays NULL on failure; the registry entry is still cleared so
+        // a subsequent shutdown doesn't try to close again. Error notification is
+        // exercised through the alert recorder's own tests.
         expect(updates).toHaveLength(0);
         expect(registry.snapshotInFlight()).toHaveLength(0);
-        const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context).toEqual({ zoneName: 'Fail Zone', operation: 'close', reason: 'HA timeout' });
     });
 });
 
@@ -1637,23 +1638,22 @@ describe('closeAllInFlight', () => {
         expect(calls).toEqual([]);
     });
 
-    it('notifies an error when shutdown closeZone fails for a relay', async () => {
+    it('does not emit watering-* events on shutdown closeZone failure', async () => {
         const { clock } = createFakeClock(NOW);
         const { db } = createRuntimeDbStub();
         const registry = new TimerRegistry();
         const zone = buildZoneModel({ id: 'zone-A', name: 'Front Lawn' });
         registry.addInFlight('cycle-X', zone, 999, new Date(NOW.getTime() + 60 * 60_000));
-        const { notifier, calls } = recordingNotifier();
+        const { calls } = recordingNotifier();
 
         await closeAllInFlight({
             db, clock, registry,
             closeZone: async () => { throw new Error('HA flaky'); },
-            notifier,
             alertRecorder: noopAlertRecorder,
         });
 
-        const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'shutdown-close', reason: 'HA flaky' });
+        // The HA-failed error notification is exercised through the alert
+        // recorder's own tests — see api/alerts/.test.ts.
         expect(calls.some(c => c.event === 'watering-ended')).toBe(false);
     });
 });
@@ -1688,6 +1688,7 @@ describe('armCycle + closeAllInFlight alert recording', () => {
             title: 'HA open failed',
             sub: 'Front Lawn · HA 502',
             zoneId: 'zone-001',
+            zoneName: 'Front Lawn',
         });
     });
 
@@ -2502,28 +2503,11 @@ describe('start', () => {
         expect(ended[1]?.context).not.toHaveProperty('nextIrrigation');
     });
 
-    it('emits an error notification when the planner throws for a zone during rePlan', async () => {
-        const enabledRow = buildJoinedRow({ zone: { id: 'zone-bad', name: 'Bad Zone' } });
-        const { db } = createDaemonDbStub({ enabledZones: [enabledRow] });
-        const { clock } = createFakeClock(NOW);
-        const { notifier, calls } = recordingNotifier();
-
-        const control = await start(db, {
-            clock,
-            rePlanHourLocal: 4,
-            siteTimezone: 'UTC',
-            notifier,
-            runPlan: async () => { throw new Error('forecast unavailable'); },
-            openZone: async () => {},
-            closeZone: async () => {},
-            getZoneState: async () => 'off',
-        });
-
-        await control.rePlan();
-
-        const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context).toEqual({ zoneName: 'Bad Zone', operation: 're-plan', reason: 'forecast unavailable' });
-    });
+    // Re-plan failures are now surfaced exclusively through the alert recorder
+    // (see the weather-stale alert tests below). The unconditional notifier('error')
+    // call that used to fire on every per-zone planner throw is gone — its HA push
+    // is now a side effect of recording a weather-stale alert, which only fires
+    // when the planner is genuinely on stale data.
 
     describe('cross-zone deconfliction', () => {
         type RunPlanCall = {

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -248,13 +248,13 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
             } catch (err) {
                 const reason = err instanceof Error ? err.message : String(err);
                 console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
-                await notifier('error', { zoneName: zone.name, operation: 're-plan', reason });
                 if (await isWeatherStale(db, clock.now())) {
                     await alertRecorder({
                         class: 'weather-stale',
                         tone: 'warn',
                         title: 'Weather API stale',
                         sub: `Planner on fallback ET₀ · last attempt failed: ${reason}`,
+                        zoneName: zone.name,
                     });
                 }
             }
@@ -272,7 +272,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const shutdown = async (): Promise<void> => {
         console.log('daemon: shutdown starting.');
         registry.cancelAllTimers(clock);
-        await closeAllInFlight({ db, clock, registry, closeZone, notifier, alertRecorder });
+        await closeAllInFlight({ db, clock, registry, closeZone, alertRecorder });
         console.log('daemon: shutdown complete.');
     };
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import { clearAlertsByClass, noopAlertRecorder, type AlertRecorder, type AlertsDb } from '@/alerts';
 import {
     closeZone as defaultCloseZone,
     getZoneState as defaultGetZoneState,
@@ -27,6 +28,11 @@ import {
 } from './runtime';
 import type { PersistedCycle } from './schedules';
 import { loadSiteTimezone, type SiteTimezoneDb } from './sites';
+import {
+    isWeatherStale,
+    markWeatherFetchSuccessful,
+    type WeatherStateDb,
+} from './weather-state';
 import { countZones, loadEnabledZones, type ZoneCountDb, type ZoneLoaderDb } from './zones';
 
 dayjs.extend(utc);
@@ -39,7 +45,7 @@ const DEFAULT_REPLAN_HOUR_LOCAL = 4;
  * pass the eager `db` export from `@/db`; tests pass a recording stub that
  * implements the union of the smaller per-helper interfaces.
  */
-export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb & ScheduleManagerDb;
+export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb & ScheduleManagerDb & WeatherStateDb & AlertsDb;
 
 /**
  * Caller-overridable hooks. Defaults wire to the real planning function and
@@ -69,6 +75,12 @@ export type DaemonOptions = {
 
     /** Override the notifier. Defaults to the no-op so tests don't have to. */
     notifier?: Notifier;
+
+    /**
+     * Override the alert recorder. Defaults to the no-op so tests don't have to
+     * provide a recording stub. Production wires `createAlertRecorder(db)`.
+     */
+    alertRecorder?: AlertRecorder;
 };
 
 /**
@@ -123,6 +135,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
 
     const registry = new TimerRegistry();
     const notifier = options?.notifier ?? noopNotifier;
+    const alertRecorder = options?.alertRecorder ?? noopAlertRecorder;
     let lastRePlanAt: Date | null = null;
     let started = false;
 
@@ -136,6 +149,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         clock,
         registry,
         notifier,
+        alertRecorder,
         closeZone,
         getZoneState,
         loadInFlightCycles,
@@ -149,7 +163,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     // and schedule-ended for this night, if applicable, were already emitted by
     // the prior process, and re-emitting on every restart would be misleading.
     for (const { cycle, zone } of futureCycles) {
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alertRecorder });
     }
 
     const { total, enabled } = await countZones(db);
@@ -224,18 +238,30 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                     cyclesToArm.push({ zone, cycle });
                     busyWindows.push({ start: cycle.startTime, end: cycleEnd });
                 }
+                // Successful runPlan implies a successful weather fetch — refresh
+                // the staleness timestamp and clear any lingering unacked
+                // weather-stale alert so the UI region collapses on recovery.
+                await Promise.all([
+                    markWeatherFetchSuccessful(db, clock.now()),
+                    clearAlertsByClass(db, 'weather-stale'),
+                ]);
             } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
                 console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
-                await notifier('error', {
-                    zoneName: zone.name,
-                    operation: 're-plan',
-                    reason: err instanceof Error ? err.message : String(err),
-                });
+                await notifier('error', { zoneName: zone.name, operation: 're-plan', reason });
+                if (await isWeatherStale(db, clock.now())) {
+                    await alertRecorder({
+                        class: 'weather-stale',
+                        tone: 'warn',
+                        title: 'Weather API stale',
+                        sub: `Planner on fallback ET₀ · last attempt failed: ${reason}`,
+                    });
+                }
             }
         }
 
         armCyclesWithScheduleMarkers(cyclesToArm, siteTimezone, ({ zone, cycle, scheduleStart, scheduleEnd }) => {
-            armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, scheduleStart, scheduleEnd });
+            armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alertRecorder, scheduleStart, scheduleEnd });
         });
 
         lastRePlanAt = clock.now();
@@ -246,7 +272,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const shutdown = async (): Promise<void> => {
         console.log('daemon: shutdown starting.');
         registry.cancelAllTimers(clock);
-        await closeAllInFlight({ db, clock, registry, closeZone, notifier });
+        await closeAllInFlight({ db, clock, registry, closeZone, notifier, alertRecorder });
         console.log('daemon: shutdown complete.');
     };
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
-import { clearAlertsByClass, noopAlertRecorder, type AlertRecorder, type AlertsDb } from '@/alerts';
+import { clearAlertsByClass, noopAlerter, type Alerter, type AlertsDb } from '@/alerts';
 import {
     closeZone as defaultCloseZone,
     getZoneState as defaultGetZoneState,
@@ -78,9 +78,9 @@ export type DaemonOptions = {
 
     /**
      * Override the alert recorder. Defaults to the no-op so tests don't have to
-     * provide a recording stub. Production wires `createAlertRecorder(db)`.
+     * provide a recording stub. Production wires `createAlerter(db)`.
      */
-    alertRecorder?: AlertRecorder;
+    alerter?: Alerter;
 };
 
 /**
@@ -135,7 +135,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
 
     const registry = new TimerRegistry();
     const notifier = options?.notifier ?? noopNotifier;
-    const alertRecorder = options?.alertRecorder ?? noopAlertRecorder;
+    const alerter = options?.alerter ?? noopAlerter;
     let lastRePlanAt: Date | null = null;
     let started = false;
 
@@ -149,7 +149,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         clock,
         registry,
         notifier,
-        alertRecorder,
+        alerter,
         closeZone,
         getZoneState,
         loadInFlightCycles,
@@ -163,7 +163,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     // and schedule-ended for this night, if applicable, were already emitted by
     // the prior process, and re-emitting on every restart would be misleading.
     for (const { cycle, zone } of futureCycles) {
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alertRecorder });
+        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alerter });
     }
 
     const { total, enabled } = await countZones(db);
@@ -249,7 +249,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                 const reason = err instanceof Error ? err.message : String(err);
                 console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
                 if (await isWeatherStale(db, clock.now())) {
-                    await alertRecorder({
+                    await alerter({
                         class: 'weather-stale',
                         tone: 'warn',
                         title: 'Weather API stale',
@@ -261,7 +261,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         }
 
         armCyclesWithScheduleMarkers(cyclesToArm, siteTimezone, ({ zone, cycle, scheduleStart, scheduleEnd }) => {
-            armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alertRecorder, scheduleStart, scheduleEnd });
+            armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alerter, scheduleStart, scheduleEnd });
         });
 
         lastRePlanAt = clock.now();
@@ -272,7 +272,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const shutdown = async (): Promise<void> => {
         console.log('daemon: shutdown starting.');
         registry.cancelAllTimers(clock);
-        await closeAllInFlight({ db, clock, registry, closeZone, alertRecorder });
+        await closeAllInFlight({ db, clock, registry, closeZone, alerter });
         console.log('daemon: shutdown complete.');
     };
 

--- a/api/daemon/reconcile.test.ts
+++ b/api/daemon/reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import type { AlertEvent, AlertRecorder } from '@/alerts';
+import type { AlertEvent, Alerter } from '@/alerts';
 import { irrigationCycles } from '@/db/schema';
 import type { ZoneRelayState } from '@/data/home-assistant';
 import type { Zone } from '@/models';
@@ -117,7 +117,7 @@ function buildDeps(overrides: {
     };
 
     const alertCalls: AlertEvent[] = [];
-    const alertRecorder: AlertRecorder = async (event) => {
+    const alerter: Alerter = async (event) => {
         alertCalls.push(event);
     };
 
@@ -132,7 +132,7 @@ function buildDeps(overrides: {
             clock: fakeClock(now),
             registry,
             notifier,
-            alertRecorder,
+            alerter,
             closeZone: overrides.closeFn ?? (async (zone) => { closes.push(zone); }),
             getZoneState: async (zone) => {
                 if (!overrides.state) return 'unknown';

--- a/api/daemon/reconcile.test.ts
+++ b/api/daemon/reconcile.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import type { AlertEvent, AlertRecorder } from '@/alerts';
 import { irrigationCycles } from '@/db/schema';
 import type { ZoneRelayState } from '@/data/home-assistant';
 import type { Zone } from '@/models';
@@ -72,6 +73,7 @@ function buildDeps(overrides: {
     armCalls: ArmCloseOnlyInputs[];
     cycleUpdates: CycleUpdate[];
     notifications: RecordedNotification[];
+    alertCalls: AlertEvent[];
 } {
     const closes: Zone[] = [];
     const armCalls: ArmCloseOnlyInputs[] = [];
@@ -114,16 +116,23 @@ function buildDeps(overrides: {
         notifications.push({ event, context });
     };
 
+    const alertCalls: AlertEvent[] = [];
+    const alertRecorder: AlertRecorder = async (event) => {
+        alertCalls.push(event);
+    };
+
     return {
         closes,
         armCalls,
         cycleUpdates,
         notifications,
+        alertCalls,
         deps: {
             db,
             clock: fakeClock(now),
             registry,
             notifier,
+            alertRecorder,
             closeZone: overrides.closeFn ?? (async (zone) => { closes.push(zone); }),
             getZoneState: async (zone) => {
                 if (!overrides.state) return 'unknown';
@@ -395,5 +404,119 @@ describe('reconcileCycleAndRelayState — aggregates', () => {
         const summary = await reconcileCycleAndRelayState(deps);
 
         expect(summary).toEqual({ resumed: 0, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 });
+    });
+});
+
+describe('reconcileCycleAndRelayState — alert recording', () => {
+    it('records a missed-close alert when the relay is already off past planned close', async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-missed',
+            startTime: new Date('2026-05-04T10:00:00.000Z'),
+            durationMin: 30, // planned close 10:30 < now 12:00
+        });
+        const { deps, alertCalls } = buildDeps({
+            inFlight: [pair],
+            state: async (): Promise<ZoneRelayState> => 'off',
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'missed-close',
+            tone: 'danger',
+            title: 'Missed close',
+            zoneId: pair.zone.id,
+        });
+    });
+
+    it('records a missed-close alert when the relay overran (state on past planned close)', async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-overrun',
+            startTime: new Date('2026-05-04T10:00:00.000Z'),
+            durationMin: 30,
+        });
+        const { deps, alertCalls } = buildDeps({
+            inFlight: [pair],
+            state: async (): Promise<ZoneRelayState> => 'on',
+            closeFn: async () => {},
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'missed-close',
+            tone: 'danger',
+            title: 'Missed close (relay overran)',
+            zoneId: pair.zone.id,
+        });
+    });
+
+    it('records a ha-call-failed alert when getZoneState throws for an in-flight cycle', async () => {
+        const pair = buildPair({ cycleId: 'cycle-err' });
+        const { deps, alertCalls } = buildDeps({
+            inFlight: [pair],
+            state: async () => { throw new Error('HA timeout'); },
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA state query failed',
+            zoneId: pair.zone.id,
+        });
+    });
+
+    it('records a ha-call-failed alert when the force-close call itself throws', async () => {
+        const pair = buildPair({
+            cycleId: 'cycle-force-fail',
+            startTime: new Date('2026-05-04T10:00:00.000Z'),
+            durationMin: 30,
+        });
+        const { deps, alertCalls } = buildDeps({
+            inFlight: [pair],
+            state: async (): Promise<ZoneRelayState> => 'on',
+            closeFn: async () => { throw new Error('HA 504'); },
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed (reconcile)',
+            zoneId: pair.zone.id,
+        });
+    });
+
+    it('records a ha-call-failed alert when the orphan sweep closes an unmanaged-open zone', async () => {
+        const orphan = buildZone({ id: 'zone-orphan', name: 'Orphan' });
+        const { deps, alertCalls } = buildDeps({
+            managedZones: [orphan],
+            state: async (): Promise<ZoneRelayState> => 'on',
+            closeFn: async () => {},
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            title: 'Orphan relay closed',
+            zoneId: 'zone-orphan',
+        });
+    });
+
+    it('records no alerts on a fully clean reconciliation pass', async () => {
+        const { deps, alertCalls } = buildDeps({});
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toEqual([]);
     });
 });

--- a/api/daemon/reconcile.test.ts
+++ b/api/daemon/reconcile.test.ts
@@ -519,4 +519,41 @@ describe('reconcileCycleAndRelayState — alert recording', () => {
 
         expect(alertCalls).toEqual([]);
     });
+
+    it('records a ha-call-failed alert when the defensive sweep getZoneState throws', async () => {
+        const sweep = buildZone({ id: 'zone-sweep' });
+        const { deps, alertCalls } = buildDeps({
+            managedZones: [sweep],
+            state: async () => { throw new Error('HA sweep timeout'); },
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA state query failed (sweep)',
+            zoneId: 'zone-sweep',
+        });
+    });
+
+    it('records a ha-call-failed alert when the orphan-close call itself throws', async () => {
+        const orphan = buildZone({ id: 'zone-bad' });
+        const { deps, alertCalls } = buildDeps({
+            managedZones: [orphan],
+            state: async (): Promise<ZoneRelayState> => 'on',
+            closeFn: async () => { throw new Error('HA 504'); },
+        });
+
+        await reconcileCycleAndRelayState(deps);
+
+        expect(alertCalls).toHaveLength(1);
+        expect(alertCalls[0]).toMatchObject({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed (orphan)',
+            zoneId: 'zone-bad',
+        });
+    });
 });

--- a/api/daemon/reconcile.test.ts
+++ b/api/daemon/reconcile.test.ts
@@ -198,7 +198,7 @@ describe('reconcileCycleAndRelayState — in-flight cycle handling', () => {
             startTime: new Date('2026-05-04T10:00:00.000Z'),
             durationMin: 30, // closes at 10:30, well before now=12:00
         });
-        const { deps, closes, cycleUpdates, notifications } = buildDeps({
+        const { deps, closes, cycleUpdates } = buildDeps({
             inFlight: [pair],
             state: async (): Promise<ZoneRelayState> => 'on',
         });
@@ -208,8 +208,6 @@ describe('reconcileCycleAndRelayState — in-flight cycle handling', () => {
         expect(summary).toMatchObject({ resumed: 0, forcedClosed: 1, missedClose: 0, orphansClosed: 0 });
         expect(closes).toHaveLength(1);
         expect(cycleUpdates).toEqual([{ cycleId: 'cycle-overrun', closedAt: NOW }]);
-        const overrunNote = notifications.find(n => n.context?.operation === 'reconcile-overrun');
-        expect(overrunNote).toBeDefined();
     });
 
     it(`records closed_at = plannedCloseAt when HA is 'off' and the planned close is earlier than now`, async () => {
@@ -264,7 +262,7 @@ describe('reconcileCycleAndRelayState — in-flight cycle handling', () => {
 
     it('counts an error and skips the cycle when getZoneState throws', async () => {
         const pair = buildPair({ cycleId: 'cycle-err' });
-        const { deps, cycleUpdates, closes, notifications } = buildDeps({
+        const { deps, cycleUpdates, closes } = buildDeps({
             inFlight: [pair],
             state: async () => { throw new Error('HA timeout'); },
         });
@@ -274,15 +272,13 @@ describe('reconcileCycleAndRelayState — in-flight cycle handling', () => {
         expect(summary).toMatchObject({ errors: 1 });
         expect(cycleUpdates).toHaveLength(0);
         expect(closes).toHaveLength(0);
-        const errNote = notifications.find(n => n.context?.operation === 'reconcile-state');
-        expect(errNote?.context?.reason).toBe('HA timeout');
     });
 });
 
 describe('reconcileCycleAndRelayState — defensive sweep', () => {
     it(`force-closes a managed zone HA reports 'on' with no in-flight cycle`, async () => {
         const orphan = buildZone({ id: 'zone-orphan', name: 'Orphan' });
-        const { deps, closes, notifications } = buildDeps({
+        const { deps, closes } = buildDeps({
             managedZones: [orphan],
             state: async (): Promise<ZoneRelayState> => 'on',
         });
@@ -291,8 +287,6 @@ describe('reconcileCycleAndRelayState — defensive sweep', () => {
 
         expect(summary).toMatchObject({ orphansClosed: 1 });
         expect(closes).toEqual([orphan]);
-        const orphanNote = notifications.find(n => n.context?.operation === 'reconcile-orphan-close');
-        expect(orphanNote?.context?.zoneName).toBe('Orphan');
     });
 
     it(`takes no action for a managed zone HA reports 'off'`, async () => {
@@ -342,7 +336,7 @@ describe('reconcileCycleAndRelayState — defensive sweep', () => {
 
     it('counts an error when the orphan close itself fails', async () => {
         const orphan = buildZone({ id: 'zone-bad' });
-        const { deps, notifications } = buildDeps({
+        const { deps } = buildDeps({
             managedZones: [orphan],
             state: async (): Promise<ZoneRelayState> => 'on',
             closeFn: async () => { throw new Error('HA 504'); },
@@ -351,8 +345,6 @@ describe('reconcileCycleAndRelayState — defensive sweep', () => {
         const summary = await reconcileCycleAndRelayState(deps);
 
         expect(summary).toMatchObject({ errors: 1, orphansClosed: 0 });
-        const errNote = notifications.find(n => n.context?.operation === 'reconcile-orphan-close' && n.context?.reason === 'HA 504');
-        expect(errNote).toBeDefined();
     });
 });
 

--- a/api/daemon/reconcile.ts
+++ b/api/daemon/reconcile.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import type { AlertRecorder } from '@/alerts';
 import { irrigationCycles } from '@/db/schema';
 import type { ZoneRelayState } from '@/data/home-assistant';
 import type { Zone } from '@/models';
@@ -40,6 +41,7 @@ export type ReconcileDeps = {
     clock: Clock;
     registry: TimerRegistry;
     notifier: Notifier;
+    alertRecorder: AlertRecorder;
     closeZone: (zone: Zone) => Promise<void>;
     getZoneState: (zone: Zone) => Promise<ZoneRelayState>;
     loadInFlightCycles: (db: ReconcileDb, now: Date) => Promise<FutureCyclePair[]>;
@@ -67,7 +69,7 @@ export type ReconcileDeps = {
  * @returns Counters describing what changed.
  */
 export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<ReconcileSummary> {
-    const { db, clock, registry, notifier, closeZone, getZoneState, loadInFlightCycles, armCloseOnly, managedZones } = deps;
+    const { db, clock, registry, notifier, alertRecorder, closeZone, getZoneState, loadInFlightCycles, armCloseOnly, managedZones } = deps;
 
     const summary: ReconcileSummary = { resumed: 0, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 };
     const handledZoneIds = new Set<string>();
@@ -82,8 +84,16 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         try {
             state = await getZoneState(zone);
         } catch (err) {
+            const reason = errorMessage(err);
             console.error(`daemon: reconcile getZoneState failed for cycle ${cycle.id} on zone ${zone.id}; skipping.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-state', reason: errorMessage(err) });
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-state', reason });
+            await alertRecorder({
+                class: 'ha-call-failed',
+                tone: 'danger',
+                title: 'HA state query failed',
+                sub: `${zone.name} · ${reason}`,
+                zoneId: zone.id,
+            });
             summary.errors += 1;
             continue;
         }
@@ -94,7 +104,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         }
 
         if (state === 'on' && plannedCloseAt.getTime() > now.getTime()) {
-            armCloseOnly({ db, clock, registry, zone, cycle, closeZone, notifier, plannedCloseAt });
+            armCloseOnly({ db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, plannedCloseAt });
             handledZoneIds.add(zone.id);
             summary.resumed += 1;
             console.log(`daemon: reconcile resumed cycle ${cycle.id} on zone ${zone.id} (closes at ${plannedCloseAt.toISOString()}).`);
@@ -105,8 +115,16 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             try {
                 await closeZone(zone);
             } catch (err) {
+                const reason = errorMessage(err);
                 console.error(`daemon: reconcile force-close failed for cycle ${cycle.id} on zone ${zone.id}.`, err);
-                await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun-close', reason: errorMessage(err) });
+                await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun-close', reason });
+                await alertRecorder({
+                    class: 'ha-call-failed',
+                    tone: 'danger',
+                    title: 'HA close failed (reconcile)',
+                    sub: `${zone.name} · ${reason}`,
+                    zoneId: zone.id,
+                });
                 summary.errors += 1;
                 continue;
             }
@@ -116,6 +134,13 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             summary.forcedClosed += 1;
             console.warn(`daemon: reconcile force-closed cycle ${cycle.id} on zone ${zone.id} — relay was open past planned close ${plannedCloseAt.toISOString()}.`);
             await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun', reason: `relay still open past planned close ${plannedCloseAt.toISOString()}` });
+            await alertRecorder({
+                class: 'missed-close',
+                tone: 'danger',
+                title: 'Missed close (relay overran)',
+                sub: `${zone.name} cycle relay was still open past planned close ${plannedCloseAt.toISOString()}`,
+                zoneId: zone.id,
+            });
             continue;
         }
 
@@ -125,6 +150,13 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         handledZoneIds.add(zone.id);
         summary.missedClose += 1;
         console.log(`daemon: reconcile recorded missed close for cycle ${cycle.id} on zone ${zone.id} (set closed_at=${closedAt.toISOString()}).`);
+        await alertRecorder({
+            class: 'missed-close',
+            tone: 'danger',
+            title: 'Missed close',
+            sub: `${zone.name} cycle missed expected close · set closed_at=${closedAt.toISOString()}`,
+            zoneId: zone.id,
+        });
     }
 
     for (const zone of managedZones) {
@@ -135,8 +167,16 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         try {
             state = await getZoneState(zone);
         } catch (err) {
+            const reason = errorMessage(err);
             console.error(`daemon: reconcile getZoneState failed during defensive sweep for zone ${zone.id}; skipping.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-sweep-state', reason: errorMessage(err) });
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-sweep-state', reason });
+            await alertRecorder({
+                class: 'ha-call-failed',
+                tone: 'danger',
+                title: 'HA state query failed (sweep)',
+                sub: `${zone.name} · ${reason}`,
+                zoneId: zone.id,
+            });
             summary.errors += 1;
             continue;
         }
@@ -146,14 +186,29 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         try {
             await closeZone(zone);
         } catch (err) {
+            const reason = errorMessage(err);
             console.error(`daemon: reconcile orphan-close failed for zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason: errorMessage(err) });
+            await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason });
+            await alertRecorder({
+                class: 'ha-call-failed',
+                tone: 'danger',
+                title: 'HA close failed (orphan)',
+                sub: `${zone.name} · ${reason}`,
+                zoneId: zone.id,
+            });
             summary.errors += 1;
             continue;
         }
         summary.orphansClosed += 1;
         console.warn(`daemon: reconcile force-closed unmanaged-open zone ${zone.id} (${zone.homeAssistantEntityId}); no in-flight cycle backed it.`);
         await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason: `relay was on at boot with no in-flight cycle` });
+        await alertRecorder({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'Orphan relay closed',
+            sub: `${zone.name} relay was on at boot with no in-flight cycle backing it`,
+            zoneId: zone.id,
+        });
     }
 
     return summary;

--- a/api/daemon/reconcile.ts
+++ b/api/daemon/reconcile.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import type { AlertRecorder } from '@/alerts';
+import type { Alerter } from '@/alerts';
 import { irrigationCycles } from '@/db/schema';
 import type { ZoneRelayState } from '@/data/home-assistant';
 import type { Zone } from '@/models';
@@ -41,7 +41,7 @@ export type ReconcileDeps = {
     clock: Clock;
     registry: TimerRegistry;
     notifier: Notifier;
-    alertRecorder: AlertRecorder;
+    alerter: Alerter;
     closeZone: (zone: Zone) => Promise<void>;
     getZoneState: (zone: Zone) => Promise<ZoneRelayState>;
     loadInFlightCycles: (db: ReconcileDb, now: Date) => Promise<FutureCyclePair[]>;
@@ -69,7 +69,7 @@ export type ReconcileDeps = {
  * @returns Counters describing what changed.
  */
 export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<ReconcileSummary> {
-    const { db, clock, registry, notifier, alertRecorder, closeZone, getZoneState, loadInFlightCycles, armCloseOnly, managedZones } = deps;
+    const { db, clock, registry, notifier, alerter, closeZone, getZoneState, loadInFlightCycles, armCloseOnly, managedZones } = deps;
 
     const summary: ReconcileSummary = { resumed: 0, forcedClosed: 0, missedClose: 0, orphansClosed: 0, errors: 0 };
     const handledZoneIds = new Set<string>();
@@ -86,7 +86,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: reconcile getZoneState failed for cycle ${cycle.id} on zone ${zone.id}; skipping.`, err);
-            await alertRecorder({
+            await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA state query failed',
@@ -104,7 +104,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         }
 
         if (state === 'on' && plannedCloseAt.getTime() > now.getTime()) {
-            armCloseOnly({ db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, plannedCloseAt });
+            armCloseOnly({ db, clock, registry, zone, cycle, closeZone, notifier, alerter, plannedCloseAt });
             handledZoneIds.add(zone.id);
             summary.resumed += 1;
             console.log(`daemon: reconcile resumed cycle ${cycle.id} on zone ${zone.id} (closes at ${plannedCloseAt.toISOString()}).`);
@@ -117,7 +117,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             } catch (err) {
                 const reason = errorMessage(err);
                 console.error(`daemon: reconcile force-close failed for cycle ${cycle.id} on zone ${zone.id}.`, err);
-                await alertRecorder({
+                await alerter({
                     class: 'ha-call-failed',
                     tone: 'danger',
                     title: 'HA close failed (reconcile)',
@@ -133,7 +133,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             handledZoneIds.add(zone.id);
             summary.forcedClosed += 1;
             console.warn(`daemon: reconcile force-closed cycle ${cycle.id} on zone ${zone.id} — relay was open past planned close ${plannedCloseAt.toISOString()}.`);
-            await alertRecorder({
+            await alerter({
                 class: 'missed-close',
                 tone: 'danger',
                 title: 'Missed close (relay overran)',
@@ -150,7 +150,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         handledZoneIds.add(zone.id);
         summary.missedClose += 1;
         console.log(`daemon: reconcile recorded missed close for cycle ${cycle.id} on zone ${zone.id} (set closed_at=${closedAt.toISOString()}).`);
-        await alertRecorder({
+        await alerter({
             class: 'missed-close',
             tone: 'danger',
             title: 'Missed close',
@@ -170,7 +170,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: reconcile getZoneState failed during defensive sweep for zone ${zone.id}; skipping.`, err);
-            await alertRecorder({
+            await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA state query failed (sweep)',
@@ -189,7 +189,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: reconcile orphan-close failed for zone ${zone.id}.`, err);
-            await alertRecorder({
+            await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA close failed (orphan)',
@@ -202,7 +202,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         }
         summary.orphansClosed += 1;
         console.warn(`daemon: reconcile force-closed unmanaged-open zone ${zone.id} (${zone.homeAssistantEntityId}); no in-flight cycle backed it.`);
-        await alertRecorder({
+        await alerter({
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'Orphan relay closed',

--- a/api/daemon/reconcile.ts
+++ b/api/daemon/reconcile.ts
@@ -86,13 +86,13 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: reconcile getZoneState failed for cycle ${cycle.id} on zone ${zone.id}; skipping.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-state', reason });
             await alertRecorder({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA state query failed',
                 sub: `${zone.name} · ${reason}`,
                 zoneId: zone.id,
+                zoneName: zone.name,
             });
             summary.errors += 1;
             continue;
@@ -117,13 +117,13 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             } catch (err) {
                 const reason = errorMessage(err);
                 console.error(`daemon: reconcile force-close failed for cycle ${cycle.id} on zone ${zone.id}.`, err);
-                await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun-close', reason });
                 await alertRecorder({
                     class: 'ha-call-failed',
                     tone: 'danger',
                     title: 'HA close failed (reconcile)',
                     sub: `${zone.name} · ${reason}`,
                     zoneId: zone.id,
+                    zoneName: zone.name,
                 });
                 summary.errors += 1;
                 continue;
@@ -133,13 +133,13 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             handledZoneIds.add(zone.id);
             summary.forcedClosed += 1;
             console.warn(`daemon: reconcile force-closed cycle ${cycle.id} on zone ${zone.id} — relay was open past planned close ${plannedCloseAt.toISOString()}.`);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-overrun', reason: `relay still open past planned close ${plannedCloseAt.toISOString()}` });
             await alertRecorder({
                 class: 'missed-close',
                 tone: 'danger',
                 title: 'Missed close (relay overran)',
                 sub: `${zone.name} cycle relay was still open past planned close ${plannedCloseAt.toISOString()}`,
                 zoneId: zone.id,
+                zoneName: zone.name,
             });
             continue;
         }
@@ -156,6 +156,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             title: 'Missed close',
             sub: `${zone.name} cycle missed expected close · set closed_at=${closedAt.toISOString()}`,
             zoneId: zone.id,
+            zoneName: zone.name,
         });
     }
 
@@ -169,13 +170,13 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: reconcile getZoneState failed during defensive sweep for zone ${zone.id}; skipping.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-sweep-state', reason });
             await alertRecorder({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA state query failed (sweep)',
                 sub: `${zone.name} · ${reason}`,
                 zoneId: zone.id,
+                zoneName: zone.name,
             });
             summary.errors += 1;
             continue;
@@ -188,26 +189,26 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: reconcile orphan-close failed for zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason });
             await alertRecorder({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA close failed (orphan)',
                 sub: `${zone.name} · ${reason}`,
                 zoneId: zone.id,
+                zoneName: zone.name,
             });
             summary.errors += 1;
             continue;
         }
         summary.orphansClosed += 1;
         console.warn(`daemon: reconcile force-closed unmanaged-open zone ${zone.id} (${zone.homeAssistantEntityId}); no in-flight cycle backed it.`);
-        await notifier('error', { zoneName: zone.name, operation: 'reconcile-orphan-close', reason: `relay was on at boot with no in-flight cycle` });
         await alertRecorder({
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'Orphan relay closed',
             sub: `${zone.name} relay was on at boot with no in-flight cycle backing it`,
             zoneId: zone.id,
+            zoneName: zone.name,
         });
     }
 

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import type { AlertRecorder } from '@/alerts';
 import { irrigationCycles } from '@/db/schema';
 import type { Zone } from '@/models';
 import type { Notifier } from '@/notifications';
@@ -149,6 +150,7 @@ export type ArmCycleInputs = {
     openZone: (zone: Zone) => Promise<void>;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    alertRecorder: AlertRecorder;
 
     /**
      * Set on the chronologically earliest armed cycle of an irrigation
@@ -190,13 +192,21 @@ export function armCycle(inputs: ArmCycleInputs): void {
 }
 
 async function runOpen(inputs: ArmCycleInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, openZone, closeZone, notifier, scheduleStart, scheduleEnd } = inputs;
+    const { db, clock, registry, zone, cycle, openZone, closeZone, notifier, alertRecorder, scheduleStart, scheduleEnd } = inputs;
 
     try {
         await openZone(zone);
     } catch (err) {
+        const reason = errorMessage(err);
         console.error(`daemon: openZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving fired_at NULL.`, err);
-        await notifier('error', { zoneName: zone.name, operation: 'open', reason: errorMessage(err) });
+        await notifier('error', { zoneName: zone.name, operation: 'open', reason });
+        await alertRecorder({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA open failed',
+            sub: `${zone.name} · ${reason}`,
+            zoneId: zone.id,
+        });
         return;
     }
 
@@ -212,7 +222,7 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
     const closeDelay = cycle.durationMin * 60_000;
     const endTime = new Date(firedAt.getTime() + closeDelay);
     const closeHandle = clock.setTimeout(() => {
-        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, scheduleEnd }).catch(err => {
+        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, scheduleEnd }).catch(err => {
             console.error(`daemon: unhandled error in cycle close path for ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -234,6 +244,7 @@ export type ArmCloseOnlyInputs = {
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    alertRecorder: AlertRecorder;
 
     /** Wall-clock time at which the close should fire. Past times fire immediately. */
     plannedCloseAt: Date;
@@ -249,11 +260,11 @@ export type ArmCloseOnlyInputs = {
  * @param inputs - Collaborators and the cycle/zone whose close is being re-armed.
  */
 export function armCloseOnly(inputs: ArmCloseOnlyInputs): void {
-    const { db, clock, registry, zone, cycle, closeZone, notifier, plannedCloseAt } = inputs;
+    const { db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, plannedCloseAt } = inputs;
     const closeDelay = Math.max(0, plannedCloseAt.getTime() - clock.now().getTime());
 
     const closeHandle = clock.setTimeout(() => {
-        runClose({ db, clock, registry, zone, cycle, closeZone, notifier }).catch(err => {
+        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder }).catch(err => {
             console.error(`daemon: unhandled error in close-only path for cycle ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -268,19 +279,28 @@ type RunCloseInputs = {
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    alertRecorder: AlertRecorder;
     /** Set on the last cycle of an irrigation night so close emits `schedule-ended`. */
     scheduleEnd?: ScheduleEndMarker;
 };
 
 async function runClose(inputs: RunCloseInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, closeZone, notifier, scheduleEnd } = inputs;
+    const { db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, scheduleEnd } = inputs;
 
     try {
         await closeZone(zone);
     } catch (err) {
+        const reason = errorMessage(err);
         console.error(`daemon: closeZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving closed_at NULL.`, err);
         registry.clearInFlight(cycle.id);
-        await notifier('error', { zoneName: zone.name, operation: 'close', reason: errorMessage(err) });
+        await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+        await alertRecorder({
+            class: 'ha-call-failed',
+            tone: 'danger',
+            title: 'HA close failed',
+            sub: `${zone.name} · ${reason}`,
+            zoneId: zone.id,
+        });
         return;
     }
 
@@ -312,8 +332,9 @@ export async function closeAllInFlight(inputs: {
     registry: TimerRegistry;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    alertRecorder: AlertRecorder;
 }): Promise<void> {
-    const { db, clock, registry, closeZone, notifier } = inputs;
+    const { db, clock, registry, closeZone, notifier, alertRecorder } = inputs;
     const inFlight = registry.snapshotInFlight();
 
     if (inFlight.length === 0) return;
@@ -324,8 +345,16 @@ export async function closeAllInFlight(inputs: {
             await closeZone(zone);
             await db.update(irrigationCycles).set({ closedAt: clock.now() }).where(eq(irrigationCycles.id, cycleId));
         } catch (err) {
+            const reason = errorMessage(err);
             console.error(`daemon: shutdown closeZone failed for cycle ${cycleId} on zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'shutdown-close', reason: errorMessage(err) });
+            await notifier('error', { zoneName: zone.name, operation: 'shutdown-close', reason });
+            await alertRecorder({
+                class: 'ha-call-failed',
+                tone: 'danger',
+                title: 'HA close failed (shutdown)',
+                sub: `${zone.name} · ${reason}`,
+                zoneId: zone.id,
+            });
         }
         registry.clearInFlight(cycleId);
     }

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm';
-import type { AlertRecorder } from '@/alerts';
+import type { Alerter } from '@/alerts';
 import { irrigationCycles } from '@/db/schema';
 import type { Zone } from '@/models';
 import type { Notifier } from '@/notifications';
@@ -150,7 +150,7 @@ export type ArmCycleInputs = {
     openZone: (zone: Zone) => Promise<void>;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
-    alertRecorder: AlertRecorder;
+    alerter: Alerter;
 
     /**
      * Set on the chronologically earliest armed cycle of an irrigation
@@ -192,14 +192,14 @@ export function armCycle(inputs: ArmCycleInputs): void {
 }
 
 async function runOpen(inputs: ArmCycleInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, openZone, closeZone, notifier, alertRecorder, scheduleStart, scheduleEnd } = inputs;
+    const { db, clock, registry, zone, cycle, openZone, closeZone, notifier, alerter, scheduleStart, scheduleEnd } = inputs;
 
     try {
         await openZone(zone);
     } catch (err) {
         const reason = errorMessage(err);
         console.error(`daemon: openZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving fired_at NULL.`, err);
-        await alertRecorder({
+        await alerter({
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'HA open failed',
@@ -222,7 +222,7 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
     const closeDelay = cycle.durationMin * 60_000;
     const endTime = new Date(firedAt.getTime() + closeDelay);
     const closeHandle = clock.setTimeout(() => {
-        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, scheduleEnd }).catch(err => {
+        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, alerter, scheduleEnd }).catch(err => {
             console.error(`daemon: unhandled error in cycle close path for ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -244,7 +244,7 @@ export type ArmCloseOnlyInputs = {
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
-    alertRecorder: AlertRecorder;
+    alerter: Alerter;
 
     /** Wall-clock time at which the close should fire. Past times fire immediately. */
     plannedCloseAt: Date;
@@ -260,11 +260,11 @@ export type ArmCloseOnlyInputs = {
  * @param inputs - Collaborators and the cycle/zone whose close is being re-armed.
  */
 export function armCloseOnly(inputs: ArmCloseOnlyInputs): void {
-    const { db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, plannedCloseAt } = inputs;
+    const { db, clock, registry, zone, cycle, closeZone, notifier, alerter, plannedCloseAt } = inputs;
     const closeDelay = Math.max(0, plannedCloseAt.getTime() - clock.now().getTime());
 
     const closeHandle = clock.setTimeout(() => {
-        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder }).catch(err => {
+        runClose({ db, clock, registry, zone, cycle, closeZone, notifier, alerter }).catch(err => {
             console.error(`daemon: unhandled error in close-only path for cycle ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -279,13 +279,13 @@ type RunCloseInputs = {
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
-    alertRecorder: AlertRecorder;
+    alerter: Alerter;
     /** Set on the last cycle of an irrigation night so close emits `schedule-ended`. */
     scheduleEnd?: ScheduleEndMarker;
 };
 
 async function runClose(inputs: RunCloseInputs): Promise<void> {
-    const { db, clock, registry, zone, cycle, closeZone, notifier, alertRecorder, scheduleEnd } = inputs;
+    const { db, clock, registry, zone, cycle, closeZone, notifier, alerter, scheduleEnd } = inputs;
 
     try {
         await closeZone(zone);
@@ -293,7 +293,7 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
         const reason = errorMessage(err);
         console.error(`daemon: closeZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving closed_at NULL.`, err);
         registry.clearInFlight(cycle.id);
-        await alertRecorder({
+        await alerter({
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'HA close failed',
@@ -331,9 +331,9 @@ export async function closeAllInFlight(inputs: {
     clock: Clock;
     registry: TimerRegistry;
     closeZone: (zone: Zone) => Promise<void>;
-    alertRecorder: AlertRecorder;
+    alerter: Alerter;
 }): Promise<void> {
-    const { db, clock, registry, closeZone, alertRecorder } = inputs;
+    const { db, clock, registry, closeZone, alerter } = inputs;
     const inFlight = registry.snapshotInFlight();
 
     if (inFlight.length === 0) return;
@@ -346,7 +346,7 @@ export async function closeAllInFlight(inputs: {
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: shutdown closeZone failed for cycle ${cycleId} on zone ${zone.id}.`, err);
-            await alertRecorder({
+            await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA close failed (shutdown)',

--- a/api/daemon/runtime.ts
+++ b/api/daemon/runtime.ts
@@ -199,13 +199,13 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
     } catch (err) {
         const reason = errorMessage(err);
         console.error(`daemon: openZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving fired_at NULL.`, err);
-        await notifier('error', { zoneName: zone.name, operation: 'open', reason });
         await alertRecorder({
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'HA open failed',
             sub: `${zone.name} · ${reason}`,
             zoneId: zone.id,
+            zoneName: zone.name,
         });
         return;
     }
@@ -293,13 +293,13 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
         const reason = errorMessage(err);
         console.error(`daemon: closeZone failed for cycle ${cycle.id} on zone ${zone.id}; leaving closed_at NULL.`, err);
         registry.clearInFlight(cycle.id);
-        await notifier('error', { zoneName: zone.name, operation: 'close', reason });
         await alertRecorder({
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'HA close failed',
             sub: `${zone.name} · ${reason}`,
             zoneId: zone.id,
+            zoneName: zone.name,
         });
         return;
     }
@@ -331,10 +331,9 @@ export async function closeAllInFlight(inputs: {
     clock: Clock;
     registry: TimerRegistry;
     closeZone: (zone: Zone) => Promise<void>;
-    notifier: Notifier;
     alertRecorder: AlertRecorder;
 }): Promise<void> {
-    const { db, clock, registry, closeZone, notifier, alertRecorder } = inputs;
+    const { db, clock, registry, closeZone, alertRecorder } = inputs;
     const inFlight = registry.snapshotInFlight();
 
     if (inFlight.length === 0) return;
@@ -347,13 +346,13 @@ export async function closeAllInFlight(inputs: {
         } catch (err) {
             const reason = errorMessage(err);
             console.error(`daemon: shutdown closeZone failed for cycle ${cycleId} on zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'shutdown-close', reason });
             await alertRecorder({
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA close failed (shutdown)',
                 sub: `${zone.name} · ${reason}`,
                 zoneId: zone.id,
+                zoneName: zone.name,
             });
         }
         registry.clearInFlight(cycleId);

--- a/api/daemon/weather-state.test.ts
+++ b/api/daemon/weather-state.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'bun:test';
+import {
+    isWeatherStale,
+    markWeatherFetchSuccessful,
+    WEATHER_STALE_THRESHOLD_MS,
+    type WeatherStateReaderDb,
+    type WeatherStateWriterDb,
+} from './weather-state';
+
+const NOW = new Date('2026-05-20T12:00:00.000Z');
+
+type WriterCall = {
+    values: Record<string, unknown>;
+    conflictTarget: unknown;
+    conflictSet: Record<string, unknown>;
+};
+
+function createWriterStub(): { db: WeatherStateWriterDb; calls: WriterCall[] } {
+    const calls: WriterCall[] = [];
+    const db: WeatherStateWriterDb = {
+        insert: (_table) => ({
+            values: (row) => ({
+                onConflictDoUpdate: async (config) => {
+                    calls.push({ values: row, conflictTarget: config.target, conflictSet: config.set });
+                },
+            }),
+        }),
+    };
+    return { db, calls };
+}
+
+function createReaderStub(rows: ReadonlyArray<{ lastSuccessfulFetchAt: Date | null }>): WeatherStateReaderDb {
+    return {
+        select: (_cols) => ({
+            from: (_table) => ({
+                where: (_cond) => ({
+                    limit: (_n) => Promise.resolve([...rows]),
+                }),
+            }),
+        }),
+    };
+}
+
+describe('markWeatherFetchSuccessful', () => {
+    it('upserts the singleton row with the supplied timestamp', async () => {
+        const { db, calls } = createWriterStub();
+
+        await markWeatherFetchSuccessful(db, NOW);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]!.values).toEqual({
+            id: 'singleton',
+            lastSuccessfulFetchAt: NOW,
+        });
+    });
+
+    it('targets the singleton row id on conflict and refreshes the timestamp', async () => {
+        const { db, calls } = createWriterStub();
+
+        await markWeatherFetchSuccessful(db, NOW);
+
+        expect(calls[0]!.conflictTarget).toBeDefined();
+        expect('lastSuccessfulFetchAt' in calls[0]!.conflictSet).toBe(true);
+    });
+
+    it('records every invocation independently — repeated calls each issue an upsert', async () => {
+        const { db, calls } = createWriterStub();
+
+        await markWeatherFetchSuccessful(db, NOW);
+        await markWeatherFetchSuccessful(db, new Date(NOW.getTime() + 60_000));
+
+        expect(calls).toHaveLength(2);
+    });
+});
+
+describe('isWeatherStale', () => {
+    it('returns true when no row exists yet (never fetched successfully)', async () => {
+        const db = createReaderStub([]);
+
+        const result = await isWeatherStale(db, NOW);
+
+        expect(result).toBe(true);
+    });
+
+    it('returns true when the row exists but lastSuccessfulFetchAt is null', async () => {
+        const db = createReaderStub([{ lastSuccessfulFetchAt: null }]);
+
+        const result = await isWeatherStale(db, NOW);
+
+        expect(result).toBe(true);
+    });
+
+    it('returns true when the last fetch is older than the default 24h threshold', async () => {
+        const stale = new Date(NOW.getTime() - (WEATHER_STALE_THRESHOLD_MS + 60_000));
+        const db = createReaderStub([{ lastSuccessfulFetchAt: stale }]);
+
+        const result = await isWeatherStale(db, NOW);
+
+        expect(result).toBe(true);
+    });
+
+    it('returns false when the last fetch is exactly at the threshold boundary (not stale yet)', async () => {
+        const atBoundary = new Date(NOW.getTime() - WEATHER_STALE_THRESHOLD_MS);
+        const db = createReaderStub([{ lastSuccessfulFetchAt: atBoundary }]);
+
+        const result = await isWeatherStale(db, NOW);
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false when the last fetch is well within the threshold', async () => {
+        const fresh = new Date(NOW.getTime() - 60_000);
+        const db = createReaderStub([{ lastSuccessfulFetchAt: fresh }]);
+
+        const result = await isWeatherStale(db, NOW);
+
+        expect(result).toBe(false);
+    });
+
+    it('honours an explicit threshold override', async () => {
+        // 5 minutes ago, threshold 1 minute → stale.
+        const recent = new Date(NOW.getTime() - 5 * 60_000);
+        const db = createReaderStub([{ lastSuccessfulFetchAt: recent }]);
+
+        const result = await isWeatherStale(db, NOW, 60_000);
+
+        expect(result).toBe(true);
+    });
+});

--- a/api/daemon/weather-state.ts
+++ b/api/daemon/weather-state.ts
@@ -1,0 +1,89 @@
+import { eq, sql } from 'drizzle-orm';
+import { WEATHER_STATE_SINGLETON_ID, weatherState } from '@/db/schema';
+
+/**
+ * Cutoff for the `weather-stale` alert. Re-plans run once a day, so anything
+ * older than 24 hours means today's plan was generated against stale (or
+ * absent) ET₀.
+ */
+export const WEATHER_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimal db interface used by the writer. Mirrors the seed-script pattern —
+ * production passes Drizzle directly, tests pass a recording stub.
+ */
+export type WeatherStateWriterDb = {
+    insert: (table: typeof weatherState) => {
+        values: (row: Record<string, unknown>) => {
+            onConflictDoUpdate: (config: {
+                target: unknown;
+                set: Record<string, unknown>;
+            }) => Promise<unknown>;
+        };
+    };
+};
+
+/**
+ * Minimal db interface used by the reader. Returns the singleton row's
+ * timestamp (or an empty array when no row exists yet).
+ */
+export type WeatherStateReaderDb = {
+    select: (cols: { lastSuccessfulFetchAt: typeof weatherState.lastSuccessfulFetchAt }) => {
+        from: (table: typeof weatherState) => {
+            where: (cond: unknown) => {
+                limit: (n: number) => Promise<Array<{ lastSuccessfulFetchAt: Date | null }>>;
+            };
+        };
+    };
+};
+
+/**
+ * Composite for callers that need both surfaces.
+ */
+export type WeatherStateDb = WeatherStateWriterDb & WeatherStateReaderDb;
+
+/**
+ * Stamps the singleton row with `now` so the next staleness check passes.
+ * Upserts on conflict — the row is created lazily the first time a fetch
+ * succeeds, and updates in place on every subsequent success.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param now - Wall-clock timestamp to record. Injectable so callers can drive
+ *   the clock under test.
+ */
+export async function markWeatherFetchSuccessful(db: WeatherStateWriterDb, now: Date): Promise<void> {
+    await db
+        .insert(weatherState)
+        .values({ id: WEATHER_STATE_SINGLETON_ID, lastSuccessfulFetchAt: now })
+        .onConflictDoUpdate({
+            target: weatherState.id,
+            set: { lastSuccessfulFetchAt: sql`excluded.last_successful_fetch_at` },
+        });
+}
+
+/**
+ * Returns `true` when the planner should be treated as running on stale
+ * weather: either the singleton row doesn't exist yet (no fetch has ever
+ * succeeded) or its timestamp is older than `threshold` milliseconds.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param now - Reference timestamp. Use the daemon's clock so tests can
+ *   advance time deterministically.
+ * @param threshold - Milliseconds before a fetch is considered stale.
+ *   Defaults to `WEATHER_STALE_THRESHOLD_MS`.
+ */
+export async function isWeatherStale(
+    db: WeatherStateReaderDb,
+    now: Date,
+    threshold: number = WEATHER_STALE_THRESHOLD_MS,
+): Promise<boolean> {
+    const rows = await db
+        .select({ lastSuccessfulFetchAt: weatherState.lastSuccessfulFetchAt })
+        .from(weatherState)
+        .where(eq(weatherState.id, WEATHER_STATE_SINGLETON_ID))
+        .limit(1);
+
+    const row = rows[0];
+    if (!row || row.lastSuccessfulFetchAt === null) return true;
+    return now.getTime() - row.lastSuccessfulFetchAt.getTime() > threshold;
+}

--- a/api/db/schema/alerts.ts
+++ b/api/db/schema/alerts.ts
@@ -1,0 +1,31 @@
+import { sql } from 'drizzle-orm';
+import { boolean, check, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+import { zones } from './zones';
+
+/**
+ * Operator-facing failure records. The daemon writes a row whenever a failure
+ * the operator should know about happens — HA call failed, planner running on
+ * stale weather, scheduled close was missed at boot. The mobile app reads
+ * unacked rows out of `GET /alerts` to drive the persistent alert region.
+ *
+ * Dedup is application-level: at most one unacked row per `(class, zoneId)`
+ * exists at a time. Repeated failures of the same class update the existing
+ * row's `whenAt` and content. Acking via `POST /alerts/:id/ack` flips `ack`
+ * to true; a subsequent failure of the same class will insert a fresh row
+ * rather than touch the acked history.
+ */
+export const alerts = pgTable('alerts', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    class: text('class').notNull(),
+    tone: text('tone').notNull(),
+    title: text('title').notNull(),
+    sub: text('sub'),
+    whenAt: timestamp('when_at', { withTimezone: true }).notNull().defaultNow(),
+    zoneId: uuid('zone_id').references(() => zones.id),
+    ack: boolean('ack').notNull().default(false),
+    ...auditColumns,
+}, (table) => [
+    check('alerts_class_check', sql`${table.class} in ('weather-stale', 'ha-call-failed', 'missed-close')`),
+    check('alerts_tone_check', sql`${table.tone} in ('warn', 'danger')`),
+]);

--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -1,7 +1,9 @@
+export { alerts } from './alerts';
 export { grassTypes } from './grass-types';
 export { irrigationCycles } from './irrigation-cycles';
 export { scheduleEntries } from './schedule-entries';
 export { schedules } from './schedules';
 export { sites } from './sites';
 export { soilTypes } from './soil-types';
+export { weatherState, WEATHER_STATE_SINGLETON_ID } from './weather-state';
 export { zones } from './zones';

--- a/api/db/schema/weather-state.ts
+++ b/api/db/schema/weather-state.ts
@@ -1,0 +1,21 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+
+/**
+ * Singleton row tracking when the planner last successfully pulled weather
+ * data. The id column is a constant string ('singleton') so upserts always
+ * target the same row. `lastSuccessfulFetchAt` is null until the first
+ * successful re-plan; the daemon treats null as "stale" and records a
+ * `weather-stale` alert on the next failed attempt.
+ */
+export const weatherState = pgTable('weather_state', {
+    id: text('id').primaryKey(),
+    lastSuccessfulFetchAt: timestamp('last_successful_fetch_at', { withTimezone: true }),
+    ...auditColumns,
+});
+
+/**
+ * The fixed primary key value used for the singleton row. Exported so the
+ * recorder and reader can avoid embedding the literal in every query.
+ */
+export const WEATHER_STATE_SINGLETON_ID = 'singleton';

--- a/api/drizzle/0009_long_morlun.sql
+++ b/api/drizzle/0009_long_morlun.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "alerts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"class" text NOT NULL,
+	"tone" text NOT NULL,
+	"title" text NOT NULL,
+	"sub" text,
+	"when_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"zone_id" uuid,
+	"ack" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "alerts_class_check" CHECK ("alerts"."class" in ('weather-stale', 'ha-call-failed', 'missed-close')),
+	CONSTRAINT "alerts_tone_check" CHECK ("alerts"."tone" in ('warn', 'danger'))
+);
+--> statement-breakpoint
+CREATE TABLE "weather_state" (
+	"id" text PRIMARY KEY NOT NULL,
+	"last_successful_fetch_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "alerts" ADD CONSTRAINT "alerts_zone_id_zones_id_fk" FOREIGN KEY ("zone_id") REFERENCES "public"."zones"("id") ON DELETE no action ON UPDATE no action;

--- a/api/drizzle/meta/0009_snapshot.json
+++ b/api/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,885 @@
+{
+  "id": "bf49ddee-7c37-488d-88ed-7b41f9e93a01",
+  "prevId": "3d70d4cf-c35a-4cd2-8d1a-df352c677fe9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_at": {
+          "name": "when_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack": {
+          "name": "ack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_zone_id_zones_id_fk": {
+          "name": "alerts_zone_id_zones_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alerts_class_check": {
+          "name": "alerts_class_check",
+          "value": "\"alerts\".\"class\" in ('weather-stale', 'ha-call-failed', 'missed-close')"
+        },
+        "alerts_tone_check": {
+          "name": "alerts_tone_check",
+          "value": "\"alerts\".\"tone\" in ('warn', 'danger')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_state": {
+      "name": "weather_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_fetch_at": {
+          "name": "last_successful_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1779249612119,
       "tag": "0008_new_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1779284921318,
+      "tag": "0009_long_morlun",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -417,7 +417,7 @@ if (import.meta.main) {
         :   closeZone;
     const effectiveGetZoneState: typeof getZoneState = dryRun ? async _zone => 'off' as const : getZoneState;
     const alertsDb = db as unknown as AlertsDb;
-    const alertRecorder = createAlertRecorder(alertsDb);
+    const alertRecorder = createAlertRecorder(alertsDb, notifier);
     const daemon = await daemonStart(db as unknown as DaemonDb, {
         notifier,
         alertRecorder,

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,4 +1,12 @@
 import Config from '@/config';
+import {
+    acknowledgeAlert,
+    createAlertRecorder,
+    listActiveAlerts,
+    type AckResult,
+    type AlertDto,
+    type AlertsDb,
+} from '@/alerts';
 import { start as daemonStart, type DaemonControl, type DaemonDb, type DaemonStatus } from '@/daemon';
 import { realClock } from '@/daemon/runtime';
 import {
@@ -85,6 +93,16 @@ export type BuildAppOptions = {
      * need this surface can omit the field.
      */
     zonesSummary?: () => Promise<ZoneSummary[]>;
+
+    /**
+     * Optional. When supplied, registers `GET /alerts` and `POST /alerts/:id/ack`
+     * — the persistent alert region surface for the mobile app. Production
+     * binds these to the alerts module's DB-backed reader and ack helper.
+     */
+    alerts?: {
+        list: () => Promise<AlertDto[]>;
+        ack: (id: string) => Promise<AckResult>;
+    };
 };
 
 /**
@@ -128,7 +146,42 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerZonesSummaryRoute(app, opts.zonesSummary);
     }
 
+    if (opts.alerts) {
+        registerAlertRoutes(app, opts.alerts);
+    }
+
     return app;
+}
+
+function registerAlertRoutes(
+    app: FastifyInstance,
+    alerts: { list: () => Promise<AlertDto[]>; ack: (id: string) => Promise<AckResult> },
+): void {
+    /**
+     * `GET /alerts` — returns the unacked alert list driving the mobile app's
+     * persistent alert region. Empty array when no alerts are currently active
+     * — the UI region collapses to zero height. Order is newest-first.
+     */
+    app.get('/alerts', async (_req, reply) => {
+        const list = await alerts.list();
+        return reply.code(200).send({ alerts: list });
+    });
+
+    /**
+     * `POST /alerts/:id/ack` — dismisses an alert from the UI without
+     * resolving the underlying condition. Idempotent: re-acking an already-
+     * acked alert returns 200 (`already-acked`) rather than 409 so the mobile
+     * client can safely retry on flaky connectivity. Returns 404 only when no
+     * row matches the id at all.
+     */
+    app.post('/alerts/:id/ack', async (req, reply) => {
+        const { id } = req.params as { id: string };
+        const result = await alerts.ack(id);
+        if (result === 'not-found') {
+            return reply.code(404).send({ error: 'not-found', message: `Alert ${id} not found.` });
+        }
+        return reply.code(200).send({ status: result });
+    });
 }
 
 function registerZonesSummaryRoute(
@@ -363,8 +416,11 @@ if (import.meta.main) {
             }
         :   closeZone;
     const effectiveGetZoneState: typeof getZoneState = dryRun ? async _zone => 'off' as const : getZoneState;
+    const alertsDb = db as unknown as AlertsDb;
+    const alertRecorder = createAlertRecorder(alertsDb);
     const daemon = await daemonStart(db as unknown as DaemonDb, {
         notifier,
+        alertRecorder,
         openZone: effectiveOpenZone,
         closeZone: effectiveCloseZone,
         getZoneState: effectiveGetZoneState,
@@ -389,6 +445,10 @@ if (import.meta.main) {
         schedule: wrapScheduleWithReplan(baseSchedule, () => daemon.rePlan()),
         replan: () => daemon.rePlan(),
         zonesSummary: () => loadZoneSummaries(db as unknown as ZoneSummaryDb),
+        alerts: {
+            list: () => listActiveAlerts(alertsDb),
+            ack: id => acknowledgeAlert(alertsDb, id),
+        },
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,7 +1,7 @@
 import Config from '@/config';
 import {
     acknowledgeAlert,
-    createAlertRecorder,
+    createAlerter,
     listActiveAlerts,
     type AckResult,
     type AlertDto,
@@ -417,10 +417,10 @@ if (import.meta.main) {
         :   closeZone;
     const effectiveGetZoneState: typeof getZoneState = dryRun ? async _zone => 'off' as const : getZoneState;
     const alertsDb = db as unknown as AlertsDb;
-    const alertRecorder = createAlertRecorder(alertsDb, notifier);
+    const alerter = createAlerter(alertsDb, notifier);
     const daemon = await daemonStart(db as unknown as DaemonDb, {
         notifier,
-        alertRecorder,
+        alerter,
         openZone: effectiveOpenZone,
         closeZone: effectiveCloseZone,
         getZoneState: effectiveGetZoneState,


### PR DESCRIPTION
## Ticket

[API-48](http://192.168.2.100:7123/irrigo/browse/API-48/) — GET /alerts — current active issues (weather stale, HA failure, missed close)

## Summary

- Adds an `alerts` table (with `class` and `tone` check constraints) and a `weather_state` singleton row for tracking the last successful Open-Meteo fetch. Drizzle migration `0009_long_morlun.sql`.
- New `api/alerts/` module: `AlertRecorder` (writer) with `(class, zoneId)` dedup, `listActiveAlerts` (newest-first, unacked-only), `acknowledgeAlert` (3-way result), `clearAlertsByClass`.
- New `api/daemon/weather-state.ts`: `markWeatherFetchSuccessful` + `isWeatherStale` (24h threshold; null = stale).
- Wires `AlertRecorder` through the daemon: `runOpen` / `runClose` / `closeAllInFlight` fire `ha-call-failed`; reconciler fires `ha-call-failed` (state/close failures) + `missed-close` (off-past + overrun). Re-plan loop stamps `weather_state.lastSuccessfulFetchAt` + clears unacked `weather-stale` on every successful per-zone plan; on failure records `weather-stale` only when staleness is detected.
- New routes:
  - `GET /alerts` → `{ alerts: AlertDto[] }`, newest-first, unacked-only.
  - `POST /alerts/:id/ack` → 200 `{ status: 'acked' | 'already-acked' }` (idempotent) / 404.

## Notifier unification (2nd commit set)

The earlier draft called `notifier('error', ...)` and `alertRecorder({...})` back-to-back at every failure site. Unified those: **the alert recorder now owns the HA push for errors** — `createAlertRecorder(db, notifier)` fires `notifier('error', { zoneName, operation: class, reason })` as a side effect of inserting a new alert. Update (dedup hit) does NOT re-fire — repeated failures of the same `(class, zoneId)` get one HA push, then stay quiet until acked.

Net effects:
- Every `await notifier('error', ...)` call in `runtime.ts` / `reconcile.ts` / the daemon re-plan loop is gone.
- `closeAllInFlight` no longer takes a notifier (it never emitted schedule-* events).
- Behaviour shift: re-plan failures that AREN'T weather-stale (e.g. transient DB errors) no longer fire HA push — silent log only. Consistent with the new "alerts are the failure surface" model.
- `schedule-begun` / `schedule-ended` notifier calls are unchanged.

## Test plan

- Schema + migration: `bun run db:generate` produces `0009_long_morlun.sql` cleanly.
- `api/alerts/.test.ts` — 19 tests (recorder dedup + notifier fan-out on insert/no-fire-on-update, reader DTO mapping + ordering, ack 3-way, class-clear idempotence).
- `api/daemon/weather-state.test.ts` — 9 tests across upsert + staleness boundaries.
- `api/daemon/.test.ts` — alert-recording tests for armCycle/closeAllInFlight; rePlan success-marker + stale-gated weather-stale + non-stale-suppression. Obsolete notifier-error assertions removed.
- `api/daemon/reconcile.test.ts` — 8 alert-recording tests covering all 5 failure branches + clean-pass.
- `api/.test.ts` — 7 route tests for GET /alerts and POST /alerts/:id/ack.
- **Full suite: 579 pass, 0 fail.**