### PR TITLE
[API-47] POST /schedule/skip-tonight + resume-tonight

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -371,12 +371,13 @@ describe('buildApp manual zone routes', () => {
 
 describe('buildApp schedule routes', () => {
     const NOW = new Date('2026-05-08T12:00:00.000Z');
-    const buildSchedule = (overrides?: Partial<{ slug: string; name: string; siteId: string; isActive: boolean }>) => ({
+    const buildSchedule = (overrides?: Partial<{ slug: string; name: string; siteId: string; isActive: boolean; skippedNightDate: string | null }>) => ({
         id: 'sched-1',
         siteId: 'site-A',
         slug: 'maintenance',
         name: 'Maintenance',
         isActive: true,
+        skippedNightDate: null as string | null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,
@@ -458,6 +459,142 @@ describe('buildApp schedule routes', () => {
         await app.close();
     });
 
+    describe('POST /schedule/skip-tonight', () => {
+        it('returns 200 with the post-update schedule on success', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async () => null,
+                    disable: async () => null,
+                    skipTonight: async () => buildSchedule({ slug: 'maintenance', name: 'Maintenance', siteId: 'site-A', skippedNightDate: '2026-05-20' }),
+                    resumeTonight: async () => null,
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/skip-tonight' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({
+                status: 'skipped',
+                schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-A', skippedNightDate: '2026-05-20' },
+            });
+            await app.close();
+        });
+
+        it('returns 404 when no schedule is active', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async () => null,
+                    disable: async () => null,
+                    skipTonight: async () => null,
+                    resumeTonight: async () => null,
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/skip-tonight' });
+
+            expect(res.statusCode).toBe(404);
+            expect(res.json()).toMatchObject({ error: 'not-found' });
+            await app.close();
+        });
+
+        it('returns 502 when the wrapped re-plan rejects', async () => {
+            const base: ScheduleApi = {
+                enable: async () => null,
+                disable: async () => null,
+                skipTonight: async () => buildSchedule({ skippedNightDate: '2026-05-20' }),
+                resumeTonight: async () => null,
+            };
+            const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('HA 503'); });
+            const app = buildApp({ getStatus: () => buildStatus(), schedule: wrapped });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/skip-tonight' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'HA 503' });
+            await app.close();
+        });
+    });
+
+    describe('POST /schedule/resume-tonight', () => {
+        it('returns 200 with the cleared schedule on success', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async () => null,
+                    disable: async () => null,
+                    skipTonight: async () => null,
+                    resumeTonight: async () => buildSchedule({ slug: 'maintenance', name: 'Maintenance', siteId: 'site-A', skippedNightDate: null }),
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/resume-tonight' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({
+                status: 'resumed',
+                schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-A', skippedNightDate: null },
+            });
+            await app.close();
+        });
+
+        it('is idempotent: returns 200 even when the marker was already null', async () => {
+            // The handler returns the row with skippedNightDate:null whether or not it
+            // was previously set; the route should treat that as success, not a no-op
+            // failure.
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async () => null,
+                    disable: async () => null,
+                    skipTonight: async () => null,
+                    resumeTonight: async () => buildSchedule({ skippedNightDate: null }),
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/resume-tonight' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toMatchObject({ status: 'resumed' });
+            await app.close();
+        });
+
+        it('returns 404 when no schedule is active', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                schedule: {
+                    enable: async () => null,
+                    disable: async () => null,
+                    skipTonight: async () => null,
+                    resumeTonight: async () => null,
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/resume-tonight' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+
+        it('returns 502 when the wrapped re-plan rejects', async () => {
+            const base: ScheduleApi = {
+                enable: async () => null,
+                disable: async () => null,
+                skipTonight: async () => null,
+                resumeTonight: async () => buildSchedule({ skippedNightDate: null }),
+            };
+            const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('HA 504'); });
+            const app = buildApp({ getStatus: () => buildStatus(), schedule: wrapped });
+
+            const res = await app.inject({ method: 'POST', url: '/schedule/resume-tonight' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'HA 504' });
+            await app.close();
+        });
+    });
+
     describe('wrapped with replan', () => {
         it('returns 502 when the wrapped enable closure rejects (re-plan failed)', async () => {
             // Simulate the production wiring: enable throws because replan threw.
@@ -493,7 +630,7 @@ describe('buildApp schedule routes', () => {
 });
 
 describe('wrapScheduleWithReplan', () => {
-    const buildSchedule = (overrides?: Partial<{ slug: string; name: string; siteId: string; isActive: boolean }>) => ({
+    const buildSchedule = (overrides?: Partial<{ slug: string; name: string; siteId: string; isActive: boolean; skippedNightDate: string | null }>) => ({
         id: 'sched-1',
         siteId: 'site-A',
         slug: 'maintenance',
@@ -503,6 +640,7 @@ describe('wrapScheduleWithReplan', () => {
         allowedTimeWindows: null,
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
+        skippedNightDate: null as string | null,
         createdAt: new Date('2026-05-11T18:00:00.000Z'),
         updatedAt: new Date('2026-05-11T18:00:00.000Z'),
         ...overrides,
@@ -571,10 +709,90 @@ describe('wrapScheduleWithReplan', () => {
         const base: ScheduleApi = {
             enable: async (slug) => buildSchedule({ slug }),
             disable: async () => null,
+            skipTonight: async () => null,
+            resumeTonight: async () => null,
         };
         const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('replan failed'); });
 
         await expect(wrapped.enable('maintenance')).rejects.toThrow('replan failed');
+    });
+
+    it('calls replan after a non-null skipTonight result, awaiting it before returning', async () => {
+        const callOrder: string[] = [];
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+            skipTonight: async () => { callOrder.push('skip'); return buildSchedule({ skippedNightDate: '2026-05-20' }); },
+            resumeTonight: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => {
+            await Promise.resolve();
+            callOrder.push('replan');
+        });
+
+        const result = await wrapped.skipTonight();
+        callOrder.push('returned');
+
+        expect(result?.skippedNightDate).toBe('2026-05-20');
+        expect(callOrder).toEqual(['skip', 'replan', 'returned']);
+    });
+
+    it('skips replan when skipTonight returns null (no active schedule)', async () => {
+        let replanCalls = 0;
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+            skipTonight: async () => null,
+            resumeTonight: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { replanCalls += 1; });
+
+        const result = await wrapped.skipTonight();
+
+        expect(result).toBeNull();
+        expect(replanCalls).toBe(0);
+    });
+
+    it('calls replan after a non-null resumeTonight result', async () => {
+        const callOrder: string[] = [];
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+            skipTonight: async () => null,
+            resumeTonight: async () => { callOrder.push('resume'); return buildSchedule({ skippedNightDate: null }); },
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { callOrder.push('replan'); });
+
+        await wrapped.resumeTonight();
+
+        expect(callOrder).toEqual(['resume', 'replan']);
+    });
+
+    it('skips replan when resumeTonight returns null', async () => {
+        let replanCalls = 0;
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+            skipTonight: async () => null,
+            resumeTonight: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { replanCalls += 1; });
+
+        await wrapped.resumeTonight();
+
+        expect(replanCalls).toBe(0);
+    });
+
+    it('propagates replan rejections through skipTonight', async () => {
+        const base: ScheduleApi = {
+            enable: async () => null,
+            disable: async () => null,
+            skipTonight: async () => buildSchedule({ skippedNightDate: '2026-05-20' }),
+            resumeTonight: async () => null,
+        };
+        const wrapped = wrapScheduleWithReplan(base, async () => { throw new Error('replan failed'); });
+
+        await expect(wrapped.skipTonight()).rejects.toThrow('replan failed');
     });
 });
 

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -673,7 +673,7 @@ describe('replaceZoneSchedule', () => {
         const { db, deleteCalls, insertCalls } = createScheduleWriterStub();
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
 
-        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
+        await replaceZoneSchedule(db, 'zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
 
         expect(deleteCalls).toHaveLength(1);
         expect(deleteCalls[0]?.table).toBe(scheduleEntries);
@@ -687,7 +687,7 @@ describe('replaceZoneSchedule', () => {
             buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
         ];
 
-        await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04', 0, 'sched-overseed');
+        await replaceZoneSchedule(db, 'zone-001', entries, dayjs('2026-05-04'), 0, 'sched-overseed');
 
         const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
         expect(entryInserts).toHaveLength(2);
@@ -703,7 +703,7 @@ describe('replaceZoneSchedule', () => {
             buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
         ];
 
-        await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04', 0, 'sched-default');
+        await replaceZoneSchedule(db, 'zone-001', entries, dayjs('2026-05-04'), 0, 'sched-default');
 
         const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
         expect(entryInserts).toHaveLength(2);
@@ -724,7 +724,7 @@ describe('replaceZoneSchedule', () => {
             { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
         ]);
 
-        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
+        await replaceZoneSchedule(db, 'zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
 
         const cycleInserts = insertCalls.filter(c => c.table === irrigationCycles);
         expect(cycleInserts).toHaveLength(1);
@@ -746,7 +746,7 @@ describe('replaceZoneSchedule', () => {
             { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
         ]);
 
-        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
+        const result = await replaceZoneSchedule(db, 'zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
 
         expect(result.cycles).toHaveLength(2);
         expect(result.cycles[0]?.id).toBe('cycle-A1');
@@ -767,7 +767,7 @@ describe('replaceZoneSchedule', () => {
             buildEntry('2026-05-05', [{ startTime: '2026-05-05T05:00:00Z', durationMin: 15 }]),
         ];
 
-        const result = await replaceZoneSchedule(db, 'zone-001', entries, '2026-05-04', 0, 'sched-default');
+        const result = await replaceZoneSchedule(db, 'zone-001', entries, dayjs('2026-05-04'), 0, 'sched-default');
 
         expect(result.cycles).toHaveLength(2);
         expect(result.cycles[0]?.entryDate).toBe('2026-05-04');
@@ -777,7 +777,7 @@ describe('replaceZoneSchedule', () => {
     it('still issues the delete and inserts no rows when given an empty entries array', async () => {
         const { db, deleteCalls, insertCalls } = createScheduleWriterStub();
 
-        const result = await replaceZoneSchedule(db, 'zone-001', [], '2026-05-04', 0, 'sched-default');
+        const result = await replaceZoneSchedule(db, 'zone-001', [], dayjs('2026-05-04'), 0, 'sched-default');
 
         expect(deleteCalls).toHaveLength(1);
         expect(insertCalls).toHaveLength(0);
@@ -788,7 +788,7 @@ describe('replaceZoneSchedule', () => {
         const { db, insertCalls } = createScheduleWriterStub({ entries: ['entry-A'] });
         const entry = buildEntry('2026-05-04', []);
 
-        const result = await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 0, 'sched-default');
+        const result = await replaceZoneSchedule(db, 'zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
 
         expect(insertCalls.filter(c => c.table === scheduleEntries)).toHaveLength(1);
         expect(insertCalls.filter(c => c.table === irrigationCycles)).toHaveLength(0);
@@ -799,7 +799,7 @@ describe('replaceZoneSchedule', () => {
         const { db, updateCalls } = createScheduleWriterStub();
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
 
-        await replaceZoneSchedule(db, 'zone-001', [entry], '2026-05-04', 7.5, 'sched-default');
+        await replaceZoneSchedule(db, 'zone-001', [entry], dayjs('2026-05-04'), 7.5, 'sched-default');
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.table).toBe(zones);
@@ -809,7 +809,7 @@ describe('replaceZoneSchedule', () => {
     it('writes the depletion update even when the entries array is empty', async () => {
         const { db, updateCalls } = createScheduleWriterStub();
 
-        await replaceZoneSchedule(db, 'zone-002', [], '2026-05-04', 12.3, 'sched-default');
+        await replaceZoneSchedule(db, 'zone-002', [], dayjs('2026-05-04'), 12.3, 'sched-default');
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 12.3 });

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -8,6 +8,7 @@ import {
     grassTypes,
     irrigationCycles,
     scheduleEntries,
+    schedules,
     sites,
     soilTypes,
     weatherState,
@@ -1783,6 +1784,7 @@ type DaemonStubInputs = {
         rootDepthMOverride: number | null;
         allowableDepletionFractionOverride: number | null;
         endBySunrise: boolean | null;
+        skippedNightDate: string | null;
         createdAt: Date;
         updatedAt: Date;
     } }>;
@@ -1836,10 +1838,16 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             rootDepthMOverride: null,
             allowableDepletionFractionOverride: null,
             endBySunrise: null,
+            skippedNightDate: null,
             createdAt: NOW_FOR_SCHEDULES,
             updatedAt: NOW_FOR_SCHEDULES,
         },
     }];
+
+    const schedulesTableUpdates: Array<{ set: Record<string, unknown>; cond: unknown }> = [];
+    let callOrder = 0;
+    let firstClearStaleCallOrder: number | null = null;
+    let firstActiveScheduleReadOrder: number | null = null;
 
     const db: DaemonDb = {
         select(columns) {
@@ -1870,7 +1878,10 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
             if ('schedule' in cols && Object.keys(cols).length === 1) {
                 return {
                     from: () => ({
-                        where: () => Promise.resolve([...activeScheduleRows]),
+                        where: () => {
+                            if (firstActiveScheduleReadOrder === null) firstActiveScheduleReadOrder = ++callOrder;
+                            return Promise.resolve([...activeScheduleRows]);
+                        },
                     }),
                 } as never;
             }
@@ -1932,10 +1943,16 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
         update(table) {
             const isZonesUpdate = table === zones;
             const isAlertsUpdate = table === alerts;
+            const isSchedulesUpdate = table === schedules;
             return {
                 set(values) {
                     return {
                         async where(cond) {
+                            if (isSchedulesUpdate) {
+                                if (firstClearStaleCallOrder === null) firstClearStaleCallOrder = ++callOrder;
+                                schedulesTableUpdates.push({ set: values, cond });
+                                return Promise.resolve(undefined);
+                            }
                             if (isZonesUpdate) {
                                 const zoneId = extractZoneId(cond);
                                 const currentDepletionMm = values['currentDepletionMm'];
@@ -1967,7 +1984,17 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
         },
     };
 
-    return { db, updates, zoneUpdates, inserts, deletes, weatherStateUpserts, alertTableUpdates };
+    return {
+        db,
+        updates,
+        zoneUpdates,
+        inserts,
+        deletes,
+        weatherStateUpserts,
+        alertTableUpdates,
+        schedulesTableUpdates,
+        getOrdering: () => ({ clearStale: firstClearStaleCallOrder, activeScheduleRead: firstActiveScheduleReadOrder }),
+    };
 }
 
 // Walks an `eq(zones.id, X)` condition the same way `extractCycleId` walks the cycle equivalent.
@@ -3077,6 +3104,107 @@ describe('start', () => {
             } finally {
                 warnSpy.mockRestore();
             }
+        });
+
+        it(`forwards the active schedule's skippedNightDate to runPlan restrictions`, async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-skip', siteId: 'site-Skip' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-skip', siteId: 'site-Skip', slug: 'maintenance', name: 'Maintenance',
+                        isActive: true,
+                        allowedDays: null, allowedTimeWindows: null,
+                        rootDepthMOverride: null, allowableDepletionFractionOverride: null,
+                        endBySunrise: null,
+                        skippedNightDate: '2099-05-04',
+                        createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: Array<{ skippedNightDate: unknown }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    planCalls.push({ skippedNightDate: opts?.restrictions?.skippedNightDate });
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toHaveLength(1);
+            // Default stub today is 2026-05-04 (NOW). The 2099 marker is in the future
+            // so it survives `clearStaleSkipMarkers` and is forwarded to the planner.
+            expect(planCalls[0]?.skippedNightDate).toBe('2099-05-04');
+        });
+
+        it('forwards skippedNightDate: null when the active schedule has no marker', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-clean', siteId: 'site-Clean' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                activeSchedules: [{
+                    schedule: {
+                        id: 'sched-clean', siteId: 'site-Clean', slug: 'maintenance', name: 'Maintenance',
+                        isActive: true,
+                        allowedDays: null, allowedTimeWindows: null,
+                        rootDepthMOverride: null, allowableDepletionFractionOverride: null,
+                        endBySunrise: null,
+                        skippedNightDate: null,
+                        createdAt: NOW, updatedAt: NOW,
+                    },
+                }],
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: Array<{ skippedNightDate: unknown }> = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (_z, opts) => {
+                    planCalls.push({ skippedNightDate: opts?.restrictions?.skippedNightDate });
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toHaveLength(1);
+            expect(planCalls[0]?.skippedNightDate).toBeNull();
+        });
+
+        it('issues a clearStaleSkipMarkers update before reading active schedules', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-order', siteId: 'site-001' } });
+            const { db, schedulesTableUpdates, getOrdering } = createDaemonDbStub({ enabledZones: [enabledRow] });
+            const { clock } = createFakeClock(NOW);
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            // First schedules-table update is the clearStaleSkipMarkers call.
+            expect(schedulesTableUpdates.length).toBeGreaterThanOrEqual(1);
+            expect(schedulesTableUpdates[0]?.set).toEqual({ skippedNightDate: null });
+            const ordering = getOrdering();
+            expect(ordering.clearStale).not.toBeNull();
+            expect(ordering.activeScheduleRead).not.toBeNull();
+            expect(ordering.clearStale!).toBeLessThan(ordering.activeScheduleRead!);
         });
     });
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -13,7 +13,7 @@ import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
-import { loadActiveSchedulesBySite, type Schedule, type ScheduleManagerDb } from './schedule-manager';
+import { clearStaleSkipMarkers, loadActiveSchedulesBySite, type Schedule, type ScheduleManagerDb } from './schedule-manager';
 import { loadFutureCycles, loadInFlightCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
 import {
     armCloseOnly,
@@ -189,9 +189,13 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         console.log('daemon: re-plan starting.');
         registry.cancelOpenTimers(clock);
 
+        const today = dayjs(clock.now()).format('YYYY-MM-DD');
+        // Wipe markers from past nights before snapshotting active schedules so
+        // a stale entry can't accidentally apply to the new night's plan.
+        await clearStaleSkipMarkers(db, today);
+
         const enabledZones = await loadEnabledZones(db);
         const activeSchedulesBySite: Map<string, Schedule> = await loadActiveSchedulesBySite(db);
-        const today = dayjs(clock.now()).format('YYYY-MM-DD');
         const now = clock.now();
         const busyWindows: Array<{ start: Date; end: Date }> = registry.snapshotInFlight()
             .map(({ endTime }) => ({ start: now, end: endTime }));
@@ -216,6 +220,7 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
                     allowedDays: activeSchedule.allowedDays,
                     allowedTimeWindows: activeSchedule.allowedTimeWindows,
                     endBySunrise: activeSchedule.endBySunrise ?? false,
+                    skippedNightDate: activeSchedule.skippedNightDate ?? null,
                 };
                 const overrides = {
                     rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -189,11 +189,10 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         console.log('daemon: re-plan starting.');
         registry.cancelOpenTimers(clock);
 
-        const todayDayjs = dayjs(clock.now());
-        const today = todayDayjs.format('YYYY-MM-DD');
+        const today = dayjs(clock.now());
         // Wipe markers from past nights before snapshotting active schedules so
         // a stale entry can't accidentally apply to the new night's plan.
-        await clearStaleSkipMarkers(db, todayDayjs);
+        await clearStaleSkipMarkers(db, today);
 
         const enabledZones = await loadEnabledZones(db);
         const activeSchedulesBySite: Map<string, Schedule> = await loadActiveSchedulesBySite(db);

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -189,10 +189,11 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
         console.log('daemon: re-plan starting.');
         registry.cancelOpenTimers(clock);
 
-        const today = dayjs(clock.now()).format('YYYY-MM-DD');
+        const todayDayjs = dayjs(clock.now());
+        const today = todayDayjs.format('YYYY-MM-DD');
         // Wipe markers from past nights before snapshotting active schedules so
         // a stale entry can't accidentally apply to the new night's plan.
-        await clearStaleSkipMarkers(db, today);
+        await clearStaleSkipMarkers(db, todayDayjs);
 
         const enabledZones = await loadEnabledZones(db);
         const activeSchedulesBySite: Map<string, Schedule> = await loadActiveSchedulesBySite(db);

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -26,6 +26,7 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
         endBySunrise: null,
+        skippedNightDate: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import dayjs from 'dayjs';
 import { schedules } from '@/db/schema';
 import {
     clearStaleSkipMarkers,
@@ -227,7 +228,7 @@ describe('skipActiveScheduleTonight', () => {
         const active = buildSchedule({ id: 'sched-active', slug: 'maintenance', isActive: true, skippedNightDate: null });
         const { db, updateCalls, getRows } = createStub([active]);
 
-        const result = await skipActiveScheduleTonight(db, '2026-05-20');
+        const result = await skipActiveScheduleTonight(db, dayjs('2026-05-20'));
 
         expect(result?.id).toBe('sched-active');
         expect(result?.skippedNightDate).toBe('2026-05-20');
@@ -240,7 +241,7 @@ describe('skipActiveScheduleTonight', () => {
         const inactive = buildSchedule({ id: 'sched-1', isActive: false });
         const { db, updateCalls } = createStub([inactive]);
 
-        const result = await skipActiveScheduleTonight(db, '2026-05-20');
+        const result = await skipActiveScheduleTonight(db, dayjs('2026-05-20'));
 
         expect(result).toBeNull();
         expect(updateCalls).toHaveLength(0);
@@ -251,7 +252,7 @@ describe('skipActiveScheduleTonight', () => {
         const inactive = buildSchedule({ id: 'sched-B', siteId: 'site-A', slug: 'overseeding', isActive: false });
         const { db, getRows } = createStub([active, inactive]);
 
-        await skipActiveScheduleTonight(db, '2026-05-20');
+        await skipActiveScheduleTonight(db, dayjs('2026-05-20'));
 
         expect(getRows().find(r => r.id === 'sched-A')?.skippedNightDate).toBe('2026-05-20');
         expect(getRows().find(r => r.id === 'sched-B')?.skippedNightDate).toBeNull();
@@ -300,7 +301,7 @@ describe('clearStaleSkipMarkers', () => {
         const fresh = buildSchedule({ id: 'sched-B', skippedNightDate: '2026-05-20' });
         const { db, updateCalls } = createStub([stale, fresh]);
 
-        await clearStaleSkipMarkers(db, '2026-05-20');
+        await clearStaleSkipMarkers(db, dayjs('2026-05-20'));
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.values).toEqual({ skippedNightDate: null });
@@ -311,7 +312,7 @@ describe('clearStaleSkipMarkers', () => {
         const b = buildSchedule({ id: 'sched-B', skippedNightDate: null });
         const { db, updateCalls } = createStub([a, b]);
 
-        await clearStaleSkipMarkers(db, '2026-05-20');
+        await clearStaleSkipMarkers(db, dayjs('2026-05-20'));
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.values).toEqual({ skippedNightDate: null });

--- a/api/daemon/schedule-manager.test.ts
+++ b/api/daemon/schedule-manager.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'bun:test';
 import { schedules } from '@/db/schema';
 import {
+    clearStaleSkipMarkers,
     disableSchedule,
     enableSchedule,
     loadActiveSchedulesBySite,
     loadScheduleBySlug,
+    resumeActiveScheduleTonight,
+    skipActiveScheduleTonight,
     type Schedule,
     type ScheduleManagerDb,
 } from './schedule-manager';
@@ -216,6 +219,102 @@ describe('disableSchedule', () => {
 
         expect(result).toBeNull();
         expect(updateCalls).toHaveLength(0);
+    });
+});
+
+describe('skipActiveScheduleTonight', () => {
+    it('sets skippedNightDate on the active schedule and returns the row', async () => {
+        const active = buildSchedule({ id: 'sched-active', slug: 'maintenance', isActive: true, skippedNightDate: null });
+        const { db, updateCalls, getRows } = createStub([active]);
+
+        const result = await skipActiveScheduleTonight(db, '2026-05-20');
+
+        expect(result?.id).toBe('sched-active');
+        expect(result?.skippedNightDate).toBe('2026-05-20');
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0]?.values).toEqual({ skippedNightDate: '2026-05-20' });
+        expect(getRows().find(r => r.id === 'sched-active')?.skippedNightDate).toBe('2026-05-20');
+    });
+
+    it('returns null without writing when no schedule is active', async () => {
+        const inactive = buildSchedule({ id: 'sched-1', isActive: false });
+        const { db, updateCalls } = createStub([inactive]);
+
+        const result = await skipActiveScheduleTonight(db, '2026-05-20');
+
+        expect(result).toBeNull();
+        expect(updateCalls).toHaveLength(0);
+    });
+
+    it('does not touch inactive rows on the same site', async () => {
+        const active = buildSchedule({ id: 'sched-A', siteId: 'site-A', slug: 'maintenance', isActive: true });
+        const inactive = buildSchedule({ id: 'sched-B', siteId: 'site-A', slug: 'overseeding', isActive: false });
+        const { db, getRows } = createStub([active, inactive]);
+
+        await skipActiveScheduleTonight(db, '2026-05-20');
+
+        expect(getRows().find(r => r.id === 'sched-A')?.skippedNightDate).toBe('2026-05-20');
+        expect(getRows().find(r => r.id === 'sched-B')?.skippedNightDate).toBeNull();
+    });
+});
+
+describe('resumeActiveScheduleTonight', () => {
+    it('clears skippedNightDate on the active schedule and returns the row', async () => {
+        const active = buildSchedule({ id: 'sched-active', isActive: true, skippedNightDate: '2026-05-20' });
+        const { db, updateCalls, getRows } = createStub([active]);
+
+        const result = await resumeActiveScheduleTonight(db);
+
+        expect(result?.id).toBe('sched-active');
+        expect(result?.skippedNightDate).toBeNull();
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0]?.values).toEqual({ skippedNightDate: null });
+        expect(getRows().find(r => r.id === 'sched-active')?.skippedNightDate).toBeNull();
+    });
+
+    it('is idempotent: returns the active row even when no marker is set', async () => {
+        const active = buildSchedule({ id: 'sched-1', isActive: true, skippedNightDate: null });
+        const { db, updateCalls } = createStub([active]);
+
+        const result = await resumeActiveScheduleTonight(db);
+
+        expect(result?.id).toBe('sched-1');
+        expect(result?.skippedNightDate).toBeNull();
+        expect(updateCalls).toHaveLength(1); // still issues UPDATE, idempotent on the row
+    });
+
+    it('returns null without writing when no schedule is active', async () => {
+        const inactive = buildSchedule({ id: 'sched-1', isActive: false });
+        const { db, updateCalls } = createStub([inactive]);
+
+        const result = await resumeActiveScheduleTonight(db);
+
+        expect(result).toBeNull();
+        expect(updateCalls).toHaveLength(0);
+    });
+});
+
+describe('clearStaleSkipMarkers', () => {
+    it('issues one UPDATE with skippedNightDate=null and the lt(today) predicate', async () => {
+        const stale = buildSchedule({ id: 'sched-A', skippedNightDate: '2026-05-19' });
+        const fresh = buildSchedule({ id: 'sched-B', skippedNightDate: '2026-05-20' });
+        const { db, updateCalls } = createStub([stale, fresh]);
+
+        await clearStaleSkipMarkers(db, '2026-05-20');
+
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0]?.values).toEqual({ skippedNightDate: null });
+    });
+
+    it('issues the UPDATE even when no rows have a marker — Drizzle handles the empty match', async () => {
+        const a = buildSchedule({ id: 'sched-A', skippedNightDate: null });
+        const b = buildSchedule({ id: 'sched-B', skippedNightDate: null });
+        const { db, updateCalls } = createStub([a, b]);
+
+        await clearStaleSkipMarkers(db, '2026-05-20');
+
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0]?.values).toEqual({ skippedNightDate: null });
     });
 });
 

--- a/api/daemon/schedule-manager.ts
+++ b/api/daemon/schedule-manager.ts
@@ -1,3 +1,4 @@
+import type dayjs from 'dayjs';
 import { and, eq, isNotNull, lt, ne } from 'drizzle-orm';
 import { schedules } from '@/db/schema';
 
@@ -105,7 +106,9 @@ export async function enableSchedule(db: ScheduleManagerDb, slug: string): Promi
  * `schedules_one_active_per_site`, which means there's at most one match per
  * site; the single-site deploy means there's at most one match overall.
  */
-export async function skipActiveScheduleTonight(db: ScheduleManagerDb, todayIso: string): Promise<Schedule | null> {
+export async function skipActiveScheduleTonight(db: ScheduleManagerDb, today: dayjs.Dayjs): Promise<Schedule | null> {
+    const todayIso = today.format('YYYY-MM-DD');
+
     const rows = await db
         .select({ schedule: schedules })
         .from(schedules)
@@ -160,7 +163,8 @@ export async function resumeActiveScheduleTonight(db: ScheduleManagerDb): Promis
  * only meaningful for the night it was created for — by the time tomorrow's
  * re-plan fires, the marker should be inert and cleaned up.
  */
-export async function clearStaleSkipMarkers(db: ScheduleManagerDb, todayIso: string): Promise<void> {
+export async function clearStaleSkipMarkers(db: ScheduleManagerDb, today: dayjs.Dayjs): Promise<void> {
+    const todayIso = today.format('YYYY-MM-DD');
     await db
         .update(schedules)
         .set({ skippedNightDate: null })

--- a/api/daemon/schedule-manager.ts
+++ b/api/daemon/schedule-manager.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne } from 'drizzle-orm';
+import { and, eq, isNotNull, lt, ne } from 'drizzle-orm';
 import { schedules } from '@/db/schema';
 
 /**
@@ -95,6 +95,76 @@ export async function enableSchedule(db: ScheduleManagerDb, slug: string): Promi
         console.log(`schedule-manager: enabled schedule ${target.id} (${slug}) on site ${target.siteId}.`);
         return { ...target, isActive: true };
     });
+}
+
+/**
+ * Sets `skippedNightDate = todayIso` on the (single) active schedule. Powers
+ * `POST /schedule/skip-tonight` — the operator override for a one-night skip.
+ * Returns the post-update row, or `null` if no schedule is currently active.
+ * The active row is identified by the partial unique index
+ * `schedules_one_active_per_site`, which means there's at most one match per
+ * site; the single-site deploy means there's at most one match overall.
+ */
+export async function skipActiveScheduleTonight(db: ScheduleManagerDb, todayIso: string): Promise<Schedule | null> {
+    const rows = await db
+        .select({ schedule: schedules })
+        .from(schedules)
+        .where(eq(schedules.isActive, true));
+
+    const target = rows[0]?.schedule;
+    if (!target) {
+        console.warn('schedule-manager: skip-tonight failed — no active schedule.');
+        return null;
+    }
+
+    await db
+        .update(schedules)
+        .set({ skippedNightDate: todayIso })
+        .where(eq(schedules.id, target.id));
+
+    console.log(`schedule-manager: marked schedule ${target.id} (${target.slug}) skipped for ${todayIso}.`);
+    return { ...target, skippedNightDate: todayIso };
+}
+
+/**
+ * Clears the `skippedNightDate` marker on the (single) active schedule. Powers
+ * `POST /schedule/resume-tonight` — the Undo / Resume button. Idempotent at
+ * the data layer (already-cleared returns success). Returns the post-update
+ * row, or `null` if no schedule is currently active.
+ */
+export async function resumeActiveScheduleTonight(db: ScheduleManagerDb): Promise<Schedule | null> {
+    const rows = await db
+        .select({ schedule: schedules })
+        .from(schedules)
+        .where(eq(schedules.isActive, true));
+
+    const target = rows[0]?.schedule;
+    if (!target) {
+        console.warn('schedule-manager: resume-tonight failed — no active schedule.');
+        return null;
+    }
+
+    await db
+        .update(schedules)
+        .set({ skippedNightDate: null })
+        .where(eq(schedules.id, target.id));
+
+    console.log(`schedule-manager: cleared skip marker on schedule ${target.id} (${target.slug}).`);
+    return { ...target, skippedNightDate: null };
+}
+
+/**
+ * Clears any `skippedNightDate` strictly older than `todayIso`. The daemon
+ * calls this at the top of every `rePlan` so a marker from a past night
+ * doesn't accumulate or accidentally apply to a future plan. The marker is
+ * only meaningful for the night it was created for — by the time tomorrow's
+ * re-plan fires, the marker should be inert and cleaned up.
+ */
+export async function clearStaleSkipMarkers(db: ScheduleManagerDb, todayIso: string): Promise<void> {
+    await db
+        .update(schedules)
+        .set({ skippedNightDate: null })
+        .where(and(isNotNull(schedules.skippedNightDate), lt(schedules.skippedNightDate, todayIso)));
 }
 
 /**

--- a/api/daemon/schedules.ts
+++ b/api/daemon/schedules.ts
@@ -1,3 +1,4 @@
+import type dayjs from 'dayjs';
 import { and, eq, gt, gte, isNotNull, isNull } from 'drizzle-orm';
 import {
     grassTypes,
@@ -76,15 +77,16 @@ export async function replaceZoneSchedule(
     db: ScheduleWriterDb,
     zoneId: string,
     entries: ReadonlyArray<IrrigationScheduleEntry>,
-    today: string,
+    today: dayjs.Dayjs,
     projectedNextDepletionMm: number,
     scheduleId: string,
 ): Promise<PersistedScheduleResult> {
-    console.log(`daemon: replacing schedule for zone ${zoneId} from ${today} (${entries.length} entry/entries).`);
+    const todayIso = today.format('YYYY-MM-DD');
+    console.log(`daemon: replacing schedule for zone ${zoneId} from ${todayIso} (${entries.length} entry/entries).`);
 
     await db
         .delete(scheduleEntries)
-        .where(and(eq(scheduleEntries.zoneId, zoneId), gte(scheduleEntries.date, today)));
+        .where(and(eq(scheduleEntries.zoneId, zoneId), gte(scheduleEntries.date, todayIso)));
 
     const persisted: PersistedCycle[] = [];
 

--- a/api/db/schema/schedules.ts
+++ b/api/db/schema/schedules.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { boolean, integer, jsonb, pgTable, real, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { boolean, date, integer, jsonb, pgTable, real, text, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
 import { sites } from './sites';
 
@@ -34,6 +34,7 @@ export const schedules = pgTable('schedules', {
     rootDepthMOverride: real('root_depth_m_override'),
     allowableDepletionFractionOverride: real('allowable_depletion_fraction_override'),
     endBySunrise: boolean('end_by_sunrise'),
+    skippedNightDate: date('skipped_night_date'),
     ...auditColumns,
 }, table => [
     uniqueIndex('schedules_site_slug_idx').on(table.siteId, table.slug),

--- a/api/drizzle/0010_married_titanium_man.sql
+++ b/api/drizzle/0010_married_titanium_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schedules" ADD COLUMN "skipped_night_date" date;

--- a/api/drizzle/meta/0010_snapshot.json
+++ b/api/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,891 @@
+{
+  "id": "b6cb2c51-a200-446a-8a93-b9a46c307592",
+  "prevId": "bf49ddee-7c37-488d-88ed-7b41f9e93a01",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_at": {
+          "name": "when_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack": {
+          "name": "ack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_zone_id_zones_id_fk": {
+          "name": "alerts_zone_id_zones_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alerts_class_check": {
+          "name": "alerts_class_check",
+          "value": "\"alerts\".\"class\" in ('weather-stale', 'ha-call-failed', 'missed-close')"
+        },
+        "alerts_tone_check": {
+          "name": "alerts_tone_check",
+          "value": "\"alerts\".\"tone\" in ('warn', 'danger')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_night_date": {
+          "name": "skipped_night_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_state": {
+      "name": "weather_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_fetch_at": {
+          "name": "last_successful_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779284921318,
       "tag": "0009_long_morlun",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779292359644,
+      "tag": "0010_married_titanium_man",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -12,9 +12,12 @@ import { realClock } from '@/daemon/runtime';
 import {
     disableSchedule as defaultDisableSchedule,
     enableSchedule as defaultEnableSchedule,
+    resumeActiveScheduleTonight as defaultResumeActiveScheduleTonight,
+    skipActiveScheduleTonight as defaultSkipActiveScheduleTonight,
     type Schedule,
     type ScheduleManagerDb,
 } from '@/daemon/schedule-manager';
+import dayjs from 'dayjs';
 import { loadZoneById, loadZoneSummaries, type ZoneSummary, type ZoneSummaryDb } from '@/daemon/zones';
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
@@ -40,6 +43,8 @@ const shutdownStarted = new WeakSet<FastifyInstance>();
 export type ScheduleApi = {
     enable: (slug: string) => Promise<Schedule | null>;
     disable: (slug: string) => Promise<Schedule | null>;
+    skipTonight: () => Promise<Schedule | null>;
+    resumeTonight: () => Promise<Schedule | null>;
 };
 
 /**
@@ -65,6 +70,16 @@ export function wrapScheduleWithReplan(base: ScheduleApi, replan: () => Promise<
         },
         disable: async slug => {
             const result = await base.disable(slug);
+            if (result !== null) await replan();
+            return result;
+        },
+        skipTonight: async () => {
+            const result = await base.skipTonight();
+            if (result !== null) await replan();
+            return result;
+        },
+        resumeTonight: async () => {
+            const result = await base.resumeTonight();
             if (result !== null) await replan();
             return result;
         },
@@ -266,6 +281,60 @@ function registerScheduleRoutes(app: FastifyInstance, schedule: ScheduleApi): vo
             schedule: { slug: result.slug, name: result.name, siteId: result.siteId },
         });
     });
+
+    /**
+     * `POST /schedule/skip-tonight` — sets a one-night skip marker on the active
+     * schedule so the planner drops tonight's cycles. 404 if no schedule is
+     * currently active; 502 if the wrapped re-plan rejects.
+     */
+    app.post('/schedule/skip-tonight', async (_req, reply) => {
+        let result;
+        try {
+            result = await schedule.skipTonight();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
+        if (result === null) {
+            return reply.code(404).send({ error: 'not-found', message: 'No active schedule.' });
+        }
+        return reply.code(200).send({
+            status: 'skipped',
+            schedule: {
+                slug: result.slug,
+                name: result.name,
+                siteId: result.siteId,
+                skippedNightDate: result.skippedNightDate,
+            },
+        });
+    });
+
+    /**
+     * `POST /schedule/resume-tonight` — clears the skip marker on the active
+     * schedule. Idempotent (already-cleared returns success). 404 if no
+     * schedule is active; 502 if the wrapped re-plan rejects.
+     */
+    app.post('/schedule/resume-tonight', async (_req, reply) => {
+        let result;
+        try {
+            result = await schedule.resumeTonight();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
+        if (result === null) {
+            return reply.code(404).send({ error: 'not-found', message: 'No active schedule.' });
+        }
+        return reply.code(200).send({
+            status: 'resumed',
+            schedule: {
+                slug: result.slug,
+                name: result.name,
+                siteId: result.siteId,
+                skippedNightDate: result.skippedNightDate,
+            },
+        });
+    });
 }
 
 function registerManualRoutes(
@@ -437,6 +506,8 @@ if (import.meta.main) {
     const baseSchedule: ScheduleApi = {
         enable: slug => defaultEnableSchedule(scheduleDb, slug),
         disable: slug => defaultDisableSchedule(scheduleDb, slug),
+        skipTonight: () => defaultSkipActiveScheduleTonight(scheduleDb, dayjs(realClock.now()).format('YYYY-MM-DD')),
+        resumeTonight: () => defaultResumeActiveScheduleTonight(scheduleDb),
     };
     const app = buildApp({
         getStatus: daemon.getStatus,

--- a/api/index.ts
+++ b/api/index.ts
@@ -506,7 +506,7 @@ if (import.meta.main) {
     const baseSchedule: ScheduleApi = {
         enable: slug => defaultEnableSchedule(scheduleDb, slug),
         disable: slug => defaultDisableSchedule(scheduleDb, slug),
-        skipTonight: () => defaultSkipActiveScheduleTonight(scheduleDb, dayjs(realClock.now()).format('YYYY-MM-DD')),
+        skipTonight: () => defaultSkipActiveScheduleTonight(scheduleDb, dayjs(realClock.now())),
         resumeTonight: () => defaultResumeActiveScheduleTonight(scheduleDb),
     };
     const app = buildApp({

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1679,4 +1679,80 @@ describe('planZoneSchedule', () => {
             expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(NOW_09.valueOf());
         });
     });
+
+    describe('skip-tonight marker', () => {
+        const singleCycleZone = () => createTestZone({
+            currentDepletionMm: 22,
+            soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+            precipitationRateMmPerHr: 50,
+        });
+
+        function weatherFromDates(startDate: string, days: number, sunriseHour = 6) {
+            return createWeatherDays(
+                Array.from({ length: days }, () => ({ evapotranspirationMmPerDay: 1.0, rainfallMm: 0 })),
+                dayjs(startDate),
+            ).map((day, idx) => ({
+                ...day,
+                sunrise: dayjs(startDate).add(idx, 'day').hour(sunriseHour).minute(0).second(0).millisecond(0),
+            }));
+        }
+
+        it('drops day 0 cycles when the marker matches and lets depletion accumulate into the next day', () => {
+            const zone = singleCycleZone();
+            // Wednesday 2026-05-06 (day 0), Thursday 2026-05-07 (day 1).
+            const weather = weatherFromDates('2026-05-06', 2);
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+                skippedNightDate: '2026-05-06',
+            });
+
+            expect(result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-06')).toBeUndefined();
+            const thursday = result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-07');
+            expect(thursday).toBeDefined();
+            // Skipped day's depletion (22.85 mm after day 0 ET) carries into Thursday's
+            // pre-irrigation depletion — sanity check it's strictly greater than the
+            // single-day depletion that would have triggered today.
+            expect(thursday?.depletionBeforeMm).toBeGreaterThan(22.85);
+        });
+
+        it('drops a specific future-day match without affecting other days', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-06', 3); // Wed, Thu, Fri
+
+            const result = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+                skippedNightDate: '2026-05-07', // skip only Thursday
+            });
+
+            // Wednesday fires normally.
+            expect(result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-06')).toBeDefined();
+            // Thursday is skipped.
+            expect(result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-07')).toBeUndefined();
+        });
+
+        it('is a no-op when the marker is null or matches no planned day (regression)', () => {
+            const zone = singleCycleZone();
+            const weather = weatherFromDates('2026-05-06', 1);
+
+            const baseline = planZoneSchedule(zone, weather);
+            const withNullMarker = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+                skippedNightDate: null,
+            });
+            const withUnmatchedMarker = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+                skippedNightDate: '1999-01-01',
+            });
+
+            expect(withNullMarker.entries).toHaveLength(baseline.entries.length);
+            expect(withUnmatchedMarker.entries).toHaveLength(baseline.entries.length);
+            expect(withNullMarker.entries[0]?.cycles[0]?.startTime.isSame(baseline.entries[0]?.cycles[0]?.startTime)).toBe(true);
+            expect(withUnmatchedMarker.entries[0]?.cycles[0]?.startTime.isSame(baseline.entries[0]?.cycles[0]?.startTime)).toBe(true);
+        });
+    });
 });

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import type { Zone, DailyWeather, IrrigationScheduleEntry, IrrigationCycle } from '../../models';
 import {
     isDayAllowed,
+    isNightSkipped,
     type ScheduleRestrictions,
 } from './restrictions';
 
@@ -223,6 +224,11 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
 
     if (!isDayAllowed(restrictions, date.isoWeekday())) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} (isoWeekday ${date.isoWeekday()}) disallowed by schedule restrictions — skipping irrigation.`);
+        return null;
+    }
+
+    if (isNightSkipped(restrictions, date)) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} is skip-marked — skipping irrigation.`);
         return null;
     }
 

--- a/api/schedules/dynamic/restrictions.ts
+++ b/api/schedules/dynamic/restrictions.ts
@@ -27,6 +27,13 @@ export type ScheduleRestrictions = {
     allowedDays: number[] | null;
     allowedTimeWindows: ScheduleTimeWindow[] | null;
     endBySunrise?: boolean;
+    /**
+     * One-shot operator override: when set, the planner drops cycles for the
+     * matching entry-date (YYYY-MM-DD). Powers `/schedule/skip-tonight`. The
+     * planner treats the skipped day identically to a disallowed weekday —
+     * depletion carries forward into the next planned day.
+     */
+    skippedNightDate?: string | null;
 };
 
 /**
@@ -46,6 +53,17 @@ export function isDayAllowed(restrictions: ScheduleRestrictions, isoWeekday: num
     const allowed = restrictions.allowedDays;
     if (allowed === null || allowed.length === 0) return true;
     return allowed.includes(isoWeekday);
+}
+
+/**
+ * Returns true when the operator has marked the given day as skipped via
+ * `/schedule/skip-tonight`. Compares the day's `YYYY-MM-DD` against the
+ * restriction's `skippedNightDate`; null/undefined means "no skip marker".
+ */
+export function isNightSkipped(restrictions: ScheduleRestrictions, day: dayjs.Dayjs): boolean {
+    const marker = restrictions.skippedNightDate;
+    if (marker === null || marker === undefined) return false;
+    return day.format('YYYY-MM-DD') === marker;
 }
 
 /**

--- a/api/scripts/disable-schedule.test.ts
+++ b/api/scripts/disable-schedule.test.ts
@@ -16,6 +16,7 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
         endBySunrise: null,
+        skippedNightDate: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/scripts/enable-schedule.test.ts
+++ b/api/scripts/enable-schedule.test.ts
@@ -16,6 +16,7 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
         rootDepthMOverride: null,
         allowableDepletionFractionOverride: null,
         endBySunrise: null,
+        skippedNightDate: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,


### PR DESCRIPTION
## Ticket

[API-47](http://192.168.2.100:7123/irrigo/browse/API-47/) POST /schedule/skip-tonight — skip the active schedule for tonight

## Summary

- Adds nullable `schedules.skipped_night_date` column (migration 0010) so the active schedule can carry a one-night skip marker.
- Extends `ScheduleRestrictions` with `skippedNightDate?: string | null` and gates `tryPlaceIrrigationForDay` so the planner drops cycles for the matching entry-date and carries depletion forward.
- New schedule-manager helpers: `skipActiveScheduleTonight`, `resumeActiveScheduleTonight`, `clearStaleSkipMarkers`. The daemon's `rePlan` clears stale markers up front and plumbs `skippedNightDate` through to per-zone restrictions.
- New routes `POST /schedule/skip-tonight` and `POST /schedule/resume-tonight`, wrapped with `wrapScheduleWithReplan` so the planner re-arms immediately. 200 on success, 404 when no active schedule, 502 when the wrapped re-plan throws.
- The marker is date-keyed and self-expires: tomorrow's `clearStaleSkipMarkers` wipes it before the next plan runs.

## Test plan

- [x] `bun --cwd api test` — 605/605 green
- [x] `bun --cwd api run type-check` — clean
- [ ] Manual: skip the active schedule, confirm planner gate fires in the logs, resume and confirm cycles re-arm.