### PR TITLE
[API-43] GET /schedules — list with active flag, rules, nextRun

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -4,6 +4,7 @@ import { encodeCursor } from '@/util/cursor';
 import type { AlertDto } from '@/alerts';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
 import type { TonightDto } from '@/tonight';
+import type { ScheduleListItem } from '@/schedules-list';
 import type { DaemonControl, DaemonStatus } from '@/daemon';
 import type { ZoneSummary } from '@/daemon/zones';
 import { BusyError, SystemDisabledError, type ManualController } from '@/manual';
@@ -1448,6 +1449,86 @@ describe('buildApp GET /tonight', () => {
 
         expect(res.statusCode).toBe(200);
         expect(res.json()).toEqual(idle);
+        await app.close();
+    });
+});
+
+describe('buildApp GET /schedules', () => {
+    const SAMPLE_LIST: ScheduleListItem[] = [
+        {
+            id: 'sched-active',
+            slug: 'maintenance',
+            name: 'Maintenance',
+            isActive: true,
+            allowedDays: [3, 5, 7],
+            allowedTimeWindows: [{ start: '00:00', end: '10:00' }],
+            rootDepthMOverride: null,
+            allowableDepletionFractionOverride: null,
+            endBySunrise: true,
+            nextRun: { inLabel: 'in 5 hours', whenLabel: 'Tomorrow at 3:00 AM', zonesLabel: 'North, South' },
+            skippedTonight: false,
+        },
+        {
+            id: 'sched-inactive',
+            slug: 'overseeding',
+            name: 'Overseeding',
+            isActive: false,
+            allowedDays: null,
+            allowedTimeWindows: null,
+            rootDepthMOverride: 0.45,
+            allowableDepletionFractionOverride: 0.35,
+            endBySunrise: null,
+        },
+    ];
+
+    it('returns 200 with the handler payload verbatim', async () => {
+        const app = buildApp({
+            getStatus: () => buildStatus(),
+            schedulesList: async () => SAMPLE_LIST,
+        });
+
+        const res = await app.inject({ method: 'GET', url: '/schedules' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual(SAMPLE_LIST);
+        await app.close();
+    });
+
+    it('returns 404 when the schedulesList handler is absent', async () => {
+        const app = buildApp({ getStatus: () => buildStatus() });
+
+        const res = await app.inject({ method: 'GET', url: '/schedules' });
+
+        expect(res.statusCode).toBe(404);
+        await app.close();
+    });
+
+    it('re-evaluates the handler on each request (not memoized)', async () => {
+        let callCount = 0;
+        const app = buildApp({
+            getStatus: () => buildStatus(),
+            schedulesList: async () => {
+                callCount += 1;
+                return SAMPLE_LIST.slice(0, callCount);
+            },
+        });
+
+        const first = await app.inject({ method: 'GET', url: '/schedules' });
+        const second = await app.inject({ method: 'GET', url: '/schedules' });
+
+        expect(first.json()).toHaveLength(1);
+        expect(second.json()).toHaveLength(2);
+        expect(callCount).toBe(2);
+        await app.close();
+    });
+
+    it('returns an empty array when the handler returns []', async () => {
+        const app = buildApp({ getStatus: () => buildStatus(), schedulesList: async () => [] });
+
+        const res = await app.inject({ method: 'GET', url: '/schedules' });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toEqual([]);
         await app.close();
     });
 });

--- a/api/index.ts
+++ b/api/index.ts
@@ -31,6 +31,7 @@ import { loadZoneById, loadZoneSummaries, type ZoneSummary, type ZoneSummaryDb }
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
 import { getSystemState, setIrrigationEnabled, type SystemStateDb, type SystemStateDto } from '@/system';
 import { getTonightSummary, type TonightDb, type TonightDto } from '@/tonight';
+import { listSchedules, type ScheduleListDb, type ScheduleListItem } from '@/schedules-list';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import { BusyError, createManualController, SystemDisabledError, type ManualController } from '@/manual';
 import type { Zone } from '@/models';
@@ -181,6 +182,15 @@ export type BuildAppOptions = {
     tonight?: () => Promise<TonightDto>;
 
     /**
+     * Optional. When supplied, registers `GET /schedules` — the list payload
+     * for the Schedules screen, drawer footer, and Home active-schedule chip.
+     * The active row in the list is enriched with `nextRun` labels and a
+     * `skippedTonight` flag. Production wires this to the schedules-list
+     * module.
+     */
+    schedulesList?: () => Promise<ScheduleListItem[]>;
+
+    /**
      * Optional. When supplied, registers `GET /activity` — the chronological
      * schedule-entries feed driving the Activity screen and the "Recent runs"
      * section on Zone detail. Production wires this to the activity module's
@@ -246,6 +256,10 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
         registerTonightRoute(app, opts.tonight);
     }
 
+    if (opts.schedulesList) {
+        registerSchedulesListRoute(app, opts.schedulesList);
+    }
+
     return app;
 }
 
@@ -257,6 +271,22 @@ function registerTonightRoute(app: FastifyInstance, tonight: () => Promise<Tonig
      */
     app.get('/tonight', async (_req, reply) => {
         const result = await tonight();
+        return reply.code(200).send(result);
+    });
+}
+
+function registerSchedulesListRoute(
+    app: FastifyInstance,
+    schedulesList: () => Promise<ScheduleListItem[]>,
+): void {
+    /**
+     * `GET /schedules` — list of every schedule (active + inactive) for the
+     * mobile app's Schedules screen, drawer footer, and Home active-schedule
+     * chip. The active row carries `nextRun` and `skippedTonight`; inactive
+     * rows omit both fields.
+     */
+    app.get('/schedules', async (_req, reply) => {
+        const result = await schedulesList();
         return reply.code(200).send(result);
     });
 }
@@ -712,6 +742,7 @@ if (import.meta.main) {
         system: wrapSystemWithReplan(baseSystem, () => daemon.rePlan()),
         activity: params => listActivity(db as unknown as ActivityDb, params),
         tonight: () => getTonightSummary(db as unknown as TonightDb, realClock.now()),
+        schedulesList: () => listSchedules(db as unknown as ScheduleListDb, realClock.now()),
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/schedules-list/.test.ts
+++ b/api/schedules-list/.test.ts
@@ -185,6 +185,23 @@ describe('listSchedules', () => {
         expect(item?.skippedTonight).toBe(false);
     });
 
+    it('emits nextRun: null when all returned cycles have already ended (past-only rows)', async () => {
+        const active = buildSchedule({ isActive: true });
+        const past = new Date('2026-05-21T06:00:00.000Z'); // before NOW (22:00)
+        const db = createStub({
+            schedules: [active],
+            nextRunRows: [{
+                entry: buildEntry({ date: '2026-05-21' }),
+                cycle: buildCycle({ startTime: past, durationMin: 30 }),
+                zone: { id: 'zone-1', name: 'North' },
+            }],
+        });
+
+        const [item] = await listSchedules(db, NOW);
+
+        expect(item?.nextRun).toBeNull();
+    });
+
     it('builds nextRun on the active schedule when an upcoming night exists', async () => {
         const active = buildSchedule({ id: 'sched-active', isActive: true });
         const start = new Date('2026-05-22T03:00:00.000Z'); // 5h after NOW

--- a/api/schedules-list/.test.ts
+++ b/api/schedules-list/.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from 'bun:test';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import { irrigationCycles, scheduleEntries, schedules, zones } from '@/db/schema';
+import type { Schedule } from '@/daemon/schedule-manager';
+import {
+    formatInLabel,
+    formatWhenLabel,
+    listSchedules,
+    type ScheduleListDb,
+} from '.';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+type EntryRow = typeof scheduleEntries.$inferSelect;
+type CycleRow = typeof irrigationCycles.$inferSelect;
+type ZoneSubset = { id: string; name: string };
+type JoinedRow = { entry: EntryRow; cycle: CycleRow | null; zone: ZoneSubset };
+
+const NOW = new Date('2026-05-21T22:00:00.000Z'); // 22:00 UTC, before any night cycles
+const SITE_TZ = 'UTC';
+
+function buildSchedule(overrides?: Partial<Schedule>): Schedule {
+    return {
+        id: 'sched-1',
+        siteId: 'site-1',
+        slug: 'maintenance',
+        name: 'Maintenance',
+        isActive: false,
+        allowedDays: null,
+        allowedTimeWindows: null,
+        rootDepthMOverride: null,
+        allowableDepletionFractionOverride: null,
+        endBySunrise: null,
+        skippedNightDate: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+function buildEntry(overrides?: Partial<EntryRow>): EntryRow {
+    return {
+        id: 'entry-1',
+        zoneId: 'zone-1',
+        scheduleId: 'sched-1',
+        date: '2026-05-21',
+        appliedDepthMm: 8.4,
+        depletionBeforeMm: 12.0,
+        depletionAfterMm: 0.3,
+        source: 'scheduled',
+        sunriseAt: null,
+        sunsetAt: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+function buildCycle(overrides?: Partial<CycleRow>): CycleRow {
+    return {
+        id: 'cycle-1',
+        scheduleEntryId: 'entry-1',
+        startTime: new Date('2026-05-22T03:00:00.000Z'), // 5h after NOW
+        durationMin: 30,
+        firedAt: null,
+        closedAt: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    };
+}
+
+type StubInputs = {
+    schedules?: Schedule[];
+    nextRunRows?: JoinedRow[];
+};
+
+function createStub(inputs?: StubInputs): ScheduleListDb {
+    const scheduleRows = inputs?.schedules ?? [];
+    const nextRunRows = inputs?.nextRunRows ?? [];
+
+    const db: ScheduleListDb = {
+        select: (cols: unknown) => {
+            const c = cols as Record<string, unknown>;
+            if ('timezone' in c && Object.keys(c).length === 1) {
+                return { from: () => Promise.resolve([{ timezone: SITE_TZ }]) } as never;
+            }
+            if ('schedule' in c && Object.keys(c).length === 1) {
+                return {
+                    from: () => ({
+                        where: () => Promise.resolve(scheduleRows.map(s => ({ schedule: s }))),
+                    }),
+                } as never;
+            }
+            if ('entry' in c && 'cycle' in c && 'zone' in c) {
+                return {
+                    from: () => ({
+                        innerJoin: () => ({
+                            leftJoin: () => ({
+                                where: () => ({
+                                    orderBy: () => ({
+                                        limit: async () => nextRunRows,
+                                    }),
+                                }),
+                            }),
+                        }),
+                    }),
+                } as never;
+            }
+            return {} as never;
+        },
+        update: () => ({ set: () => ({ where: async () => undefined }) }),
+        transaction: async (cb) => cb(db as never),
+    };
+    return db;
+}
+
+describe('listSchedules', () => {
+    it('returns an empty array when no schedules exist', async () => {
+        const db = createStub();
+
+        const result = await listSchedules(db, NOW);
+
+        expect(result).toEqual([]);
+    });
+
+    it('maps a single inactive schedule with no nextRun or skippedTonight fields', async () => {
+        const inactive = buildSchedule({ id: 'sched-X', slug: 'overseeding', name: 'Overseeding', isActive: false });
+        const db = createStub({ schedules: [inactive] });
+
+        const result = await listSchedules(db, NOW);
+
+        expect(result).toHaveLength(1);
+        const item = result[0]!;
+        expect(item).toEqual({
+            id: 'sched-X',
+            slug: 'overseeding',
+            name: 'Overseeding',
+            isActive: false,
+            allowedDays: null,
+            allowedTimeWindows: null,
+            rootDepthMOverride: null,
+            allowableDepletionFractionOverride: null,
+            endBySunrise: null,
+        });
+        expect(item.nextRun).toBeUndefined();
+        expect(item.skippedTonight).toBeUndefined();
+    });
+
+    it('passes allowedDays / allowedTimeWindows / overrides / endBySunrise through verbatim', async () => {
+        const sched = buildSchedule({
+            allowedDays: [3, 5, 7],
+            allowedTimeWindows: [
+                { start: '00:00', end: '10:00' },
+                { start: '19:00', end: '23:59' },
+            ],
+            rootDepthMOverride: 0.45,
+            allowableDepletionFractionOverride: 0.35,
+            endBySunrise: true,
+        });
+        const db = createStub({ schedules: [sched] });
+
+        const [item] = await listSchedules(db, NOW);
+
+        expect(item?.allowedDays).toEqual([3, 5, 7]);
+        expect(item?.allowedTimeWindows).toEqual([
+            { start: '00:00', end: '10:00' },
+            { start: '19:00', end: '23:59' },
+        ]);
+        expect(item?.rootDepthMOverride).toBe(0.45);
+        expect(item?.allowableDepletionFractionOverride).toBe(0.35);
+        expect(item?.endBySunrise).toBe(true);
+    });
+
+    it('emits nextRun: null on the active schedule when no upcoming entries exist', async () => {
+        const active = buildSchedule({ isActive: true });
+        const db = createStub({ schedules: [active], nextRunRows: [] });
+
+        const [item] = await listSchedules(db, NOW);
+
+        expect(item?.nextRun).toBeNull();
+        expect(item?.skippedTonight).toBe(false);
+    });
+
+    it('builds nextRun on the active schedule when an upcoming night exists', async () => {
+        const active = buildSchedule({ id: 'sched-active', isActive: true });
+        const start = new Date('2026-05-22T03:00:00.000Z'); // 5h after NOW
+        const db = createStub({
+            schedules: [active],
+            nextRunRows: [
+                {
+                    entry: buildEntry({ id: 'entry-north', date: '2026-05-22' }),
+                    cycle: buildCycle({ id: 'c-north', startTime: start, durationMin: 30 }),
+                    zone: { id: 'zone-north', name: 'North' },
+                },
+                {
+                    entry: buildEntry({ id: 'entry-south', date: '2026-05-22' }),
+                    cycle: buildCycle({
+                        id: 'c-south',
+                        startTime: new Date(start.getTime() + 45 * 60_000),
+                        durationMin: 30,
+                    }),
+                    zone: { id: 'zone-south', name: 'South' },
+                },
+            ],
+        });
+
+        const [item] = await listSchedules(db, NOW);
+
+        expect(item?.nextRun).toEqual({
+            // NOW is 22:00 on the 21st; start is 03:00 on the 22nd → 5h.
+            inLabel: 'in 5 hours',
+            // 03:00 UTC on the 22nd, which is the next site-local day from NOW.
+            whenLabel: 'Tomorrow at 3:00 AM',
+            // North fires first, South second.
+            zonesLabel: 'North, South',
+        });
+    });
+
+    it('only carries nextRun and skippedTonight on the active row when multiple schedules exist', async () => {
+        const inactive = buildSchedule({ id: 'sched-other', slug: 'overseeding', name: 'Overseeding', isActive: false });
+        const active = buildSchedule({ id: 'sched-active', slug: 'maintenance', isActive: true });
+        const db = createStub({
+            schedules: [inactive, active],
+            nextRunRows: [
+                {
+                    entry: buildEntry({ date: '2026-05-22' }),
+                    cycle: buildCycle({ startTime: new Date('2026-05-22T03:00:00.000Z'), durationMin: 30 }),
+                    zone: { id: 'zone-1', name: 'North' },
+                },
+            ],
+        });
+
+        const result = await listSchedules(db, NOW);
+
+        expect(result).toHaveLength(2);
+        const inactiveItem = result.find(i => i.id === 'sched-other')!;
+        const activeItem = result.find(i => i.id === 'sched-active')!;
+        expect(inactiveItem.nextRun).toBeUndefined();
+        expect(inactiveItem.skippedTonight).toBeUndefined();
+        expect(activeItem.nextRun).not.toBeUndefined();
+        expect(activeItem.skippedTonight).toBe(false);
+    });
+
+    it('sets skippedTonight: true when the active schedule’s skip marker matches today site-local', async () => {
+        // NOW = 2026-05-21 22:00 UTC; site-local YYYY-MM-DD is 2026-05-21.
+        const active = buildSchedule({ isActive: true, skippedNightDate: '2026-05-21' });
+        const db = createStub({ schedules: [active], nextRunRows: [] });
+
+        const [item] = await listSchedules(db, NOW);
+
+        expect(item?.skippedTonight).toBe(true);
+    });
+
+    it('sets skippedTonight: false when the active schedule’s skip marker is stale (not today)', async () => {
+        const active = buildSchedule({ isActive: true, skippedNightDate: '2026-05-18' });
+        const db = createStub({ schedules: [active], nextRunRows: [] });
+
+        const [item] = await listSchedules(db, NOW);
+
+        expect(item?.skippedTonight).toBe(false);
+    });
+});
+
+describe('formatInLabel', () => {
+    const NOW_MS = NOW.getTime();
+
+    it('returns "Running now" when the start time is already at or past now', () => {
+        expect(formatInLabel(NOW_MS, NOW_MS)).toBe('Running now');
+        expect(formatInLabel(NOW_MS - 60_000, NOW_MS)).toBe('Running now');
+    });
+
+    it('returns minutes for sub-hour deltas', () => {
+        expect(formatInLabel(NOW_MS + 12 * 60_000, NOW_MS)).toBe('in 12 min');
+        expect(formatInLabel(NOW_MS + 59 * 60_000, NOW_MS)).toBe('in 59 min');
+    });
+
+    it('singularises "hour" at exactly 1 hour', () => {
+        expect(formatInLabel(NOW_MS + 60 * 60_000, NOW_MS)).toBe('in 1 hour');
+    });
+
+    it('returns "in N hours" for sub-day deltas', () => {
+        expect(formatInLabel(NOW_MS + 5 * 60 * 60_000, NOW_MS)).toBe('in 5 hours');
+        expect(formatInLabel(NOW_MS + 23 * 60 * 60_000, NOW_MS)).toBe('in 23 hours');
+    });
+
+    it('returns days for >= 24h deltas', () => {
+        expect(formatInLabel(NOW_MS + 24 * 60 * 60_000, NOW_MS)).toBe('in 1 day');
+        expect(formatInLabel(NOW_MS + 3 * 24 * 60 * 60_000, NOW_MS)).toBe('in 3 days');
+    });
+});
+
+describe('formatWhenLabel', () => {
+    const now = dayjs('2026-05-21T22:00:00.000Z').tz('UTC');
+
+    it('prefixes "Tonight" when the start is on the same site-local day', () => {
+        const start = dayjs('2026-05-21T23:30:00.000Z').tz('UTC');
+        expect(formatWhenLabel(start, now)).toBe('Tonight at 11:30 PM');
+    });
+
+    it('prefixes "Tomorrow" when the start is on the next site-local day', () => {
+        const start = dayjs('2026-05-22T03:00:00.000Z').tz('UTC');
+        expect(formatWhenLabel(start, now)).toBe('Tomorrow at 3:00 AM');
+    });
+
+    it('prefixes the long-form weekday name for further-out days', () => {
+        const start = dayjs('2026-05-24T03:00:00.000Z').tz('UTC');
+        // 2026-05-24 is a Sunday.
+        expect(formatWhenLabel(start, now)).toBe('Sunday at 3:00 AM');
+    });
+});
+
+// Keep table imports alive when Drizzle tree-shakes the refs.
+void schedules;
+void scheduleEntries;
+void irrigationCycles;
+void zones;

--- a/api/schedules-list/index.ts
+++ b/api/schedules-list/index.ts
@@ -1,0 +1,246 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import { and, asc, eq, gte, sql } from 'drizzle-orm';
+import { irrigationCycles, scheduleEntries, schedules, zones } from '@/db/schema';
+import { loadSiteTimezone, type SiteTimezoneDb } from '@/daemon/sites';
+import type { Schedule, ScheduleManagerDb } from '@/daemon/schedule-manager';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * Hard cap on how many entry/cycle rows we'll read for the active-schedule
+ * next-run lookup. Same rationale as `TONIGHT_FETCH_LIMIT` — well above any
+ * realistic single-night row count.
+ */
+const NEXT_RUN_FETCH_LIMIT = 200;
+
+/**
+ * One allowed irrigation window within a day. `start` and `end` are `HH:MM`
+ * strings interpreted in the site's local timezone. Mirrors the
+ * `ScheduleTimeWindow` shape from the schema so the wire payload doesn't
+ * leak Drizzle types.
+ */
+export type ScheduleAllowedTimeWindow = {
+    start: string;
+    end: string;
+};
+
+/**
+ * Derived "next run" labels rendered on the active-schedule chip and the
+ * Schedules screen's active row. Formatted server-side so each client (app,
+ * eventually a web dashboard) doesn't reimplement the rules.
+ */
+export type ScheduleNextRun = {
+    inLabel: string;
+    whenLabel: string;
+    zonesLabel: string;
+};
+
+/**
+ * Wire shape served by `GET /schedules` — one item per row in the `schedules`
+ * table. `nextRun` and `skippedTonight` are present only on the active row
+ * (and only when there's actually a next run to describe). Inactive rows
+ * omit them so the client doesn't have to disambiguate `null` vs missing.
+ */
+export type ScheduleListItem = {
+    id: string;
+    slug: string;
+    name: string;
+    isActive: boolean;
+    allowedDays: number[] | null;
+    allowedTimeWindows: ScheduleAllowedTimeWindow[] | null;
+    rootDepthMOverride: number | null;
+    allowableDepletionFractionOverride: number | null;
+    endBySunrise: boolean | null;
+    nextRun?: ScheduleNextRun | null;
+    skippedTonight?: boolean;
+};
+
+type NextRunJoinedRow = {
+    entry: typeof scheduleEntries.$inferSelect;
+    cycle: typeof irrigationCycles.$inferSelect | null;
+    zone: { id: string; name: string };
+};
+
+/**
+ * Minimal db interface for the active schedule's next-night query. Mirrors
+ * the shape used by `api/tonight/` for the same data.
+ */
+export type ScheduleListLoaderDb = {
+    select: (columns: {
+        entry: typeof scheduleEntries;
+        cycle: typeof irrigationCycles;
+        zone: { id: typeof zones.id; name: typeof zones.name };
+    }) => {
+        from: (table: typeof scheduleEntries) => {
+            innerJoin: (table: typeof zones, on: unknown) => {
+                leftJoin: (table: typeof irrigationCycles, on: unknown) => {
+                    where: (cond: unknown) => {
+                        orderBy: (...exprs: ReadonlyArray<unknown>) => {
+                            limit: (n: number) => Promise<NextRunJoinedRow[]>;
+                        };
+                    };
+                };
+            };
+        };
+    };
+};
+
+/**
+ * Composite db interface. Production callers pass the eager `db` export from
+ * `@/db`; tests compose stubs from the per-helper interfaces.
+ */
+export type ScheduleListDb = ScheduleManagerDb & SiteTimezoneDb & ScheduleListLoaderDb;
+
+/**
+ * Lists every schedule for the mobile app's Schedules screen + drawer footer
+ * + Home active-schedule chip. The active schedule additionally carries
+ * `skippedTonight` and a derived `nextRun` label block.
+ *
+ * @param db - Drizzle client (or compatible stub).
+ * @param now - Wall-clock reference. Drives both the `skippedTonight`
+ *   comparison and the `nextRun` "in X" / "Tonight at Y" formatting.
+ */
+export async function listSchedules(db: ScheduleListDb, now: Date): Promise<ScheduleListItem[]> {
+    const siteTimezone = await loadSiteTimezone(db);
+    const nowInTz = dayjs(now).tz(siteTimezone);
+    const todaySiteLocal = nowInTz.format('YYYY-MM-DD');
+
+    const rows = await db
+        .select({ schedule: schedules })
+        .from(schedules)
+        .where(sql`true`);
+
+    const items: ScheduleListItem[] = [];
+    const activeSchedules: Schedule[] = [];
+    for (const row of rows) {
+        items.push(toBaseDto(row.schedule));
+        if (row.schedule.isActive) activeSchedules.push(row.schedule);
+    }
+
+    if (activeSchedules.length === 0) return items;
+
+    // The single-site deploy means there's at most one active schedule; the
+    // next-night query doesn't filter by site. If multi-site arrives, this is
+    // the spot to filter cycles by `zones.siteId === schedule.siteId`.
+    const nextNight = await loadNextNight(db, now);
+
+    for (const active of activeSchedules) {
+        const item = items.find(i => i.id === active.id);
+        if (!item) continue;
+        item.skippedTonight = active.skippedNightDate === todaySiteLocal;
+        item.nextRun = nextNight !== null ? buildNextRun(nextNight, nowInTz, siteTimezone) : null;
+    }
+
+    return items;
+}
+
+function toBaseDto(row: Schedule): ScheduleListItem {
+    return {
+        id: row.id,
+        slug: row.slug,
+        name: row.name,
+        isActive: row.isActive,
+        allowedDays: row.allowedDays,
+        allowedTimeWindows: row.allowedTimeWindows ?? null,
+        rootDepthMOverride: row.rootDepthMOverride,
+        allowableDepletionFractionOverride: row.allowableDepletionFractionOverride,
+        endBySunrise: row.endBySunrise,
+    };
+}
+
+type NextNight = {
+    earliestStart: Date;
+    zoneOrder: string[];
+};
+
+async function loadNextNight(db: ScheduleListLoaderDb, now: Date): Promise<NextNight | null> {
+    const todaySiteLocalDate = dayjs(now).format('YYYY-MM-DD');
+    const rows = await db
+        .select({
+            entry: scheduleEntries,
+            cycle: irrigationCycles,
+            zone: { id: zones.id, name: zones.name },
+        })
+        .from(scheduleEntries)
+        .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+        .leftJoin(irrigationCycles, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+        .where(and(gte(scheduleEntries.date, todaySiteLocalDate), eq(scheduleEntries.source, 'scheduled')))
+        .orderBy(asc(scheduleEntries.date), asc(zones.id), asc(irrigationCycles.startTime))
+        .limit(NEXT_RUN_FETCH_LIMIT);
+
+    const byDate = new Map<string, NextRunJoinedRow[]>();
+    for (const row of rows) {
+        const group = byDate.get(row.entry.date) ?? [];
+        group.push(row);
+        byDate.set(row.entry.date, group);
+    }
+
+    const nowMs = now.getTime();
+    for (const [, group] of byDate) {
+        const futureCycles = group.filter(r => {
+            if (r.cycle === null) return false;
+            const endMs = r.cycle.startTime.getTime() + r.cycle.durationMin * 60_000;
+            return endMs > nowMs;
+        });
+        if (futureCycles.length === 0) continue;
+
+        const sorted = [...futureCycles].sort((a, b) =>
+            (a.cycle!.startTime.getTime()) - (b.cycle!.startTime.getTime()),
+        );
+        const earliestStart = sorted[0]!.cycle!.startTime;
+        const zoneOrder: string[] = [];
+        const seen = new Set<string>();
+        for (const r of sorted) {
+            if (seen.has(r.zone.id)) continue;
+            seen.add(r.zone.id);
+            zoneOrder.push(r.zone.name);
+        }
+        return { earliestStart, zoneOrder };
+    }
+
+    return null;
+}
+
+function buildNextRun(nextNight: NextNight, now: dayjs.Dayjs, siteTimezone: string): ScheduleNextRun {
+    const startInTz = dayjs(nextNight.earliestStart).tz(siteTimezone);
+    return {
+        inLabel: formatInLabel(nextNight.earliestStart.getTime(), now.valueOf()),
+        whenLabel: formatWhenLabel(startInTz, now),
+        zonesLabel: nextNight.zoneOrder.join(', '),
+    };
+}
+
+/**
+ * Formats `startMs - nowMs` as a human-readable "in X" string. Returns
+ * `"Running now"` when the gap is non-positive (cycle already started or
+ * is firing right now). Exported for direct unit testing.
+ */
+export function formatInLabel(startMs: number, nowMs: number): string {
+    const deltaMs = startMs - nowMs;
+    if (deltaMs <= 0) return 'Running now';
+    const minutes = Math.round(deltaMs / 60_000);
+    if (minutes < 60) return `in ${minutes} min`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `in ${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+    const days = Math.round(hours / 24);
+    return `in ${days} ${days === 1 ? 'day' : 'days'}`;
+}
+
+/**
+ * Formats a site-local start time as `"<Tonight|Tomorrow|<DayName>> at h:mm A"`.
+ * The day-name prefix uses the long-form English weekday (`Wednesday`) to match
+ * the spec's example, falling back to short-form would lose hover-target
+ * information on the mobile chip. Exported for direct unit testing.
+ */
+export function formatWhenLabel(start: dayjs.Dayjs, now: dayjs.Dayjs): string {
+    const dayDiff = start.startOf('day').diff(now.startOf('day'), 'day');
+    const prefix =
+        dayDiff <= 0 ? 'Tonight'
+        : dayDiff === 1 ? 'Tomorrow'
+        : start.format('dddd');
+    const time = start.format('h:mm A');
+    return `${prefix} at ${time}`;
+}

--- a/api/schedules-list/index.ts
+++ b/api/schedules-list/index.ts
@@ -125,7 +125,7 @@ export async function listSchedules(db: ScheduleListDb, now: Date): Promise<Sche
     // The single-site deploy means there's at most one active schedule; the
     // next-night query doesn't filter by site. If multi-site arrives, this is
     // the spot to filter cycles by `zones.siteId === schedule.siteId`.
-    const nextNight = await loadNextNight(db, now);
+    const nextNight = await loadNextNight(db, now, todaySiteLocal);
 
     for (const active of activeSchedules) {
         const item = items.find(i => i.id === active.id);
@@ -156,8 +156,7 @@ type NextNight = {
     zoneOrder: string[];
 };
 
-async function loadNextNight(db: ScheduleListLoaderDb, now: Date): Promise<NextNight | null> {
-    const todaySiteLocalDate = dayjs(now).format('YYYY-MM-DD');
+async function loadNextNight(db: ScheduleListLoaderDb, now: Date, todaySiteLocal: string): Promise<NextNight | null> {
     const rows = await db
         .select({
             entry: scheduleEntries,
@@ -167,7 +166,7 @@ async function loadNextNight(db: ScheduleListLoaderDb, now: Date): Promise<NextN
         .from(scheduleEntries)
         .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
         .leftJoin(irrigationCycles, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
-        .where(and(gte(scheduleEntries.date, todaySiteLocalDate), eq(scheduleEntries.source, 'scheduled')))
+        .where(and(gte(scheduleEntries.date, todaySiteLocal), eq(scheduleEntries.source, 'scheduled')))
         .orderBy(asc(scheduleEntries.date), asc(zones.id), asc(irrigationCycles.startTime))
         .limit(NEXT_RUN_FETCH_LIMIT);
 


### PR DESCRIPTION
## Ticket

[API-43](http://192.168.2.100:7123/irrigo/browse/API-43/) GET /schedules — list with active flag, rules, days, windows

## Summary

- New \`api/schedules-list/\` module — \`listSchedules(db, now)\` reads every \`schedules\` row, maps to a wire DTO with id/slug/name/isActive/allowedDays/allowedTimeWindows/rootDepthMOverride/allowableDepletionFractionOverride/endBySunrise, and enriches active rows with \`skippedTonight\` and a derived \`nextRun\` block.
- \`nextRun\` is built from the same "earliest entry-date with future cycles" rule used by /tonight, but emits human-formatted labels — \`inLabel\` (\`Running now\` / \`in 12 min\` / \`in 5 hours\` / \`in 3 days\`), \`whenLabel\` (\`Tonight at 11:30 PM\` / \`Tomorrow at 3:00 AM\` / \`Sunday at 3:00 AM\`), and \`zonesLabel\` (zone names in first-fire order, comma-joined).
- \`skippedTonight\` compares the active schedule's \`skippedNightDate\` against site-local today.
- New route \`GET /schedules\` returns the array verbatim. 404 when handler is absent.
- Lister + label helpers (\`formatInLabel\`, \`formatWhenLabel\`) are exported and individually unit-tested.

## Test plan

- [x] \`bun --cwd api test\` — 696/696 green (20 new tests across module + route).
- [x] \`bun --cwd api run type-check\` — clean.
- [ ] Manual: \`curl /schedules\` → array with every row; active row carries \`nextRun\` and \`skippedTonight\`. \`POST /schedule/skip-tonight\` flips \`skippedTonight\` to true on the next read.