### PR TITLE
[API-46] Master irrigation kill switch — /system routes + planner/manual gates

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -3,7 +3,7 @@ import type { AlertDto } from '@/alerts';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, type ScheduleApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
 import type { ZoneSummary } from '@/daemon/zones';
-import { BusyError, type ManualController } from '@/manual';
+import { BusyError, SystemDisabledError, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
 
 function buildStatus(overrides?: Partial<DaemonStatus>): DaemonStatus {
@@ -194,6 +194,18 @@ describe('buildApp manual zone routes', () => {
             await app.close();
         });
 
+        it('returns 409 with system-disabled when the controller throws SystemDisabledError', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ open: async () => { throw new SystemDisabledError('manual: irrigation is disabled.'); } }),
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/zones/zone-001/open' });
+
+            expect(res.statusCode).toBe(409);
+            expect(res.json()).toMatchObject({ error: 'system-disabled', message: 'manual: irrigation is disabled.' });
+            await app.close();
+        });
+
         it('returns 502 when the controller throws a non-busy error (HA failure)', async () => {
             const app = buildAppWithManual({
                 manual: buildManual({ open: async () => { throw new Error('HA 502'); } }),
@@ -322,6 +334,23 @@ describe('buildApp manual zone routes', () => {
             });
 
             expect(res.statusCode).toBe(409);
+            await app.close();
+        });
+
+        it('returns 409 with system-disabled when the controller throws SystemDisabledError', async () => {
+            const app = buildAppWithManual({
+                manual: buildManual({ run: async () => { throw new SystemDisabledError('manual: irrigation is disabled.'); } }),
+            });
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/zones/zone-001/run',
+                payload: { durationMin: 5 },
+                headers: { 'content-type': 'application/json' },
+            });
+
+            expect(res.statusCode).toBe(409);
+            expect(res.json()).toMatchObject({ error: 'system-disabled' });
             await app.close();
         });
 

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import type { AlertDto } from '@/alerts';
-import { buildApp, gracefulShutdown, wrapScheduleWithReplan, type ScheduleApi } from '@/index';
+import { buildApp, gracefulShutdown, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
 import type { ZoneSummary } from '@/daemon/zones';
 import { BusyError, SystemDisabledError, type ManualController } from '@/manual';
@@ -1059,5 +1059,171 @@ describe('buildApp alert routes', () => {
             expect(acked).toEqual(['my-id-here']);
             await app.close();
         });
+    });
+});
+
+describe('buildApp /system routes', () => {
+    const SINCE_ISO = '2026-05-21T12:34:56.000Z';
+    const buildEnabled = () => ({ irrigationEnabled: true, since: SINCE_ISO });
+    const buildDisabled = () => ({ irrigationEnabled: false, since: SINCE_ISO });
+
+    describe('GET /system', () => {
+        it('returns 200 with the DTO from the handler', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                system: {
+                    get: async () => buildEnabled(),
+                    enable: async () => buildEnabled(),
+                    disable: async () => buildDisabled(),
+                },
+            });
+
+            const res = await app.inject({ method: 'GET', url: '/system' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ irrigationEnabled: true, since: SINCE_ISO });
+            await app.close();
+        });
+
+        it('returns 404 when system handler is absent from BuildAppOptions', async () => {
+            const app = buildApp({ getStatus: () => buildStatus() });
+
+            const res = await app.inject({ method: 'GET', url: '/system' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+    });
+
+    describe('POST /system/enable', () => {
+        it('returns 200 with the post-flip DTO', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                system: {
+                    get: async () => buildDisabled(),
+                    enable: async () => buildEnabled(),
+                    disable: async () => buildDisabled(),
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/system/enable' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ irrigationEnabled: true, since: SINCE_ISO });
+            await app.close();
+        });
+
+        it('returns 502 with error: replan-failed when the wrapped handler rejects', async () => {
+            const base: SystemApi = {
+                get: async () => buildDisabled(),
+                enable: async () => buildEnabled(),
+                disable: async () => buildDisabled(),
+            };
+            const wrapped = wrapSystemWithReplan(base, async () => { throw new Error('HA 503'); });
+            const app = buildApp({ getStatus: () => buildStatus(), system: wrapped });
+
+            const res = await app.inject({ method: 'POST', url: '/system/enable' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'HA 503' });
+            await app.close();
+        });
+    });
+
+    describe('POST /system/disable', () => {
+        it('returns 200 with the post-flip DTO', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                system: {
+                    get: async () => buildEnabled(),
+                    enable: async () => buildEnabled(),
+                    disable: async () => buildDisabled(),
+                },
+            });
+
+            const res = await app.inject({ method: 'POST', url: '/system/disable' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ irrigationEnabled: false, since: SINCE_ISO });
+            await app.close();
+        });
+
+        it('returns 502 with error: replan-failed when the wrapped handler rejects', async () => {
+            const base: SystemApi = {
+                get: async () => buildEnabled(),
+                enable: async () => buildEnabled(),
+                disable: async () => buildDisabled(),
+            };
+            const wrapped = wrapSystemWithReplan(base, async () => { throw new Error('HA 504'); });
+            const app = buildApp({ getStatus: () => buildStatus(), system: wrapped });
+
+            const res = await app.inject({ method: 'POST', url: '/system/disable' });
+
+            expect(res.statusCode).toBe(502);
+            expect(res.json()).toMatchObject({ error: 'replan-failed', message: 'HA 504' });
+            await app.close();
+        });
+    });
+});
+
+describe('wrapSystemWithReplan', () => {
+    const buildState = (enabled: boolean) => ({ irrigationEnabled: enabled, since: '2026-05-21T12:00:00.000Z' });
+
+    it('calls replan after enable, awaiting it before returning', async () => {
+        const callOrder: string[] = [];
+        const base: SystemApi = {
+            get: async () => buildState(false),
+            enable: async () => { callOrder.push('enable'); return buildState(true); },
+            disable: async () => buildState(false),
+        };
+        const wrapped = wrapSystemWithReplan(base, async () => {
+            await Promise.resolve();
+            callOrder.push('replan');
+        });
+
+        const result = await wrapped.enable();
+        callOrder.push('returned');
+
+        expect(result.irrigationEnabled).toBe(true);
+        expect(callOrder).toEqual(['enable', 'replan', 'returned']);
+    });
+
+    it('calls replan after disable', async () => {
+        const callOrder: string[] = [];
+        const base: SystemApi = {
+            get: async () => buildState(true),
+            enable: async () => buildState(true),
+            disable: async () => { callOrder.push('disable'); return buildState(false); },
+        };
+        const wrapped = wrapSystemWithReplan(base, async () => { callOrder.push('replan'); });
+
+        await wrapped.disable();
+
+        expect(callOrder).toEqual(['disable', 'replan']);
+    });
+
+    it('does NOT call replan on get (reads are side-effect-free)', async () => {
+        let replanCalls = 0;
+        const base: SystemApi = {
+            get: async () => buildState(true),
+            enable: async () => buildState(true),
+            disable: async () => buildState(false),
+        };
+        const wrapped = wrapSystemWithReplan(base, async () => { replanCalls += 1; });
+
+        await wrapped.get();
+
+        expect(replanCalls).toBe(0);
+    });
+
+    it('propagates replan rejections so the route can map them to 502', async () => {
+        const base: SystemApi = {
+            get: async () => buildState(true),
+            enable: async () => buildState(true),
+            disable: async () => buildState(false),
+        };
+        const wrapped = wrapSystemWithReplan(base, async () => { throw new Error('replan failed'); });
+
+        await expect(wrapped.enable()).rejects.toThrow('replan failed');
     });
 });

--- a/api/daemon/.test.ts
+++ b/api/daemon/.test.ts
@@ -11,6 +11,7 @@ import {
     schedules,
     sites,
     soilTypes,
+    systemState,
     weatherState,
     zones,
 } from '@/db/schema';
@@ -1773,6 +1774,11 @@ type DaemonStubInputs = {
     siteTimezones?: ReadonlyArray<{ timezone: string }>;
     /** Seed value the weather_state stub returns; `undefined` ⇒ no row ⇒ stale. */
     lastSuccessfulFetchAt?: Date | null;
+    /**
+     * Seed value the system_state stub returns. Defaults to enabled with a
+     * fixed `since` so the existing tests don't have to plumb it.
+     */
+    systemState?: { irrigationEnabled: boolean; since: Date };
     activeSchedules?: ReadonlyArray<{ schedule: {
         id: string;
         siteId: string;
@@ -1870,6 +1876,18 @@ function createDaemonDbStub(inputs?: DaemonStubInputs) {
                                     ? [{ lastSuccessfulFetchAt: inputs.lastSuccessfulFetchAt }]
                                     : [],
                             ),
+                        }),
+                    }),
+                } as never;
+            }
+            // SystemStateDb shape: `irrigationEnabled` + `since`. Defaults to
+            // enabled with a fixed `since` so legacy tests don't have to plumb it.
+            if ('irrigationEnabled' in cols && 'since' in cols) {
+                const seed = inputs?.systemState ?? { irrigationEnabled: true, since: new Date('2026-05-04T00:00:00.000Z') };
+                return {
+                    from: () => ({
+                        where: () => ({
+                            limit: () => Promise.resolve([seed]),
                         }),
                     }),
                 } as never;
@@ -3205,6 +3223,117 @@ describe('start', () => {
             expect(ordering.clearStale).not.toBeNull();
             expect(ordering.activeScheduleRead).not.toBeNull();
             expect(ordering.clearStale!).toBeLessThan(ordering.activeScheduleRead!);
+        });
+    });
+
+    describe('master kill switch', () => {
+        it('does NOT arm future cycles at boot when the system is disabled, but still runs reconcile', async () => {
+            const futureRow = buildFutureCycleRow({
+                cycle: {
+                    id: 'cycle-future-disabled',
+                    startTime: new Date('2026-05-04T13:00:00.000Z'),
+                    durationMin: 10,
+                    firedAt: null,
+                },
+            });
+            const inFlightRow = buildFutureCycleRow({
+                cycle: {
+                    id: 'cycle-inflight',
+                    startTime: new Date('2026-05-04T11:00:00.000Z'),
+                    durationMin: 90,
+                    firedAt: new Date('2026-05-04T11:00:00.000Z'),
+                    closedAt: null,
+                },
+                zone: { id: 'zone-inflight' },
+            });
+            const { db } = createDaemonDbStub({
+                futureCycles: [futureRow],
+                inFlightCycles: [inFlightRow],
+                systemState: { irrigationEnabled: false, since: new Date('2026-05-04T08:00:00.000Z') },
+            });
+            const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
+            const opens: string[] = [];
+            const stateQueries: string[] = [];
+
+            await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+                openZone: async (z) => { opens.push(z.id); },
+                closeZone: async () => {},
+                getZoneState: async (z) => {
+                    stateQueries.push(z.id);
+                    return 'off';
+                },
+            });
+
+            // Reconcile still runs (it inspected the in-flight zone's relay state).
+            expect(stateQueries).toContain('zone-inflight');
+
+            // Advance well past the future cycle's start time — it must NOT fire.
+            const pendingBefore = getPendingCount();
+            await advanceTo(new Date('2026-05-04T14:00:00.000Z'));
+            expect(opens).toEqual([]);
+
+            // The only timer that should remain pending is the next re-plan tick
+            // (not the future-cycle arming, which we skipped).
+            expect(pendingBefore).toBeLessThanOrEqual(1);
+        });
+
+        it('rePlan() skips planning when the system is disabled but still advances lastRePlanAt', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-disabled', siteId: 'site-001' } });
+            const { db, inserts } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                systemState: { irrigationEnabled: false, since: new Date('2026-05-04T08:00:00.000Z') },
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: string[] = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (z) => {
+                    planCalls.push(z.id);
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            // No runPlan calls, no schedule_entries inserts.
+            expect(planCalls).toEqual([]);
+            expect(inserts.filter(c => c.table === scheduleEntries)).toHaveLength(0);
+            // lastRePlanAt still advances so /health reflects the attempt.
+            expect(control.getStatus().lastRePlanAt).toBe(NOW.toISOString());
+        });
+
+        it('rePlan() with system enabled runs the planner normally (regression)', async () => {
+            const enabledRow = buildJoinedRow({ zone: { id: 'zone-enabled', siteId: 'site-001' } });
+            const { db } = createDaemonDbStub({
+                enabledZones: [enabledRow],
+                systemState: { irrigationEnabled: true, since: new Date('2026-05-04T08:00:00.000Z') },
+            });
+            const { clock } = createFakeClock(NOW);
+            const planCalls: string[] = [];
+
+            const control = await start(db, {
+                clock,
+                rePlanHourLocal: 4,
+                runPlan: async (z) => {
+                    planCalls.push(z.id);
+                    return { entries: [], projectedNextDepletionMm: 0 };
+                },
+                openZone: async () => {},
+                closeZone: async () => {},
+                getZoneState: async () => 'off',
+            });
+
+            await control.rePlan();
+
+            expect(planCalls).toEqual(['zone-enabled']);
         });
     });
 

--- a/api/daemon/index.ts
+++ b/api/daemon/index.ts
@@ -15,6 +15,7 @@ import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
 import { clearStaleSkipMarkers, loadActiveSchedulesBySite, type Schedule, type ScheduleManagerDb } from './schedule-manager';
 import { loadFutureCycles, loadInFlightCycles, replaceZoneSchedule, type FutureCyclesDb, type ScheduleWriterDb } from './schedules';
+import { getSystemState, type SystemStateDb } from '@/system';
 import {
     armCloseOnly,
     armCycle,
@@ -45,7 +46,7 @@ const DEFAULT_REPLAN_HOUR_LOCAL = 4;
  * pass the eager `db` export from `@/db`; tests pass a recording stub that
  * implements the union of the smaller per-helper interfaces.
  */
-export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb & ScheduleManagerDb & WeatherStateDb & AlertsDb;
+export type DaemonDb = ZoneLoaderDb & ScheduleWriterDb & FutureCyclesDb & RuntimeDb & ZoneCountDb & SiteTimezoneDb & ScheduleManagerDb & WeatherStateDb & AlertsDb & SystemStateDb;
 
 /**
  * Caller-overridable hooks. Defaults wire to the real planning function and
@@ -159,11 +160,16 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     console.log(`daemon: reconcile summary — resumed: ${reconcileSummary.resumed}, forcedClosed: ${reconcileSummary.forcedClosed}, missedClose: ${reconcileSummary.missedClose}, orphansClosed: ${reconcileSummary.orphansClosed}, errors: ${reconcileSummary.errors}.`);
 
     const futureCycles = await loadFutureCycles(db, clock.now());
-    // Boot-recovery arms leave the schedule markers undefined — schedule-begun
-    // and schedule-ended for this night, if applicable, were already emitted by
-    // the prior process, and re-emitting on every restart would be misleading.
-    for (const { cycle, zone } of futureCycles) {
-        armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alerter });
+    const systemAtBoot = await getSystemState(db);
+    if (!systemAtBoot.irrigationEnabled) {
+        console.warn(`daemon: system irrigation is disabled (since ${systemAtBoot.since}); skipping arm of ${futureCycles.length} future cycle(s).`);
+    } else {
+        // Boot-recovery arms leave the schedule markers undefined — schedule-begun
+        // and schedule-ended for this night, if applicable, were already emitted by
+        // the prior process, and re-emitting on every restart would be misleading.
+        for (const { cycle, zone } of futureCycles) {
+            armCycle({ db, clock, registry, zone, cycle, openZone, closeZone, notifier, alerter });
+        }
     }
 
     const { total, enabled } = await countZones(db);
@@ -188,6 +194,14 @@ export async function start(db: DaemonDb, options?: DaemonOptions): Promise<Daem
     const rePlan = async (): Promise<void> => {
         console.log('daemon: re-plan starting.');
         registry.cancelOpenTimers(clock);
+
+        const system = await getSystemState(db);
+        if (!system.irrigationEnabled) {
+            console.warn(`daemon: re-plan skipped — system irrigation is disabled (since ${system.since}). All armed cycles cancelled; no new cycles will arm until re-enabled.`);
+            lastRePlanAt = clock.now();
+            scheduleNextRePlan();
+            return;
+        }
 
         const today = dayjs(clock.now());
         // Wipe markers from past nights before snapshotting active schedules so

--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -5,5 +5,6 @@ export { scheduleEntries } from './schedule-entries';
 export { schedules } from './schedules';
 export { sites } from './sites';
 export { soilTypes } from './soil-types';
+export { systemState, SYSTEM_STATE_SINGLETON_ID } from './system-state';
 export { weatherState, WEATHER_STATE_SINGLETON_ID } from './weather-state';
 export { zones } from './zones';

--- a/api/db/schema/system-state.ts
+++ b/api/db/schema/system-state.ts
@@ -1,0 +1,24 @@
+import { boolean, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+
+/**
+ * Singleton row backing the master irrigation kill switch. The id column is a
+ * constant string ('singleton') so upserts always target the same row. The
+ * migration seeds a row with `irrigationEnabled = true` so the read path
+ * always returns a populated `since` timestamp the UI can render.
+ *
+ * `since` is bumped on every flip — both enable and disable — and represents
+ * "the system has been in its current state since this instant."
+ */
+export const systemState = pgTable('system_state', {
+    id: text('id').primaryKey(),
+    irrigationEnabled: boolean('irrigation_enabled').notNull().default(true),
+    since: timestamp('since', { withTimezone: true }).notNull().defaultNow(),
+    ...auditColumns,
+});
+
+/**
+ * The fixed primary key value used for the singleton row. Exported so the
+ * reader and writer can avoid embedding the literal in every query.
+ */
+export const SYSTEM_STATE_SINGLETON_ID = 'singleton';

--- a/api/drizzle/0011_lethal_gamora.sql
+++ b/api/drizzle/0011_lethal_gamora.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "system_state" (
+	"id" text PRIMARY KEY NOT NULL,
+	"irrigation_enabled" boolean DEFAULT true NOT NULL,
+	"since" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO "system_state" ("id", "irrigation_enabled", "since") VALUES ('singleton', true, now()) ON CONFLICT ("id") DO NOTHING;

--- a/api/drizzle/meta/0011_snapshot.json
+++ b/api/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,938 @@
+{
+  "id": "d879c6f4-136e-4fda-af1c-a27d452b686a",
+  "prevId": "b6cb2c51-a200-446a-8a93-b9a46c307592",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_at": {
+          "name": "when_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack": {
+          "name": "ack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_zone_id_zones_id_fk": {
+          "name": "alerts_zone_id_zones_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alerts_class_check": {
+          "name": "alerts_class_check",
+          "value": "\"alerts\".\"class\" in ('weather-stale', 'ha-call-failed', 'missed-close')"
+        },
+        "alerts_tone_check": {
+          "name": "alerts_tone_check",
+          "value": "\"alerts\".\"tone\" in ('warn', 'danger')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_night_date": {
+          "name": "skipped_night_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_state": {
+      "name": "system_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "irrigation_enabled": {
+          "name": "irrigation_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_state": {
+      "name": "weather_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_fetch_at": {
+          "name": "last_successful_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779292359644,
       "tag": "0010_married_titanium_man",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779311579247,
+      "tag": "0011_lethal_gamora",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -20,7 +20,7 @@ import {
 import dayjs from 'dayjs';
 import { loadZoneById, loadZoneSummaries, type ZoneSummary, type ZoneSummaryDb } from '@/daemon/zones';
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
-import { getSystemState, type SystemStateDb } from '@/system';
+import { getSystemState, setIrrigationEnabled, type SystemStateDb, type SystemStateDto } from '@/system';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import { BusyError, createManualController, SystemDisabledError, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
@@ -47,6 +47,41 @@ export type ScheduleApi = {
     skipTonight: () => Promise<Schedule | null>;
     resumeTonight: () => Promise<Schedule | null>;
 };
+
+/**
+ * HTTP surface of the master kill switch. Production wires this against
+ * `getSystemState` / `setIrrigationEnabled` from `@/system`, optionally
+ * wrapped with `wrapSystemWithReplan` so the daemon re-plans on each flip.
+ */
+export type SystemApi = {
+    get: () => Promise<SystemStateDto>;
+    enable: () => Promise<SystemStateDto>;
+    disable: () => Promise<SystemStateDto>;
+};
+
+/**
+ * Wraps a base `SystemApi` so each non-throwing `enable` / `disable` call
+ * triggers `replan()` before resolving. Mirrors `wrapScheduleWithReplan`.
+ * The `get` accessor is unwrapped — reads don't change planner state.
+ *
+ * @param base - The underlying handlers (DB-backed in production).
+ * @param replan - The daemon's `rePlan` reference.
+ */
+export function wrapSystemWithReplan(base: SystemApi, replan: () => Promise<void>): SystemApi {
+    return {
+        get: () => base.get(),
+        enable: async () => {
+            const result = await base.enable();
+            await replan();
+            return result;
+        },
+        disable: async () => {
+            const result = await base.disable();
+            await replan();
+            return result;
+        },
+    };
+}
 
 /**
  * Wraps a base `ScheduleApi` so that any non-null `enable` / `disable`
@@ -119,6 +154,14 @@ export type BuildAppOptions = {
         list: () => Promise<AlertDto[]>;
         ack: (id: string) => Promise<AckResult>;
     };
+
+    /**
+     * Optional. When supplied, registers `GET /system`, `POST /system/enable`
+     * and `POST /system/disable` — the master irrigation kill switch surface.
+     * Production wraps the base handlers with `wrapSystemWithReplan` so each
+     * flip triggers an immediate re-plan.
+     */
+    system?: SystemApi;
 };
 
 /**
@@ -166,7 +209,51 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerAlertRoutes(app, opts.alerts);
     }
 
+    if (opts.system) {
+        registerSystemRoutes(app, opts.system);
+    }
+
     return app;
+}
+
+function registerSystemRoutes(app: FastifyInstance, system: SystemApi): void {
+    /**
+     * `GET /system` — current state of the master irrigation kill switch.
+     * Backs the mobile Home screen's toggle and "off since …" label.
+     */
+    app.get('/system', async (_req, reply) => {
+        const state = await system.get();
+        return reply.code(200).send(state);
+    });
+
+    /**
+     * `POST /system/enable` — flip the kill switch on. Returns the post-flip
+     * DTO (`since` reflects the time of this flip). 502 when the wrapped
+     * re-plan rejects.
+     */
+    app.post('/system/enable', async (_req, reply) => {
+        try {
+            const state = await system.enable();
+            return reply.code(200).send(state);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
+    });
+
+    /**
+     * `POST /system/disable` — flip the kill switch off. Returns the post-flip
+     * DTO. 502 when the wrapped re-plan rejects.
+     */
+    app.post('/system/disable', async (_req, reply) => {
+        try {
+            const state = await system.disable();
+            return reply.code(200).send(state);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return reply.code(502).send({ error: 'replan-failed', message });
+        }
+    });
 }
 
 function registerAlertRoutes(
@@ -515,6 +602,11 @@ if (import.meta.main) {
         skipTonight: () => defaultSkipActiveScheduleTonight(scheduleDb, dayjs(realClock.now())),
         resumeTonight: () => defaultResumeActiveScheduleTonight(scheduleDb),
     };
+    const baseSystem: SystemApi = {
+        get: () => getSystemState(systemDb),
+        enable: () => setIrrigationEnabled(systemDb, true, realClock.now()),
+        disable: () => setIrrigationEnabled(systemDb, false, realClock.now()),
+    };
     const app = buildApp({
         getStatus: daemon.getStatus,
         manual,
@@ -526,6 +618,7 @@ if (import.meta.main) {
             list: () => listActiveAlerts(alertsDb),
             ack: id => acknowledgeAlert(alertsDb, id),
         },
+        system: wrapSystemWithReplan(baseSystem, () => daemon.rePlan()),
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -20,8 +20,9 @@ import {
 import dayjs from 'dayjs';
 import { loadZoneById, loadZoneSummaries, type ZoneSummary, type ZoneSummaryDb } from '@/daemon/zones';
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
+import { getSystemState, type SystemStateDb } from '@/system';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
-import { BusyError, createManualController, type ManualController } from '@/manual';
+import { BusyError, createManualController, SystemDisabledError, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
 import { createNotifier } from '@/notifications';
 import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
@@ -417,6 +418,9 @@ function registerManualRoutes(
 }
 
 function sendControllerError(reply: FastifyReply, err: unknown): FastifyReply {
+    if (err instanceof SystemDisabledError) {
+        return reply.code(409).send({ error: 'system-disabled', message: err.message });
+    }
     if (err instanceof BusyError) {
         return reply.code(409).send({ error: 'busy', message: err.message });
     }
@@ -487,6 +491,7 @@ if (import.meta.main) {
     const effectiveGetZoneState: typeof getZoneState = dryRun ? async _zone => 'off' as const : getZoneState;
     const alertsDb = db as unknown as AlertsDb;
     const alerter = createAlerter(alertsDb, notifier);
+    const systemDb = db as unknown as SystemStateDb;
     const daemon = await daemonStart(db as unknown as DaemonDb, {
         notifier,
         alerter,
@@ -501,6 +506,7 @@ if (import.meta.main) {
         closeZone: effectiveCloseZone,
         notifier,
         isAnyScheduledInFlight: () => daemon.getStatus().activeZones.length > 0,
+        isIrrigationEnabled: async () => (await getSystemState(systemDb)).irrigationEnabled,
     });
     const scheduleDb = db as unknown as ScheduleManagerDb;
     const baseSchedule: ScheduleApi = {

--- a/api/manual/.test.ts
+++ b/api/manual/.test.ts
@@ -7,6 +7,7 @@ import {
     BusyError,
     createManualController,
     MAX_RUN_DURATION_MIN,
+    SystemDisabledError,
     type ManualControllerDb,
 } from '.';
 
@@ -144,6 +145,7 @@ describe('manual controller — open', () => {
             closeZone: async () => {},
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
 
@@ -168,6 +170,7 @@ describe('manual controller — open', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => true,
+            isIrrigationEnabled: async () => true,
         });
 
         await expect(controller.open(buildZone())).rejects.toBeInstanceOf(BusyError);
@@ -184,6 +187,7 @@ describe('manual controller — open', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         await controller.open(buildZone());
 
@@ -201,6 +205,7 @@ describe('manual controller — open', () => {
             closeZone: async () => {},
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
 
         await expect(controller.open(buildZone())).rejects.toThrow('HA 502');
@@ -223,6 +228,7 @@ describe('manual controller — close', () => {
             closeZone: async (z) => { closes.push(z); },
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
         await controller.open(zone);
@@ -263,6 +269,7 @@ describe('manual controller — close', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
         await controller.open(zone);
@@ -285,6 +292,7 @@ describe('manual controller — close', () => {
             closeZone: async (z) => { closes.push(z); },
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
 
@@ -306,6 +314,7 @@ describe('manual controller — close', () => {
             closeZone: async () => { throw new Error('HA timeout'); },
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
         await controller.open(zone);
@@ -329,6 +338,7 @@ describe('manual controller — run', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         await controller.open(buildZone());
 
@@ -345,6 +355,7 @@ describe('manual controller — run', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
 
         await expect(controller.run(buildZone(), 0)).rejects.toThrow(/> 0/);
@@ -362,6 +373,7 @@ describe('manual controller — run', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
 
         await expect(controller.run(buildZone(), MAX_RUN_DURATION_MIN + 1)).rejects.toThrow(/exceeds maximum/);
@@ -379,6 +391,7 @@ describe('manual controller — run', () => {
             closeZone: async (z) => { closes.push(z); },
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
 
@@ -416,6 +429,7 @@ describe('manual controller — run', () => {
             closeZone: async () => { throw new Error('HA 504'); },
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
 
@@ -437,6 +451,7 @@ describe('manual controller — run', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         // flowRate 15 L/min, area 100 m² → 60*(15/100) = 9 mm/hr. Same as the explicit 9 default.
         const zone = buildZone({ precipitationRateMmPerHr: undefined });
@@ -458,6 +473,7 @@ describe('manual controller — run', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         // Tiny existing depletion + a long fire that would otherwise overshoot.
         const zone = buildZone({ currentDepletionMm: 0.5 });
@@ -466,6 +482,98 @@ describe('manual controller — run', () => {
 
         const scheduleInsert = inserts.find(c => c.table === scheduleEntries);
         expect(scheduleInsert?.rows[0]?.['depletionAfterMm']).toBe(0);
+    });
+});
+
+describe('manual controller — master kill switch', () => {
+    it('open rejects with SystemDisabledError when isIrrigationEnabled returns false; no HA call, no DB writes, no notifier', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, inserts, updates } = createDbStub();
+        let openCalls = 0;
+        const { notifier, calls } = recordingNotifier();
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => { openCalls += 1; },
+            closeZone: async () => {},
+            notifier,
+            isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => false,
+        });
+
+        await expect(controller.open(buildZone())).rejects.toBeInstanceOf(SystemDisabledError);
+        expect(openCalls).toBe(0);
+        expect(inserts).toHaveLength(0);
+        expect(updates).toHaveLength(0);
+        expect(calls).toHaveLength(0);
+        expect(controller.getActiveZone()).toBeNull();
+    });
+
+    it('run rejects with SystemDisabledError when isIrrigationEnabled returns false; no HA call, no DB writes', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db, inserts, updates } = createDbStub();
+        let openCalls = 0;
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => { openCalls += 1; },
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => false,
+        });
+
+        await expect(controller.run(buildZone(), 5)).rejects.toBeInstanceOf(SystemDisabledError);
+        expect(openCalls).toBe(0);
+        expect(inserts).toHaveLength(0);
+        expect(updates).toHaveLength(0);
+    });
+
+    it('close is NOT gated by the kill switch — an open relay must always be stoppable', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        // Start with the system enabled so we can open, then flip off and confirm close still works.
+        let enabled = true;
+        let closeCalls = 0;
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => { closeCalls += 1; },
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => enabled,
+        });
+
+        const zone = buildZone();
+        await controller.open(zone);
+        enabled = false; // flip the kill switch while the relay is open
+
+        const result = await controller.close(zone);
+
+        expect(result.closed).toBe(true);
+        expect(closeCalls).toBe(1);
+        expect(controller.getActiveZone()).toBeNull();
+    });
+
+    it('defensive close on an unknown zone is NOT gated either', async () => {
+        const { clock } = createFakeClock(NOW);
+        const { db } = createDbStub();
+        let closeCalls = 0;
+        const controller = createManualController({
+            db,
+            clock,
+            openZone: async () => {},
+            closeZone: async () => { closeCalls += 1; },
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => false,
+        });
+
+        const result = await controller.close(buildZone());
+
+        expect(result.closed).toBe(true);
+        expect(closeCalls).toBe(1);
     });
 });
 
@@ -480,6 +588,7 @@ describe('manual controller — getActiveZone and shutdown', () => {
             closeZone: async () => {},
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
 
         expect(controller.getActiveZone()).toBeNull();
@@ -501,6 +610,7 @@ describe('manual controller — getActiveZone and shutdown', () => {
             closeZone: async (z) => { closes.push(z); },
             notifier,
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
         const zone = buildZone();
         await controller.run(zone, 10);
@@ -531,6 +641,7 @@ describe('manual controller — getActiveZone and shutdown', () => {
             closeZone: async (z) => { closes.push(z); },
             notifier: async () => {},
             isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
         });
 
         await controller.shutdown();

--- a/api/manual/index.ts
+++ b/api/manual/index.ts
@@ -24,6 +24,19 @@ export class BusyError extends Error {
 }
 
 /**
+ * Sentinel error thrown by `open` and `run` when the master irrigation kill
+ * switch is off. The HTTP layer maps this to a 409 with
+ * `error: 'system-disabled'` so the mobile client can render a distinct
+ * "irrigation is paused" message rather than a generic busy state.
+ */
+export class SystemDisabledError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SystemDisabledError';
+    }
+}
+
+/**
  * Minimal db interface needed by the manual controller. Mirrors the chained
  * Drizzle `insert/update` shapes the recording test stub already supports.
  */
@@ -56,6 +69,14 @@ export type ManualControllerDeps = {
      * uses this to refuse manual fires while the daemon owns the relay.
      */
     isAnyScheduledInFlight: () => boolean;
+
+    /**
+     * Returns the current state of the master irrigation kill switch. The
+     * controller queries this at the top of `open` and `run` so a flipped-off
+     * system can't accept new manual fires. `close` and `shutdown` are NOT
+     * gated — closing an already-open relay must always be possible.
+     */
+    isIrrigationEnabled: () => Promise<boolean>;
 };
 
 export type ActiveManualSnapshot = {
@@ -112,8 +133,14 @@ type ActiveManualFire = {
  * @returns Wired controller ready to back the `/zones/:id/...` routes.
  */
 export function createManualController(deps: ManualControllerDeps): ManualController {
-    const { db, clock, openZone, closeZone, notifier, isAnyScheduledInFlight } = deps;
+    const { db, clock, openZone, closeZone, notifier, isAnyScheduledInFlight, isIrrigationEnabled } = deps;
     let current: ActiveManualFire | null = null;
+
+    const ensureSystemEnabled = async (action: string, zone: Zone): Promise<void> => {
+        if (!(await isIrrigationEnabled())) {
+            throw new SystemDisabledError(`manual: cannot ${action} zone ${zone.id} — irrigation is disabled.`);
+        }
+    };
 
     const ensureFree = (action: string, zone: Zone): void => {
         if (current !== null) {
@@ -189,6 +216,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
     };
 
     const open: ManualController['open'] = async (zone) => {
+        await ensureSystemEnabled('open', zone);
         ensureFree('open', zone);
 
         try {
@@ -282,6 +310,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         if (durationMin > MAX_RUN_DURATION_MIN) {
             throw new Error(`manual: durationMin ${durationMin} exceeds maximum ${MAX_RUN_DURATION_MIN}.`);
         }
+        await ensureSystemEnabled('run', zone);
         ensureFree('run', zone);
 
         try {

--- a/api/system/.test.ts
+++ b/api/system/.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { systemState } from '@/db/schema';
+import {
+    getSystemState,
+    setIrrigationEnabled,
+    type SystemStateDb,
+    type SystemStateReaderDb,
+    type SystemStateWriterDb,
+} from '.';
+
+type SelectResult = Array<{ irrigationEnabled: boolean; since: Date }>;
+
+function readerStub(rows: SelectResult): SystemStateReaderDb {
+    return {
+        select: () => ({
+            from: () => ({
+                where: () => ({
+                    limit: async () => rows,
+                }),
+            }),
+        }),
+    };
+}
+
+type InsertCall = { values: Record<string, unknown>; conflictSet: Record<string, unknown> };
+
+function writerStub(): { db: SystemStateWriterDb; calls: InsertCall[] } {
+    const calls: InsertCall[] = [];
+    const db: SystemStateWriterDb = {
+        insert: () => ({
+            values: (row) => ({
+                onConflictDoUpdate: async ({ set }) => {
+                    calls.push({ values: row, conflictSet: set });
+                },
+            }),
+        }),
+    };
+    return { db, calls };
+}
+
+function bothStub(initialRows: SelectResult): { db: SystemStateDb; calls: InsertCall[] } {
+    const writer = writerStub();
+    const reader = readerStub(initialRows);
+    return {
+        db: { ...writer.db, ...reader },
+        calls: writer.calls,
+    };
+}
+
+describe('getSystemState', () => {
+    it('maps the singleton row to a DTO with ISO since', async () => {
+        const since = new Date('2026-05-20T14:00:00.000Z');
+        const db = readerStub([{ irrigationEnabled: true, since }]);
+
+        const result = await getSystemState(db);
+
+        expect(result).toEqual({ irrigationEnabled: true, since: '2026-05-20T14:00:00.000Z' });
+    });
+
+    it('returns the disabled state verbatim', async () => {
+        const since = new Date('2026-05-20T15:30:00.000Z');
+        const db = readerStub([{ irrigationEnabled: false, since }]);
+
+        const result = await getSystemState(db);
+
+        expect(result).toEqual({ irrigationEnabled: false, since: '2026-05-20T15:30:00.000Z' });
+    });
+
+    describe('defensive fallback when the singleton row is missing', () => {
+        let warnSpy: ReturnType<typeof spyOn>;
+
+        beforeEach(() => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it('returns enabled with the unix epoch and warns', async () => {
+            const db = readerStub([]);
+
+            const result = await getSystemState(db);
+
+            expect(result).toEqual({ irrigationEnabled: true, since: '1970-01-01T00:00:00.000Z' });
+            const messages = warnSpy.mock.calls.map(args => String((args as unknown[])[0]));
+            expect(messages.some(m => m.includes('singleton row missing'))).toBe(true);
+        });
+    });
+});
+
+describe('setIrrigationEnabled', () => {
+    it('upserts with the new flag and timestamp, returning the DTO', async () => {
+        const { db, calls } = writerStub();
+        const now = new Date('2026-05-20T17:00:00.000Z');
+
+        const result = await setIrrigationEnabled(db, false, now);
+
+        expect(result).toEqual({ irrigationEnabled: false, since: '2026-05-20T17:00:00.000Z' });
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.values).toMatchObject({
+            id: 'singleton',
+            irrigationEnabled: false,
+            since: now,
+        });
+    });
+
+    it('round-trips through a reader-and-writer composite', async () => {
+        // After a flip-to-disabled, a subsequent read still maps to the new state.
+        const initialSince = new Date('2026-05-20T10:00:00.000Z');
+        const { db } = bothStub([{ irrigationEnabled: true, since: initialSince }]);
+        const flippedAt = new Date('2026-05-20T18:00:00.000Z');
+
+        const post = await setIrrigationEnabled(db, false, flippedAt);
+
+        expect(post.irrigationEnabled).toBe(false);
+        expect(post.since).toBe(flippedAt.toISOString());
+    });
+});
+
+// Use the systemState import so the file compiles even if Drizzle tree-shakes.
+void systemState;

--- a/api/system/index.ts
+++ b/api/system/index.ts
@@ -1,0 +1,107 @@
+import { eq, sql } from 'drizzle-orm';
+import { SYSTEM_STATE_SINGLETON_ID, systemState } from '@/db/schema';
+
+/**
+ * Wire-format snapshot of the master irrigation kill switch. `since` is the
+ * ISO-8601 UTC instant the system entered its current state — bumped on every
+ * flip — so the mobile UI can render "off since 2:34 PM" labels.
+ */
+export type SystemStateDto = {
+    irrigationEnabled: boolean;
+    since: string;
+};
+
+/**
+ * Minimal db interface used by the reader. Returns the singleton row (or
+ * empty when, defensively, no seed exists yet).
+ */
+export type SystemStateReaderDb = {
+    select: (cols: {
+        irrigationEnabled: typeof systemState.irrigationEnabled;
+        since: typeof systemState.since;
+    }) => {
+        from: (table: typeof systemState) => {
+            where: (cond: unknown) => {
+                limit: (n: number) => Promise<Array<{ irrigationEnabled: boolean; since: Date }>>;
+            };
+        };
+    };
+};
+
+/**
+ * Minimal db interface used by the writer. Mirrors the weather-state upsert
+ * pattern — production passes Drizzle directly, tests pass a recording stub.
+ */
+export type SystemStateWriterDb = {
+    insert: (table: typeof systemState) => {
+        values: (row: Record<string, unknown>) => {
+            onConflictDoUpdate: (config: {
+                target: unknown;
+                set: Record<string, unknown>;
+            }) => Promise<unknown>;
+        };
+    };
+};
+
+/**
+ * Composite for callers (the daemon, the HTTP wiring) that need both surfaces.
+ */
+export type SystemStateDb = SystemStateReaderDb & SystemStateWriterDb;
+
+/**
+ * Reads the singleton row backing the kill switch. The migration seeds the
+ * row at table-creation time, so this should never miss in production — the
+ * defensive fallback exists in case a migration was bypassed during dev. A
+ * warn-log fires if the fallback path is taken so the discrepancy isn't
+ * silent.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @returns DTO with the current flag value and ISO `since` timestamp.
+ */
+export async function getSystemState(db: SystemStateReaderDb): Promise<SystemStateDto> {
+    const rows = await db
+        .select({
+            irrigationEnabled: systemState.irrigationEnabled,
+            since: systemState.since,
+        })
+        .from(systemState)
+        .where(eq(systemState.id, SYSTEM_STATE_SINGLETON_ID))
+        .limit(1);
+
+    const row = rows[0];
+    if (!row) {
+        console.warn('system: singleton row missing — falling back to enabled default. Re-run migrations.');
+        return { irrigationEnabled: true, since: new Date(0).toISOString() };
+    }
+    return { irrigationEnabled: row.irrigationEnabled, since: row.since.toISOString() };
+}
+
+/**
+ * Upserts the singleton row with the new flag and a fresh `since` timestamp.
+ * Returns the post-update DTO so route handlers can echo the new state back
+ * to the client without an extra read.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param enabled - The new value of the `irrigationEnabled` flag.
+ * @param now - Timestamp to write into `since`. Injectable so callers drive
+ *   the clock under test.
+ */
+export async function setIrrigationEnabled(
+    db: SystemStateWriterDb,
+    enabled: boolean,
+    now: Date,
+): Promise<SystemStateDto> {
+    await db
+        .insert(systemState)
+        .values({ id: SYSTEM_STATE_SINGLETON_ID, irrigationEnabled: enabled, since: now })
+        .onConflictDoUpdate({
+            target: systemState.id,
+            set: {
+                irrigationEnabled: sql`excluded.irrigation_enabled`,
+                since: sql`excluded.since`,
+            },
+        });
+
+    console.log(`system: irrigationEnabled=${enabled} since=${now.toISOString()}.`);
+    return { irrigationEnabled: enabled, since: now.toISOString() };
+}


### PR DESCRIPTION
## Ticket

[API-46](http://192.168.2.100:7123/irrigo/browse/API-46/) Master irrigation kill switch — POST /system/enable + /system/disable + GET /system

## Summary

- New singleton \`system_state\` table (migration 0011, seeded \`irrigationEnabled=true\` on creation) backed by a tiny \`api/system/\` module (\`getSystemState\` / \`setIrrigationEnabled\`).
- Daemon boot skips arming \`loadFutureCycles\` when disabled (reconcile still runs); \`rePlan()\` cancels open timers, advances \`lastRePlanAt\`, and returns early without planning when disabled.
- Manual controller throws \`SystemDisabledError\` from \`open\` / \`run\` when the switch is off; \`close\` and \`shutdown\` stay ungated so an open relay can always be stopped. The route layer maps that to **409 \`system-disabled\`**.
- New routes: \`GET /system\` (200 with \`{ irrigationEnabled, since }\`), \`POST /system/enable\` / \`/disable\` (200 with post-flip DTO, 502 on wrapped re-plan failure). Wrapped with \`wrapSystemWithReplan\` so flips take effect immediately.
- Production wiring in \`api/index.ts\` connects the system handlers to the daemon and the manual controller's \`isIrrigationEnabled\` predicate.

## Test plan

- [x] \`bun --cwd api test\` — 629/629 green
- [x] \`bun --cwd api run type-check\` — clean
- [ ] Manual: \`POST /system/disable\` → confirm daemon logs the gate fire; \`POST /zones/<id>/open\` returns 409 \`system-disabled\`; \`POST /system/enable\` restores normal operation.