### PR TITLE
[API-45] GET /activity — chronological schedule-entries feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,12 @@ First-time setup:
 
 Detailed frontend conventions (component structure, hooks, Tailwind/NativeWind) live in `shared/CLAUDE.md`.
 
+## Shell commands
+
+- Never prepend `cd /app` (or any other current-directory `cd`) to a command. The working directory is already `/app` — run the command directly. Prepending `cd` triggers a separate permission prompt for every invocation.
+- For commands that need a different cwd, prefer the tool's `--cwd` flag over `cd && …`. Examples: `bun --cwd api test`, `bun --cwd api run type-check`, `bun --cwd /app/api run db:generate`. Same for `docker compose --project-directory …`.
+- `git` always operates on the current working tree — never prefix git commands with `cd`.
+
 ## Testing
 
 - **Every change to a code file requires matching test coverage** — new behavior gets new tests, modified behavior gets updated tests. A change isn't complete until the tests cover it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ Detailed frontend conventions (component structure, hooks, Tailwind/NativeWind) 
 - Never prepend `cd /app` (or any other current-directory `cd`) to a command. The working directory is already `/app` — run the command directly. Prepending `cd` triggers a separate permission prompt for every invocation.
 - For commands that need a different cwd, prefer the tool's `--cwd` flag over `cd && …`. Examples: `bun --cwd api test`, `bun --cwd api run type-check`, `bun --cwd /app/api run db:generate`. Same for `docker compose --project-directory …`.
 - `git` always operates on the current working tree — never prefix git commands with `cd`.
+- **No compound commands.** Don't chain shell expressions with `&&`, `||`, or `;` — each Bash call should run exactly one logical command so the permission matcher can pre-approve it by prefix. Run multi-step verification (type-check + tests) as separate Bash calls. The only exception is `git commit -m "$(cat <<'EOF' … EOF)"` heredoc for multi-line messages — that's still one logical command.
+- **No `| tail` / `| head` / `2>&1` redirection.** The Bash tool already captures stdout + stderr in full. Trimming output in the shell triggers a fresh permission prompt for every distinct compound; if a result is too long for context, truncate it when summarizing rather than in the pipe.
 
 ## Testing
 

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import { encodeCursor as encodeActivityCursor, type ActivityDto, type ActivityListParams, type ActivityListResult } from '@/activity';
 import type { AlertDto } from '@/alerts';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
@@ -1225,5 +1226,149 @@ describe('wrapSystemWithReplan', () => {
         const wrapped = wrapSystemWithReplan(base, async () => { throw new Error('replan failed'); });
 
         await expect(wrapped.enable()).rejects.toThrow('replan failed');
+    });
+});
+
+describe('buildApp GET /activity', () => {
+    function buildDto(overrides?: Partial<ActivityDto>): ActivityDto {
+        return {
+            id: 'entry-1',
+            date: '2026-05-20',
+            zone: { id: 'zone-1', name: 'Front Lawn', slug: 'front-lawn' },
+            appliedDepthMm: 8.4,
+            durationMin: 42,
+            depletionBeforeMm: 12.0,
+            depletionAfterMm: 0.3,
+            source: 'planner',
+            ...overrides,
+        };
+    }
+
+    type RecordedCall = ActivityListParams;
+
+    function recordingActivity(result: ActivityListResult): {
+        handler: (params: ActivityListParams) => Promise<ActivityListResult>;
+        calls: RecordedCall[];
+    } {
+        const calls: RecordedCall[] = [];
+        return {
+            handler: async (params) => {
+                calls.push(params);
+                return result;
+            },
+            calls,
+        };
+    }
+
+    it('returns 200 with the lister result', async () => {
+        const result: ActivityListResult = {
+            activity: [buildDto(), buildDto({ id: 'entry-2', source: 'manual' })],
+            nextCursor: encodeActivityCursor('2026-05-19', 'entry-cursor'),
+        };
+        const { handler } = recordingActivity(result);
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        const res = await app.inject({ method: 'GET', url: '/activity' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual(result);
+        await app.close();
+    });
+
+    it('returns 404 when the activity handler is absent', async () => {
+        const app = buildApp({ getStatus: () => buildStatus() });
+
+        const res = await app.inject({ method: 'GET', url: '/activity' });
+
+        expect(res.statusCode).toBe(404);
+        await app.close();
+    });
+
+    it('defaults limit to 20 when no limit query param is provided', async () => {
+        const { handler, calls } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        await app.inject({ method: 'GET', url: '/activity' });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.limit).toBe(20);
+        expect(calls[0]?.zoneId).toBeUndefined();
+        expect(calls[0]?.cursor).toBeUndefined();
+        await app.close();
+    });
+
+    it('passes the zoneId query param through to the handler', async () => {
+        const { handler, calls } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        await app.inject({ method: 'GET', url: '/activity?zoneId=zone-001' });
+
+        expect(calls[0]?.zoneId).toBe('zone-001');
+        await app.close();
+    });
+
+    it('passes a parsed numeric limit through to the handler', async () => {
+        const { handler, calls } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        await app.inject({ method: 'GET', url: '/activity?limit=5' });
+
+        expect(calls[0]?.limit).toBe(5);
+        await app.close();
+    });
+
+    it('passes the cursor through verbatim when it round-trips', async () => {
+        const cursor = encodeActivityCursor('2026-05-19', 'entry-prev');
+        const { handler, calls } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        await app.inject({ method: 'GET', url: `/activity?cursor=${encodeURIComponent(cursor)}` });
+
+        expect(calls[0]?.cursor).toBe(cursor);
+        await app.close();
+    });
+
+    it('returns 400 when limit is not an integer', async () => {
+        const { handler } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        const res = await app.inject({ method: 'GET', url: '/activity?limit=abc' });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.json()).toMatchObject({ error: 'bad-request' });
+        await app.close();
+    });
+
+    it('returns 400 when limit is zero or negative', async () => {
+        const { handler } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        const zero = await app.inject({ method: 'GET', url: '/activity?limit=0' });
+        const negative = await app.inject({ method: 'GET', url: '/activity?limit=-3' });
+
+        expect(zero.statusCode).toBe(400);
+        expect(negative.statusCode).toBe(400);
+        await app.close();
+    });
+
+    it('returns 400 when limit exceeds the max', async () => {
+        const { handler } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        const res = await app.inject({ method: 'GET', url: '/activity?limit=999' });
+
+        expect(res.statusCode).toBe(400);
+        await app.close();
+    });
+
+    it('returns 400 when cursor is malformed', async () => {
+        const { handler } = recordingActivity({ activity: [], nextCursor: null });
+        const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
+
+        const res = await app.inject({ method: 'GET', url: '/activity?cursor=not-a-cursor' });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.json()).toMatchObject({ error: 'bad-request' });
+        await app.close();
     });
 });

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
-import { encodeCursor as encodeActivityCursor, type ActivityDto, type ActivityListParams, type ActivityListResult } from '@/activity';
+import type { ActivityDto, ActivityListParams, ActivityListResult } from '@/activity';
+import { encodeCursor } from '@/util/cursor';
 import type { AlertDto } from '@/alerts';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
@@ -1263,7 +1264,7 @@ describe('buildApp GET /activity', () => {
     it('returns 200 with the lister result', async () => {
         const result: ActivityListResult = {
             activity: [buildDto(), buildDto({ id: 'entry-2', source: 'manual' })],
-            nextCursor: encodeActivityCursor('2026-05-19', 'entry-cursor'),
+            nextCursor: encodeCursor('2026-05-19', 'entry-cursor'),
         };
         const { handler } = recordingActivity(result);
         const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
@@ -1318,7 +1319,7 @@ describe('buildApp GET /activity', () => {
     });
 
     it('passes the cursor through verbatim when it round-trips', async () => {
-        const cursor = encodeActivityCursor('2026-05-19', 'entry-prev');
+        const cursor = encodeCursor('2026-05-19', 'entry-prev');
         const { handler, calls } = recordingActivity({ activity: [], nextCursor: null });
         const app = buildApp({ getStatus: () => buildStatus(), activity: handler });
 

--- a/api/activity/.test.ts
+++ b/api/activity/.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import { decodeCursor, encodeCursor } from '@/util/cursor';
 import {
     DEFAULT_ACTIVITY_LIMIT,
-    decodeCursor,
-    encodeCursor,
     listActivity,
     MAX_ACTIVITY_LIMIT,
     type ActivityDb,
@@ -89,40 +88,6 @@ function recordingDb(rows: JoinedRow[]): { db: ActivityDb; calls: DbCall[] } {
     };
     return { db, calls };
 }
-
-describe('encodeCursor / decodeCursor', () => {
-    it('round-trips a (date, id) pair', () => {
-        const cursor = encodeCursor('2026-05-20', 'entry-abc-123');
-
-        const decoded = decodeCursor(cursor);
-
-        expect(decoded).toEqual({ date: '2026-05-20', id: 'entry-abc-123' });
-    });
-
-    it('returns null for an empty cursor', () => {
-        expect(decodeCursor('')).toBeNull();
-    });
-
-    it('returns null for a cursor missing the separator', () => {
-        const noSeparator = Buffer.from('2026-05-20-entry-1', 'utf8').toString('base64url');
-
-        expect(decodeCursor(noSeparator)).toBeNull();
-    });
-
-    it('returns null when one of the parts is empty', () => {
-        const emptyDate = Buffer.from('|entry-1', 'utf8').toString('base64url');
-        const emptyId = Buffer.from('2026-05-20|', 'utf8').toString('base64url');
-
-        expect(decodeCursor(emptyDate)).toBeNull();
-        expect(decodeCursor(emptyId)).toBeNull();
-    });
-
-    it('returns null on garbage input', () => {
-        // Random non-base64 string. Buffer is permissive, so we exercise both a
-        // structurally-decodable-but-meaningless cursor and a clearly invalid one.
-        expect(decodeCursor('!!!@@@###')).toBeNull();
-    });
-});
 
 describe('listActivity', () => {
     it('maps planner and manual entries to the right source DTO field', async () => {

--- a/api/activity/.test.ts
+++ b/api/activity/.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'bun:test';
+import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import {
+    DEFAULT_ACTIVITY_LIMIT,
+    decodeCursor,
+    encodeCursor,
+    listActivity,
+    MAX_ACTIVITY_LIMIT,
+    type ActivityDb,
+} from '.';
+
+type EntryRow = typeof scheduleEntries.$inferSelect;
+type JoinedRow = {
+    entry: EntryRow;
+    zone: { id: string; name: string; slug: string };
+    durationMin: number;
+};
+
+const NOW = new Date('2026-05-21T12:00:00.000Z');
+
+function buildEntry(overrides?: Partial<EntryRow>): EntryRow {
+    return {
+        id: 'entry-1',
+        zoneId: 'zone-1',
+        scheduleId: 'sched-1',
+        date: '2026-05-20',
+        appliedDepthMm: 8.4,
+        depletionBeforeMm: 12.0,
+        depletionAfterMm: 0.6,
+        source: 'scheduled',
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+function buildJoinedRow(overrides?: {
+    entry?: Partial<EntryRow>;
+    zone?: Partial<{ id: string; name: string; slug: string }>;
+    durationMin?: number;
+}): JoinedRow {
+    return {
+        entry: buildEntry(overrides?.entry),
+        zone: {
+            id: 'zone-1',
+            name: 'Front Lawn',
+            slug: 'front-lawn',
+            ...overrides?.zone,
+        },
+        durationMin: overrides?.durationMin ?? 0,
+    };
+}
+
+type DbCall = {
+    select: Record<string, unknown>;
+    where: unknown;
+    groupBy: ReadonlyArray<unknown>;
+    orderBy: ReadonlyArray<unknown>;
+    limit: number;
+};
+
+function recordingDb(rows: JoinedRow[]): { db: ActivityDb; calls: DbCall[] } {
+    const calls: DbCall[] = [];
+    const db: ActivityDb = {
+        select: (cols) => ({
+            from: () => ({
+                innerJoin: () => ({
+                    leftJoin: () => ({
+                        where: (whereCond) => ({
+                            groupBy: (...groupBy) => ({
+                                orderBy: (...orderBy) => ({
+                                    limit: async (n) => {
+                                        calls.push({
+                                            select: cols as unknown as Record<string, unknown>,
+                                            where: whereCond,
+                                            groupBy,
+                                            orderBy,
+                                            limit: n,
+                                        });
+                                        return rows.slice(0, n);
+                                    },
+                                }),
+                            }),
+                        }),
+                    }),
+                }),
+            }),
+        }),
+    };
+    return { db, calls };
+}
+
+describe('encodeCursor / decodeCursor', () => {
+    it('round-trips a (date, id) pair', () => {
+        const cursor = encodeCursor('2026-05-20', 'entry-abc-123');
+
+        const decoded = decodeCursor(cursor);
+
+        expect(decoded).toEqual({ date: '2026-05-20', id: 'entry-abc-123' });
+    });
+
+    it('returns null for an empty cursor', () => {
+        expect(decodeCursor('')).toBeNull();
+    });
+
+    it('returns null for a cursor missing the separator', () => {
+        const noSeparator = Buffer.from('2026-05-20-entry-1', 'utf8').toString('base64url');
+
+        expect(decodeCursor(noSeparator)).toBeNull();
+    });
+
+    it('returns null when one of the parts is empty', () => {
+        const emptyDate = Buffer.from('|entry-1', 'utf8').toString('base64url');
+        const emptyId = Buffer.from('2026-05-20|', 'utf8').toString('base64url');
+
+        expect(decodeCursor(emptyDate)).toBeNull();
+        expect(decodeCursor(emptyId)).toBeNull();
+    });
+
+    it('returns null on garbage input', () => {
+        // Random non-base64 string. Buffer is permissive, so we exercise both a
+        // structurally-decodable-but-meaningless cursor and a clearly invalid one.
+        expect(decodeCursor('!!!@@@###')).toBeNull();
+    });
+});
+
+describe('listActivity', () => {
+    it('maps planner and manual entries to the right source DTO field', async () => {
+        const rows: JoinedRow[] = [
+            buildJoinedRow({ entry: { id: 'e-planner', source: 'scheduled' } }),
+            buildJoinedRow({ entry: { id: 'e-manual', source: 'manual' } }),
+        ];
+        const { db } = recordingDb(rows);
+
+        const result = await listActivity(db, { limit: 10 });
+
+        expect(result.activity.map(a => ({ id: a.id, source: a.source }))).toEqual([
+            { id: 'e-planner', source: 'planner' },
+            { id: 'e-manual', source: 'manual' },
+        ]);
+    });
+
+    it('forwards the joined zone fields and depletion values into the DTO', async () => {
+        const { db } = recordingDb([
+            buildJoinedRow({
+                entry: { id: 'e-1', appliedDepthMm: 7.5, depletionBeforeMm: 11.2, depletionAfterMm: 0.3, date: '2026-05-19' },
+                zone: { id: 'zone-7', name: 'Back Strip', slug: 'back-strip' },
+                durationMin: 42,
+            }),
+        ]);
+
+        const { activity } = await listActivity(db, { limit: 10 });
+
+        expect(activity[0]).toEqual({
+            id: 'e-1',
+            date: '2026-05-19',
+            zone: { id: 'zone-7', name: 'Back Strip', slug: 'back-strip' },
+            appliedDepthMm: 7.5,
+            durationMin: 42,
+            depletionBeforeMm: 11.2,
+            depletionAfterMm: 0.3,
+            source: 'planner',
+        });
+    });
+
+    it('returns durationMin = 0 when the entry has no associated cycles', async () => {
+        const { db } = recordingDb([buildJoinedRow({ durationMin: 0 })]);
+
+        const { activity } = await listActivity(db, { limit: 10 });
+
+        expect(activity[0]?.durationMin).toBe(0);
+    });
+
+    it('orders rows by (date DESC, id DESC) — passes the right exprs to orderBy', async () => {
+        const { db, calls } = recordingDb([buildJoinedRow()]);
+
+        await listActivity(db, { limit: 10 });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.orderBy).toHaveLength(2);
+        // The exprs are Drizzle SQL objects whose internal `.column` references
+        // back to scheduleEntries.date / .id. We check the count + that the
+        // limit reaches the lister rather than peering inside the SQL AST.
+        expect(calls[0]?.limit).toBe(11); // limit + 1 for peek-ahead
+    });
+
+    it('trims results to limit and emits nextCursor when a peek-ahead row exists', async () => {
+        const rows: JoinedRow[] = [
+            buildJoinedRow({ entry: { id: 'e-1', date: '2026-05-20' } }),
+            buildJoinedRow({ entry: { id: 'e-2', date: '2026-05-19' } }),
+            buildJoinedRow({ entry: { id: 'e-3', date: '2026-05-18' } }),
+        ];
+        const { db } = recordingDb(rows);
+
+        const result = await listActivity(db, { limit: 2 });
+
+        expect(result.activity).toHaveLength(2);
+        expect(result.activity.map(a => a.id)).toEqual(['e-1', 'e-2']);
+        // nextCursor encodes the LAST returned row's (date, id) — the peek-ahead
+        // row stays on the next page.
+        expect(result.nextCursor).not.toBeNull();
+        expect(decodeCursor(result.nextCursor!)).toEqual({ date: '2026-05-19', id: 'e-2' });
+    });
+
+    it('returns nextCursor: null when the result is the final page', async () => {
+        const rows: JoinedRow[] = [buildJoinedRow({ entry: { id: 'only' } })];
+        const { db } = recordingDb(rows);
+
+        const result = await listActivity(db, { limit: 10 });
+
+        expect(result.activity).toHaveLength(1);
+        expect(result.nextCursor).toBeNull();
+    });
+
+    it('returns an empty page with no nextCursor when the table is empty', async () => {
+        const { db } = recordingDb([]);
+
+        const result = await listActivity(db, { limit: 10 });
+
+        expect(result.activity).toEqual([]);
+        expect(result.nextCursor).toBeNull();
+    });
+
+    it('threads the zoneId filter into the WHERE clause', async () => {
+        const { db, calls } = recordingDb([buildJoinedRow()]);
+
+        await listActivity(db, { limit: 10, zoneId: 'zone-7' });
+
+        expect(calls).toHaveLength(1);
+        const params = paramValues(calls[0]?.where);
+        expect(params).toContain('zone-7');
+    });
+
+    it('threads the decoded cursor (date, id) into the WHERE clause', async () => {
+        const cursor = encodeCursor('2026-05-18', 'entry-cursor');
+        const { db, calls } = recordingDb([buildJoinedRow()]);
+
+        await listActivity(db, { limit: 10, cursor });
+
+        expect(calls).toHaveLength(1);
+        const params = paramValues(calls[0]?.where);
+        expect(params).toContain('2026-05-18');
+        expect(params).toContain('entry-cursor');
+    });
+
+    it('returns the lister-default page size when limit equals DEFAULT_ACTIVITY_LIMIT', async () => {
+        const { db, calls } = recordingDb([]);
+
+        await listActivity(db, { limit: DEFAULT_ACTIVITY_LIMIT });
+
+        expect(calls[0]?.limit).toBe(DEFAULT_ACTIVITY_LIMIT + 1);
+    });
+});
+
+function paramValues(cond: unknown): string[] {
+    // Drizzle conditions are SQL objects whose `queryChunks` carry `Param`
+    // instances with `.value`. We walk the tree to extract bound string values
+    // (the only kind our lister threads through). This is the same pattern used
+    // by the schedule-manager tests.
+    const seen = new WeakSet<object>();
+    const values: string[] = [];
+    function walk(node: unknown): void {
+        if (typeof node !== 'object' || node === null) return;
+        if (seen.has(node)) return;
+        seen.add(node);
+        const obj = node as Record<string, unknown>;
+        if ('encoder' in obj && 'value' in obj && typeof obj['value'] === 'string') {
+            values.push(obj['value']);
+            return;
+        }
+        if (Array.isArray(node)) { for (const item of node) walk(item); return; }
+        for (const v of Object.values(obj)) walk(v);
+    }
+    walk(cond);
+    return values;
+}
+
+// Ensure the table imports compile even if Drizzle tree-shakes the references.
+void scheduleEntries;
+void irrigationCycles;
+void zones;
+void MAX_ACTIVITY_LIMIT;

--- a/api/activity/index.ts
+++ b/api/activity/index.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, lt, or, sql } from 'drizzle-orm';
 import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import { decodeCursor, encodeCursor } from '@/util/cursor';
 
 /**
  * Wire-format value for the entry's origin. The DB column stores the legacy
@@ -86,36 +87,6 @@ export type ActivityDb = {
         };
     };
 };
-
-/**
- * Encodes a `(date, id)` pair as an opaque base64url cursor. Format used by
- * `decodeCursor` is `${date}|${id}` — both fields are URL-safe ASCII, so the
- * `|` separator can't collide with the payload.
- */
-export function encodeCursor(date: string, id: string): string {
-    return Buffer.from(`${date}|${id}`, 'utf8').toString('base64url');
-}
-
-/**
- * Decodes an opaque cursor back into its `(date, id)` parts. Returns `null`
- * when the input is malformed (not base64, missing separator, empty parts) so
- * the route handler can map that to a 400 without leaking the format.
- */
-export function decodeCursor(cursor: string): { date: string; id: string } | null {
-    if (cursor.length === 0) return null;
-    let decoded: string;
-    try {
-        decoded = Buffer.from(cursor, 'base64url').toString('utf8');
-    } catch {
-        return null;
-    }
-    const sep = decoded.indexOf('|');
-    if (sep <= 0 || sep === decoded.length - 1) return null;
-    const date = decoded.slice(0, sep);
-    const id = decoded.slice(sep + 1);
-    if (date.length === 0 || id.length === 0) return null;
-    return { date, id };
-}
 
 /**
  * Fetches a page of the chronological activity feed.

--- a/api/activity/index.ts
+++ b/api/activity/index.ts
@@ -1,0 +1,190 @@
+import { and, desc, eq, lt, or, sql } from 'drizzle-orm';
+import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+
+/**
+ * Wire-format value for the entry's origin. The DB column stores the legacy
+ * value `'scheduled'` for planner-driven entries (it's the column default),
+ * but the mobile spec wants `'planner'` — so we map at the DTO boundary.
+ */
+export type ActivitySource = 'planner' | 'manual';
+
+/**
+ * One row in the Activity feed. Drives both the Activity screen and the
+ * "Recent runs" section on Zone detail. `id` is the underlying
+ * `schedule_entries.id` — also used to build the next-page cursor.
+ *
+ * `durationMin` is the SUM of associated `irrigation_cycles.duration_min`
+ * rows (0 when an entry has no cycles, e.g. a planner entry that was deferred
+ * by restrictions).
+ */
+export type ActivityDto = {
+    id: string;
+    date: string;
+    zone: { id: string; name: string; slug: string };
+    appliedDepthMm: number;
+    durationMin: number;
+    depletionBeforeMm: number;
+    depletionAfterMm: number;
+    source: ActivitySource;
+};
+
+/**
+ * Parameters accepted by `listActivity`. `limit` is required from the caller
+ * (the route handler applies the default + clamps) so the lister can stay
+ * focused on data fetching rather than validation.
+ */
+export type ActivityListParams = {
+    zoneId?: string;
+    limit: number;
+    cursor?: string;
+};
+
+/**
+ * Result of a `listActivity` call. `nextCursor` is `null` when the result is
+ * the last page; otherwise it's an opaque base64 string the client passes
+ * back as `?cursor=…` to fetch the next page.
+ */
+export type ActivityListResult = {
+    activity: ActivityDto[];
+    nextCursor: string | null;
+};
+
+/** Default page size when the client omits `?limit=`. */
+export const DEFAULT_ACTIVITY_LIMIT = 20;
+
+/** Hard cap to keep the wire payload bounded under arbitrary clients. */
+export const MAX_ACTIVITY_LIMIT = 100;
+
+type ActivityJoinedRow = {
+    entry: typeof scheduleEntries.$inferSelect;
+    zone: { id: string; name: string; slug: string };
+    durationMin: number;
+};
+
+/**
+ * Minimal db interface the lister needs. Mirrors Drizzle's chained
+ * select-with-joins shape so a recording stub can stand in for tests.
+ */
+export type ActivityDb = {
+    select: (columns: {
+        entry: typeof scheduleEntries;
+        zone: { id: typeof zones.id; name: typeof zones.name; slug: typeof zones.slug };
+        durationMin: unknown;
+    }) => {
+        from: (table: typeof scheduleEntries) => {
+            innerJoin: (table: typeof zones, on: unknown) => {
+                leftJoin: (table: typeof irrigationCycles, on: unknown) => {
+                    where: (cond: unknown) => {
+                        groupBy: (...exprs: ReadonlyArray<unknown>) => {
+                            orderBy: (...exprs: ReadonlyArray<unknown>) => {
+                                limit: (n: number) => Promise<ActivityJoinedRow[]>;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+};
+
+/**
+ * Encodes a `(date, id)` pair as an opaque base64url cursor. Format used by
+ * `decodeCursor` is `${date}|${id}` — both fields are URL-safe ASCII, so the
+ * `|` separator can't collide with the payload.
+ */
+export function encodeCursor(date: string, id: string): string {
+    return Buffer.from(`${date}|${id}`, 'utf8').toString('base64url');
+}
+
+/**
+ * Decodes an opaque cursor back into its `(date, id)` parts. Returns `null`
+ * when the input is malformed (not base64, missing separator, empty parts) so
+ * the route handler can map that to a 400 without leaking the format.
+ */
+export function decodeCursor(cursor: string): { date: string; id: string } | null {
+    if (cursor.length === 0) return null;
+    let decoded: string;
+    try {
+        decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    } catch {
+        return null;
+    }
+    const sep = decoded.indexOf('|');
+    if (sep <= 0 || sep === decoded.length - 1) return null;
+    const date = decoded.slice(0, sep);
+    const id = decoded.slice(sep + 1);
+    if (date.length === 0 || id.length === 0) return null;
+    return { date, id };
+}
+
+/**
+ * Fetches a page of the chronological activity feed.
+ *
+ * Joins `schedule_entries × zones` for the row data, left-joins
+ * `irrigation_cycles` for the runtime SUM. Pagination is keyset on
+ * `(date DESC, id DESC)` — `date` is day-granularity so the secondary `id`
+ * sort makes pages stable when multiple zones write on the same date.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param params - Filter, page size, and optional cursor from the route.
+ * @returns The page of DTOs plus `nextCursor` (null on the final page).
+ */
+export async function listActivity(db: ActivityDb, params: ActivityListParams): Promise<ActivityListResult> {
+    const cursorParts = params.cursor !== undefined ? decodeCursor(params.cursor) : null;
+    // The route handler validates the cursor before calling us; we only reach
+    // this with a `cursor` field when it's well-formed. Treat `cursorParts ===
+    // null` here as "no cursor supplied" (the undefined case).
+
+    const conditions: unknown[] = [];
+    if (params.zoneId !== undefined) {
+        conditions.push(eq(scheduleEntries.zoneId, params.zoneId));
+    }
+    if (cursorParts !== null) {
+        conditions.push(
+            or(
+                lt(scheduleEntries.date, cursorParts.date),
+                and(eq(scheduleEntries.date, cursorParts.date), lt(scheduleEntries.id, cursorParts.id)),
+            ),
+        );
+    }
+    const whereCondition: unknown =
+        conditions.length === 0 ? sql`true`
+        : conditions.length === 1 ? conditions[0]
+        : and(...(conditions as Parameters<typeof and>));
+
+    const rows = await db
+        .select({
+            entry: scheduleEntries,
+            zone: { id: zones.id, name: zones.name, slug: zones.slug },
+            durationMin: sql<number>`COALESCE(SUM(${irrigationCycles.durationMin}), 0)`,
+        })
+        .from(scheduleEntries)
+        .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+        .leftJoin(irrigationCycles, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+        .where(whereCondition)
+        .groupBy(scheduleEntries.id, zones.id)
+        .orderBy(desc(scheduleEntries.date), desc(scheduleEntries.id))
+        .limit(params.limit + 1);
+
+    const hasMore = rows.length > params.limit;
+    const pageRows = hasMore ? rows.slice(0, params.limit) : rows;
+    const activity = pageRows.map(rowToDto);
+    const lastRow = pageRows[pageRows.length - 1];
+    const nextCursor = hasMore && lastRow !== undefined ? encodeCursor(lastRow.entry.date, lastRow.entry.id) : null;
+
+    console.log(`api: listActivity returned ${activity.length} entry/entries (zoneId=${params.zoneId ?? '*'}, more=${hasMore}).`);
+    return { activity, nextCursor };
+}
+
+function rowToDto(row: ActivityJoinedRow): ActivityDto {
+    return {
+        id: row.entry.id,
+        date: row.entry.date,
+        zone: row.zone,
+        appliedDepthMm: row.entry.appliedDepthMm,
+        durationMin: row.durationMin,
+        depletionBeforeMm: row.entry.depletionBeforeMm,
+        depletionAfterMm: row.entry.depletionAfterMm,
+        source: row.entry.source === 'manual' ? 'manual' : 'planner',
+    };
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,5 +1,14 @@
 import Config from '@/config';
 import {
+    DEFAULT_ACTIVITY_LIMIT,
+    decodeCursor as decodeActivityCursor,
+    listActivity,
+    MAX_ACTIVITY_LIMIT,
+    type ActivityDb,
+    type ActivityListParams,
+    type ActivityListResult,
+} from '@/activity';
+import {
     acknowledgeAlert,
     createAlerter,
     listActiveAlerts,
@@ -162,6 +171,14 @@ export type BuildAppOptions = {
      * flip triggers an immediate re-plan.
      */
     system?: SystemApi;
+
+    /**
+     * Optional. When supplied, registers `GET /activity` — the chronological
+     * schedule-entries feed driving the Activity screen and the "Recent runs"
+     * section on Zone detail. Production wires this to the activity module's
+     * DB-backed lister.
+     */
+    activity?: (params: ActivityListParams) => Promise<ActivityListResult>;
 };
 
 /**
@@ -213,7 +230,57 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerSystemRoutes(app, opts.system);
     }
 
+    if (opts.activity) {
+        registerActivityRoute(app, opts.activity);
+    }
+
     return app;
+}
+
+function registerActivityRoute(
+    app: FastifyInstance,
+    activity: (params: ActivityListParams) => Promise<ActivityListResult>,
+): void {
+    /**
+     * `GET /activity` — chronological schedule-entries feed. Drives the
+     * Activity screen (no filter) and Zone detail's "Recent runs" tab
+     * (?zoneId=…). Pagination is keyset: pass `?cursor=` from the previous
+     * response to fetch the next page.
+     */
+    app.get('/activity', async (req, reply) => {
+        const query = req.query as Record<string, unknown>;
+        const zoneIdRaw = query['zoneId'];
+        const zoneId = typeof zoneIdRaw === 'string' && zoneIdRaw.length > 0 ? zoneIdRaw : undefined;
+
+        const limitRaw = query['limit'];
+        let limit = DEFAULT_ACTIVITY_LIMIT;
+        if (limitRaw !== undefined) {
+            const parsed = typeof limitRaw === 'string' ? Number(limitRaw) : Number(limitRaw);
+            if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_ACTIVITY_LIMIT) {
+                return reply.code(400).send({
+                    error: 'bad-request',
+                    message: `limit must be an integer between 1 and ${MAX_ACTIVITY_LIMIT}.`,
+                });
+            }
+            limit = parsed;
+        }
+
+        const cursorRaw = query['cursor'];
+        let cursor: string | undefined;
+        if (cursorRaw !== undefined) {
+            if (typeof cursorRaw !== 'string' || cursorRaw.length === 0 || decodeActivityCursor(cursorRaw) === null) {
+                return reply.code(400).send({ error: 'bad-request', message: 'cursor is malformed.' });
+            }
+            cursor = cursorRaw;
+        }
+
+        const result = await activity({
+            ...(zoneId !== undefined ? { zoneId } : {}),
+            limit,
+            ...(cursor !== undefined ? { cursor } : {}),
+        });
+        return reply.code(200).send(result);
+    });
 }
 
 function registerSystemRoutes(app: FastifyInstance, system: SystemApi): void {
@@ -619,6 +686,7 @@ if (import.meta.main) {
             ack: id => acknowledgeAlert(alertsDb, id),
         },
         system: wrapSystemWithReplan(baseSystem, () => daemon.rePlan()),
+        activity: params => listActivity(db as unknown as ActivityDb, params),
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,13 +1,13 @@
 import Config from '@/config';
 import {
     DEFAULT_ACTIVITY_LIMIT,
-    decodeCursor as decodeActivityCursor,
     listActivity,
     MAX_ACTIVITY_LIMIT,
     type ActivityDb,
     type ActivityListParams,
     type ActivityListResult,
 } from '@/activity';
+import { decodeCursor } from '@/util/cursor';
 import {
     acknowledgeAlert,
     createAlerter,
@@ -268,7 +268,7 @@ function registerActivityRoute(
         const cursorRaw = query['cursor'];
         let cursor: string | undefined;
         if (cursorRaw !== undefined) {
-            if (typeof cursorRaw !== 'string' || cursorRaw.length === 0 || decodeActivityCursor(cursorRaw) === null) {
+            if (typeof cursorRaw !== 'string' || cursorRaw.length === 0 || decodeCursor(cursorRaw) === null) {
                 return reply.code(400).send({ error: 'bad-request', message: 'cursor is malformed.' });
             }
             cursor = cursorRaw;

--- a/api/util/cursor.test.ts
+++ b/api/util/cursor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { decodeCursor, encodeCursor } from './cursor';
+
+describe('encodeCursor / decodeCursor', () => {
+    it('round-trips a (date, id) pair', () => {
+        const cursor = encodeCursor('2026-05-20', 'entry-abc-123');
+
+        const decoded = decodeCursor(cursor);
+
+        expect(decoded).toEqual({ date: '2026-05-20', id: 'entry-abc-123' });
+    });
+
+    it('returns null for an empty cursor', () => {
+        expect(decodeCursor('')).toBeNull();
+    });
+
+    it('returns null for a cursor missing the separator', () => {
+        const noSeparator = Buffer.from('2026-05-20-entry-1', 'utf8').toString('base64url');
+
+        expect(decodeCursor(noSeparator)).toBeNull();
+    });
+
+    it('returns null when one of the parts is empty', () => {
+        const emptyDate = Buffer.from('|entry-1', 'utf8').toString('base64url');
+        const emptyId = Buffer.from('2026-05-20|', 'utf8').toString('base64url');
+
+        expect(decodeCursor(emptyDate)).toBeNull();
+        expect(decodeCursor(emptyId)).toBeNull();
+    });
+
+    it('returns null on garbage input', () => {
+        // Random non-base64 string. Buffer is permissive, so we exercise both a
+        // structurally-decodable-but-meaningless cursor and a clearly invalid one.
+        expect(decodeCursor('!!!@@@###')).toBeNull();
+    });
+});

--- a/api/util/cursor.ts
+++ b/api/util/cursor.ts
@@ -1,0 +1,44 @@
+/**
+ * Generic keyset-pagination cursor codec.
+ *
+ * Encodes a `(date, id)` tuple as an opaque base64url string the HTTP client
+ * round-trips verbatim. Keeping the wire shape opaque means the server is
+ * free to change the cursor's internal fields later (add a tertiary sort key,
+ * widen the date precision, swap to opaque page tokens, etc.) without
+ * breaking clients that have stored old cursors.
+ *
+ * Used by `api/activity/` and intended for any future endpoint that paginates
+ * by `(date DESC, id DESC)`. If a new endpoint needs a different key shape
+ * (e.g. `(timestamp, id)`), add a parallel codec rather than overloading
+ * this one.
+ */
+
+/**
+ * Encodes a `(date, id)` pair as an opaque base64url cursor. The internal
+ * format is `${date}|${id}` — both fields are URL-safe ASCII, so the `|`
+ * separator can't collide with the payload.
+ */
+export function encodeCursor(date: string, id: string): string {
+    return Buffer.from(`${date}|${id}`, 'utf8').toString('base64url');
+}
+
+/**
+ * Decodes an opaque cursor back into its `(date, id)` parts. Returns `null`
+ * when the input is malformed (not base64, missing separator, empty parts)
+ * so callers can map that to a 400 without leaking the internal format.
+ */
+export function decodeCursor(cursor: string): { date: string; id: string } | null {
+    if (cursor.length === 0) return null;
+    let decoded: string;
+    try {
+        decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    } catch {
+        return null;
+    }
+    const sep = decoded.indexOf('|');
+    if (sep <= 0 || sep === decoded.length - 1) return null;
+    const date = decoded.slice(0, sep);
+    const id = decoded.slice(sep + 1);
+    if (date.length === 0 || id.length === 0) return null;
+    return { date, id };
+}


### PR DESCRIPTION
## Ticket

[API-45](http://192.168.2.100:7123/irrigo/browse/API-45/) GET /activity — chronological schedule-entries across zones

## Summary

- New \`api/activity/\` module — DTO types, opaque base64url cursor codec, and \`listActivity\` lister. Joins \`schedule_entries × zones\`, left-joins \`irrigation_cycles\` for the \`durationMin\` SUM, groups by entry id.
- Pagination is keyset on \`(date DESC, id DESC)\` so pages stay stable across concurrent writes; \`limit + 1\` peek-ahead builds the \`nextCursor\` without a count query.
- New route \`GET /activity?zoneId=&limit=&cursor=\` — validates \`limit\` against \`MAX_ACTIVITY_LIMIT = 100\` (default 20), validates the cursor via the codec, returns \`200 { activity, nextCursor }\`. 404 when the handler is absent from \`BuildAppOptions\`.
- DB source value \`'scheduled'\` (planner default) maps to the wire-format \`'planner'\` at the DTO boundary; \`'manual'\` passes through unchanged.
- Includes a small \`chore:\` commit documenting the shell-cwd convention in \`CLAUDE.md\`.

## Test plan

- [x] \`bun --cwd api test\` — 654/654 green
- [x] \`bun --cwd api run type-check\` — clean
- [ ] Manual: \`curl 'http://localhost:<port>/activity?limit=5'\` returns the latest five entries newest-first; following \`nextCursor\` pages forward correctly; \`?zoneId=<id>\` scopes to one zone.