### PR TITLE
[API-57] Refactor manual module into repositories + service + models

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -7,7 +7,7 @@ import type { TonightDto } from '@/tonight';
 import type { ScheduleListItem } from '@/schedules-list';
 import type { DaemonControl, DaemonStatus } from '@/service/daemon';
 import type { ZoneSummary } from '@/models/zone';
-import { BusyError, SystemDisabledError, type ManualController } from '@/manual';
+import { BusyError, SystemDisabledError, type ManualController } from '@/service/manual';
 import type { Zone } from '@/models';
 
 function buildStatus(overrides?: Partial<DaemonStatus>): DaemonStatus {

--- a/api/index.ts
+++ b/api/index.ts
@@ -42,7 +42,13 @@ import type { SystemStateDto } from '@/models/system';
 import { getTonightSummary, type TonightDb, type TonightDto } from '@/tonight';
 import { listSchedules, type ScheduleListDb, type ScheduleListItem } from '@/schedules-list';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
-import { BusyError, createManualController, SystemDisabledError, type ManualController } from '@/manual';
+import {
+    bootManualService,
+    BusyError,
+    createManualController,
+    SystemDisabledError,
+    type ManualController,
+} from '@/service/manual';
 import type { Zone } from '@/models';
 import { createNotifier } from '@/notifications';
 import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
@@ -713,6 +719,7 @@ if (import.meta.main) {
     bootSitesService({ db: typedDb });
     bootSchedulesService({ db: typedDb });
     bootZonesService({ db: typedDb });
+    bootManualService({ db: typedDb });
     bootDaemonService({ db: typedDb });
     const daemon = await daemonStart({
         notifier,
@@ -722,7 +729,6 @@ if (import.meta.main) {
         getZoneState: effectiveGetZoneState,
     });
     const manual = createManualController({
-        db: db as unknown as Parameters<typeof createManualController>[0]['db'],
         clock: realClock,
         openZone: effectiveOpenZone,
         closeZone: effectiveCloseZone,

--- a/api/models/manual.ts
+++ b/api/models/manual.ts
@@ -1,0 +1,67 @@
+import type { Clock } from '@/service/daemon/runtime';
+import type { Zone } from '@/models';
+import type { Notifier } from '@/notifications';
+
+/**
+ * Snapshot of the active manual fire (if any). Drives the HTTP status the
+ * mobile app shows on the Zone detail screen.
+ */
+export type ActiveManualSnapshot = {
+    zoneId: string;
+    zoneName: string;
+    since: Date;
+};
+
+/**
+ * Collaborators injected into `createManualController`. No `db` here — the
+ * controller pulls its `ManualRepository` from module-level state set by
+ * `bootManualService` at process startup.
+ */
+export type ManualControllerDeps = {
+    clock: Clock;
+    openZone: (zone: Zone) => Promise<void>;
+    closeZone: (zone: Zone) => Promise<void>;
+    notifier: Notifier;
+
+    /**
+     * Returns true if a scheduled cycle is currently in-flight. The controller
+     * uses this to refuse manual fires while the daemon owns the relay.
+     */
+    isAnyScheduledInFlight: () => boolean;
+
+    /**
+     * Returns the current state of the master irrigation kill switch. The
+     * controller queries this at the top of `open` and `run` so a flipped-off
+     * system can't accept new manual fires. `close` and `shutdown` are NOT
+     * gated — closing an already-open relay must always be possible.
+     */
+    isIrrigationEnabled: () => Promise<boolean>;
+};
+
+/**
+ * Public surface of the manual fire controller. Wired into HTTP routes.
+ */
+export type ManualController = {
+    /** Opens the zone's relay. Returns when HA acknowledges the turn_on. */
+    open: (zone: Zone) => Promise<{ since: Date }>;
+
+    /**
+     * Closes the zone's relay. Idempotent: if the controller has no record
+     * of this zone being open, it still issues HA's `turn_off` (itself
+     * idempotent) and returns success.
+     */
+    close: (zone: Zone) => Promise<{ closed: boolean }>;
+
+    /**
+     * Opens the relay and schedules an automatic close after `durationMin`
+     * minutes. Equivalent to `open` followed by a deferred `close`, but
+     * records the planned duration in the irrigation_cycles row up front.
+     */
+    run: (zone: Zone, durationMin: number) => Promise<{ since: Date; willCloseAt: Date }>;
+
+    /** Snapshot of the active manual fire (if any). Drives the HTTP status. */
+    getActiveZone: () => ActiveManualSnapshot | null;
+
+    /** Closes the open relay (best-effort) and cancels any pending close timer. */
+    shutdown: () => Promise<void>;
+};

--- a/api/repositories/manual/.test.ts
+++ b/api/repositories/manual/.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, spyOn } from 'bun:test';
+import type { Database } from '@/db';
+import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import type { Zone } from '@/models';
+import { createManualRepository } from '.';
+
+const OPENED_AT = new Date('2026-05-04T15:00:00.000Z');
+const CLOSED_AT = new Date('2026-05-04T15:10:00.000Z');
+
+function buildZone(overrides?: Partial<Zone>): Zone {
+    return {
+        id: 'zone-001',
+        name: 'Front Lawn',
+        grassType: { name: 'Kentucky Bluegrass', cropCoefficient: 0.85 },
+        soil: { name: 'Loam', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 25 },
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        flowRateLPerMin: 15,
+        areaM2: 100,
+        precipitationRateMmPerHr: 9,
+        currentDepletionMm: 12,
+        siteId: 'site-A',
+        siteTimezone: 'America/Edmonton',
+        isEnabled: true,
+        homeAssistantEntityId: 'switch.zone_001',
+        microclimateFactor: 1,
+        location: { lat: 51, lon: -114 },
+        ...overrides,
+    };
+}
+
+type InsertCall = { table: unknown; rows: ReadonlyArray<Record<string, unknown>> };
+type UpdateCall = { table: unknown; values: Record<string, unknown>; cond: unknown };
+
+function stubDb(idPlan?: { entryIds?: Array<string | null>; cycleIds?: Array<string | null> }) {
+    const inserts: InsertCall[] = [];
+    const updates: UpdateCall[] = [];
+    let entryIdx = 0;
+    let cycleIdx = 0;
+
+    // `null` in the plan means "the insert returned no rows" — must check
+    // length explicitly instead of using `??` since `null ?? fallback`
+    // resolves to the fallback.
+    const planned = (plan: Array<string | null> | undefined, idx: number, fallback: string): string | null => {
+        if (plan && idx < plan.length) return plan[idx]!;
+        return fallback;
+    };
+
+    const runInsertReturning = async (table: unknown, rows: ReadonlyArray<Record<string, unknown>>): Promise<Array<Record<string, unknown>>> => {
+        inserts.push({ table, rows });
+        if (table === scheduleEntries) {
+            const id = planned(idPlan?.entryIds, entryIdx, `entry-${entryIdx + 1}`);
+            entryIdx += 1;
+            return id === null ? [] : [{ id }];
+        }
+        if (table === irrigationCycles) {
+            const id = planned(idPlan?.cycleIds, cycleIdx, `cycle-${cycleIdx + 1}`);
+            cycleIdx += 1;
+            return id === null ? [] : [{ id }];
+        }
+        return [];
+    };
+
+    const runUpdateWhere = async (table: unknown, values: Record<string, unknown>, cond: unknown): Promise<void> => {
+        updates.push({ table, values, cond });
+    };
+
+    const db = {
+        insert: (table: unknown) => ({ values: (rows: ReadonlyArray<Record<string, unknown>>) => ({ returning: () => runInsertReturning(table, rows) }) }),
+        update: (table: unknown) => ({ set: (values: Record<string, unknown>) => ({ where: (cond: unknown) => runUpdateWhere(table, values, cond) }) }),
+    } as unknown as Database;
+
+    return { db, inserts, updates };
+}
+
+describe('createManualRepository.writeManualRecord', () => {
+    it('inserts a schedule_entries row with source=manual, no schedule, rounded depletion fields', async () => {
+        const { db, inserts } = stubDb();
+        const repo = createManualRepository(db);
+
+        await repo.writeManualRecord(buildZone(), OPENED_AT, CLOSED_AT, 10);
+
+        const entryInsert = inserts.find(c => c.table === scheduleEntries);
+        expect(entryInsert?.rows[0]).toMatchObject({
+            zoneId: 'zone-001',
+            scheduleId: null,
+            date: '2026-05-04',
+            source: 'manual',
+        });
+        // precip=9 mm/hr, duration=10/60 → appliedDepth=1.5, rounded to 1.5.
+        expect(entryInsert?.rows[0]?.['appliedDepthMm']).toBeCloseTo(1.5, 1);
+        expect(entryInsert?.rows[0]?.['depletionBeforeMm']).toBeCloseTo(12, 1);
+        // depletionAfter = max(0, 12 - 1.5 * 0.8) = 10.8 → rounded to 10.8.
+        expect(entryInsert?.rows[0]?.['depletionAfterMm']).toBeCloseTo(10.8, 1);
+    });
+
+    it('inserts an irrigation_cycles row tied to the returned entry id with the supplied open/close/duration', async () => {
+        const { db, inserts } = stubDb({ entryIds: ['entry-X'] });
+        const repo = createManualRepository(db);
+
+        await repo.writeManualRecord(buildZone(), OPENED_AT, CLOSED_AT, 15);
+
+        const cycleInsert = inserts.find(c => c.table === irrigationCycles);
+        expect(cycleInsert?.rows[0]).toMatchObject({
+            scheduleEntryId: 'entry-X',
+            durationMin: 15,
+            firedAt: OPENED_AT,
+            closedAt: CLOSED_AT,
+        });
+        expect(cycleInsert?.rows[0]?.['startTime']).toEqual(OPENED_AT);
+    });
+
+    it('updates zones.currentDepletionMm to the clamped post-fire value and returns the inserted cycle id', async () => {
+        const { db, updates } = stubDb({ cycleIds: ['cycle-Y'] });
+        const repo = createManualRepository(db);
+
+        const result = await repo.writeManualRecord(buildZone(), OPENED_AT, CLOSED_AT, 10);
+
+        expect(result).toBe('cycle-Y');
+        const zoneUpdate = updates.find(u => u.table === zones);
+        expect(zoneUpdate?.values).toMatchObject({});
+        // depletionAfter = max(0, 12 - 10/60 * 9 * 0.8) = 10.8
+        expect(zoneUpdate?.values['currentDepletionMm']).toBeCloseTo(10.8, 1);
+    });
+
+    it('returns null with a warn when the schedule-entries insert returns no id', async () => {
+        const warn = spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const { db, inserts } = stubDb({ entryIds: [null] });
+            const repo = createManualRepository(db);
+
+            const result = await repo.writeManualRecord(buildZone(), OPENED_AT, CLOSED_AT, 10);
+
+            expect(result).toBeNull();
+            // No cycle insert when the entry id was missing.
+            expect(inserts.some(c => c.table === irrigationCycles)).toBe(false);
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it('falls back to flow-rate / area precipitation when the zone has no precipitationRateMmPerHr', async () => {
+        const { db, inserts } = stubDb();
+        const repo = createManualRepository(db);
+        // flowRate 15 L/min, area 100 m² → 60*(15/100) = 9 mm/hr. Same as the explicit default.
+        const zone = buildZone({ precipitationRateMmPerHr: undefined });
+
+        await repo.writeManualRecord(zone, OPENED_AT, CLOSED_AT, 10);
+
+        const entryInsert = inserts.find(c => c.table === scheduleEntries);
+        // 10/60 * 9 = 1.5 mm.
+        expect(entryInsert?.rows[0]?.['appliedDepthMm']).toBeCloseTo(1.5, 1);
+    });
+
+    it('clamps depletionAfter at zero rather than going negative', async () => {
+        const { db, inserts, updates } = stubDb();
+        const repo = createManualRepository(db);
+        // Tiny existing depletion + a long fire that would otherwise overshoot.
+        const zone = buildZone({ currentDepletionMm: 0.5 });
+
+        await repo.writeManualRecord(zone, OPENED_AT, CLOSED_AT, 60);
+
+        const entryInsert = inserts.find(c => c.table === scheduleEntries);
+        expect(entryInsert?.rows[0]?.['depletionAfterMm']).toBe(0);
+        const zoneUpdate = updates.find(u => u.table === zones);
+        expect(zoneUpdate?.values['currentDepletionMm']).toBe(0);
+    });
+
+    it('returns null when the cycle insert returns no id (cycleId fallback)', async () => {
+        const { db } = stubDb({ cycleIds: [null] });
+        const repo = createManualRepository(db);
+
+        const result = await repo.writeManualRecord(buildZone(), OPENED_AT, null, 5);
+
+        expect(result).toBeNull();
+    });
+});
+
+describe('createManualRepository.updateCycleClosedAt', () => {
+    it('issues a single UPDATE on irrigation_cycles with the supplied closedAt', async () => {
+        const { db, updates } = stubDb();
+        const repo = createManualRepository(db);
+
+        await repo.updateCycleClosedAt('cycle-Z', CLOSED_AT);
+
+        expect(updates).toHaveLength(1);
+        expect(updates[0]?.table).toBe(irrigationCycles);
+        expect(updates[0]?.values).toEqual({ closedAt: CLOSED_AT });
+    });
+});

--- a/api/repositories/manual/index.ts
+++ b/api/repositories/manual/index.ts
@@ -1,0 +1,112 @@
+import dayjs from 'dayjs';
+import { eq } from 'drizzle-orm';
+import type { Database } from '@/db';
+import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
+import type { Zone } from '@/models';
+
+/**
+ * Domain interface for the manual-fire DB writes. The two methods bundle the
+ * Drizzle chains that today's inline manual controller does directly. The
+ * service tier owns the in-process single-slot lock and the close-timer
+ * lifecycle; only the persistence bits live here.
+ */
+export interface ManualRepository {
+    /**
+     * Persists one manual fire: inserts a `schedule_entries` row (`source =
+     * 'manual'`), inserts a matching `irrigation_cycles` row, and updates
+     * `zones.current_depletion_mm` to the clamped post-fire value. Returns
+     * the inserted cycle id (or `null` if the schedule-entries insert
+     * returned no id — a defensive guard with a warn).
+     *
+     * @param zone - The zone being fired. Depletion math reads from
+     *   `currentDepletionMm`, `irrigationEfficiency`, `precipitationRateMmPerHr`
+     *   (with flow-rate / area fallback).
+     * @param openedAt - Wall-clock time the relay actually opened. Also
+     *   stored as the cycle's `startTime` and `firedAt`.
+     * @param closedAt - Wall-clock close time, or `null` for a `run` that
+     *   hasn't auto-closed yet.
+     * @param durationMin - Planned (or elapsed) duration in minutes; drives
+     *   the depletion math.
+     */
+    writeManualRecord(
+        zone: Zone,
+        openedAt: Date,
+        closedAt: Date | null,
+        durationMin: number,
+    ): Promise<string | null>;
+
+    /** Stamps the cycle's `closed_at` column after a successful HA close. */
+    updateCycleClosedAt(cycleId: string, closedAt: Date): Promise<void>;
+}
+
+/**
+ * Builds the production `ManualRepository` bound to a Drizzle client. Factory
+ * tests pass a partial Drizzle stub cast via `as unknown as Database` and
+ * assert the chained INSERT / INSERT / UPDATE payloads.
+ */
+export function createManualRepository(db: Database): ManualRepository {
+    return {
+        writeManualRecord: async (zone, openedAt, closedAt, durationMin) => {
+            const today = dayjs(openedAt).format('YYYY-MM-DD');
+            const precipRate = zone.precipitationRateMmPerHr ?? (60 * (zone.flowRateLPerMin / zone.areaM2));
+            const appliedDepth = (durationMin / 60) * precipRate;
+            const netDepth = appliedDepth * zone.irrigationEfficiency;
+            const depletionBefore = zone.currentDepletionMm;
+            const depletionAfter = Math.max(0, depletionBefore - netDepth);
+
+            const insertedEntry = await db
+                .insert(scheduleEntries)
+                .values([
+                    {
+                        zoneId: zone.id,
+                        scheduleId: null,
+                        date: today,
+                        appliedDepthMm: roundTo1Decimal(appliedDepth),
+                        depletionBeforeMm: roundTo1Decimal(depletionBefore),
+                        depletionAfterMm: roundTo1Decimal(depletionAfter),
+                        source: 'manual',
+                    },
+                ])
+                .returning({ id: scheduleEntries.id });
+
+            const entryId = (insertedEntry[0] as { id: string } | undefined)?.id;
+            if (!entryId) {
+                console.warn(`manual: schedule_entries insert returned no id for zone ${zone.id}; skipping cycle row.`);
+                return null;
+            }
+
+            const insertedCycle = await db
+                .insert(irrigationCycles)
+                .values([
+                    {
+                        scheduleEntryId: entryId,
+                        startTime: openedAt,
+                        durationMin,
+                        firedAt: openedAt,
+                        closedAt,
+                    },
+                ])
+                .returning({ id: irrigationCycles.id });
+
+            const cycleId = (insertedCycle[0] as { id: string } | undefined)?.id ?? null;
+
+            await db
+                .update(zones)
+                .set({ currentDepletionMm: depletionAfter })
+                .where(eq(zones.id, zone.id));
+
+            return cycleId;
+        },
+
+        updateCycleClosedAt: async (cycleId, closedAt) => {
+            await db
+                .update(irrigationCycles)
+                .set({ closedAt })
+                .where(eq(irrigationCycles.id, cycleId));
+        },
+    };
+}
+
+function roundTo1Decimal(value: number): number {
+    return Math.round(value * 10) / 10;
+}

--- a/api/service/manual/.test.ts
+++ b/api/service/manual/.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, expect } from 'bun:test';
-import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
-import type { Clock, TimerHandle } from '@/service/daemon/runtime';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import type { Zone } from '@/models';
+import type { ManualRepository } from '@/repositories/manual';
+import type { Clock, TimerHandle } from '@/service/daemon/runtime';
 import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
 import {
     BusyError,
+    bootManualService,
     createManualController,
     MAX_RUN_DURATION_MIN,
     SystemDisabledError,
-    type ManualControllerDb,
 } from '.';
 
 type RecordedNotification = { event: NotificationEvent; context: NotificationContext | undefined };
@@ -64,49 +64,24 @@ function createFakeClock(initial: Date) {
     return { clock, advanceTo, getPendingCount: () => timers.size };
 }
 
-type InsertCall = { table: unknown; rows: ReadonlyArray<Record<string, unknown>> };
-type UpdateCall = { table: unknown; values: Record<string, unknown> };
+type WriteCall = { zone: Zone; openedAt: Date; closedAt: Date | null; durationMin: number };
+type UpdateCall = { cycleId: string; closedAt: Date };
 
-function createDbStub() {
-    const inserts: InsertCall[] = [];
+function fakeRepo(overrides?: {
+    cycleId?: string | null;
+}): { repo: ManualRepository; writes: WriteCall[]; updates: UpdateCall[] } {
+    const writes: WriteCall[] = [];
     const updates: UpdateCall[] = [];
-    let nextEntryId = 1;
-    let nextCycleId = 1;
-
-    const db: ManualControllerDb = {
-        insert(table) {
-            return {
-                values(rows) {
-                    return {
-                        returning() {
-                            inserts.push({ table, rows });
-                            if (table === scheduleEntries) {
-                                return Promise.resolve(rows.map(() => ({ id: `entry-${nextEntryId++}` })));
-                            }
-                            if (table === irrigationCycles) {
-                                return Promise.resolve(rows.map(() => ({ id: `cycle-${nextCycleId++}` })));
-                            }
-                            return Promise.resolve([]);
-                        },
-                    };
-                },
-            };
+    const repo: ManualRepository = {
+        writeManualRecord: async (zone, openedAt, closedAt, durationMin) => {
+            writes.push({ zone, openedAt, closedAt, durationMin });
+            return overrides?.cycleId !== undefined ? overrides.cycleId : `cycle-${writes.length}`;
         },
-        update(table) {
-            return {
-                set(values) {
-                    return {
-                        where() {
-                            updates.push({ table, values });
-                            return Promise.resolve(undefined);
-                        },
-                    };
-                },
-            };
+        updateCycleClosedAt: async (cycleId, closedAt) => {
+            updates.push({ cycleId, closedAt });
         },
     };
-
-    return { db, inserts, updates };
+    return { repo, writes, updates };
 }
 
 function buildZone(overrides?: Partial<Zone>): Zone {
@@ -126,6 +101,8 @@ function buildZone(overrides?: Partial<Zone>): Zone {
         siteTimezone: 'America/Edmonton',
         isEnabled: true,
         homeAssistantEntityId: 'switch.zone_001',
+        microclimateFactor: 1,
+        location: { lat: 51, lon: -114 },
         ...overrides,
     };
 }
@@ -133,13 +110,21 @@ function buildZone(overrides?: Partial<Zone>): Zone {
 const NOW = new Date('2026-05-04T15:00:00.000Z');
 
 describe('manual controller — open', () => {
+    let writes: WriteCall[];
+    let updates: UpdateCall[];
+
+    beforeEach(() => {
+        const r = fakeRepo();
+        writes = r.writes;
+        updates = r.updates;
+        bootManualService({ repo: r.repo });
+    });
+
     it('opens the relay, records active state, returns the open timestamp', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const opens: Zone[] = [];
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async (z) => { opens.push(z); },
             closeZone: async () => {},
@@ -157,14 +142,15 @@ describe('manual controller — open', () => {
         expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-001', zoneName: 'Front Lawn', since: NOW });
         const started = calls.find(c => c.event === 'watering-started');
         expect(started?.context).toEqual({ zoneName: 'Front Lawn', reason: 'manual' });
+        // `open` alone doesn't write — the write happens at close (or up-front in `run`).
+        expect(writes).toHaveLength(0);
+        expect(updates).toHaveLength(0);
     });
 
     it('rejects with BusyError when a scheduled cycle is in flight', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         let openCalls = 0;
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => { openCalls += 1; },
             closeZone: async () => {},
@@ -179,9 +165,7 @@ describe('manual controller — open', () => {
 
     it('rejects with BusyError when another manual fire is already active', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => {},
@@ -196,10 +180,8 @@ describe('manual controller — open', () => {
 
     it('does not retain state and emits an error notification when openZone throws', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => { throw new Error('HA 502'); },
             closeZone: async () => {},
@@ -216,13 +198,21 @@ describe('manual controller — open', () => {
 });
 
 describe('manual controller — close', () => {
-    it('closes the active zone, inserts schedule_entries with source=manual, updates depletion, clears state', async () => {
+    let writes: WriteCall[];
+    let updates: UpdateCall[];
+
+    beforeEach(() => {
+        const r = fakeRepo();
+        writes = r.writes;
+        updates = r.updates;
+        bootManualService({ repo: r.repo });
+    });
+
+    it('closes the active zone, calls writeManualRecord with elapsed duration, clears state', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
-        const { db, inserts, updates } = createDbStub();
         const closes: Zone[] = [];
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
@@ -237,33 +227,20 @@ describe('manual controller — close', () => {
         await controller.close(zone);
 
         expect(closes).toHaveLength(1);
-        const scheduleInserts = inserts.filter(c => c.table === scheduleEntries);
-        expect(scheduleInserts).toHaveLength(1);
-        expect(scheduleInserts[0]?.rows[0]).toMatchObject({
-            zoneId: 'zone-001',
-            scheduleId: null,
-            date: '2026-05-04',
-            source: 'manual',
-        });
-        expect(scheduleInserts[0]?.rows[0]?.['appliedDepthMm']).toBeCloseTo(0.9, 1);
-        expect(scheduleInserts[0]?.rows[0]?.['depletionBeforeMm']).toBeCloseTo(12, 1);
-        const cycleInserts = inserts.filter(c => c.table === irrigationCycles);
-        expect(cycleInserts).toHaveLength(1);
-        expect(cycleInserts[0]?.rows[0]).toMatchObject({
-            scheduleEntryId: 'entry-1',
-            firedAt: NOW,
-        });
-        const zoneUpdate = updates.find(u => u.table === zones);
-        expect(zoneUpdate?.values['currentDepletionMm']).toBeCloseTo(11.3, 1);
+        expect(writes).toHaveLength(1);
+        expect(writes[0]?.zone.id).toBe('zone-001');
+        expect(writes[0]?.openedAt).toEqual(NOW);
+        expect(writes[0]?.closedAt).toEqual(new Date('2026-05-04T15:06:00.000Z'));
+        expect(writes[0]?.durationMin).toBeCloseTo(6, 5);
+        // close on an `open`-then-`close` path uses writeManualRecord, not updateCycleClosedAt.
+        expect(updates).toHaveLength(0);
         expect(controller.getActiveZone()).toBeNull();
         expect(calls.some(c => c.event === 'watering-ended')).toBe(true);
     });
 
     it('records duration as elapsed time between open and close', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
-        const { db, inserts } = createDbStub();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => {},
@@ -277,16 +254,13 @@ describe('manual controller — close', () => {
 
         await controller.close(zone);
 
-        const cycleInsert = inserts.find(c => c.table === irrigationCycles);
-        expect(cycleInsert?.rows[0]?.['durationMin']).toBe(10);
+        expect(writes[0]?.durationMin).toBe(10);
     });
 
     it('is a no-op success that defensively closes when no manual fire is active', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db, inserts } = createDbStub();
         const closes: Zone[] = [];
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
@@ -300,15 +274,14 @@ describe('manual controller — close', () => {
 
         expect(result).toEqual({ closed: true });
         expect(closes).toHaveLength(1);
-        expect(inserts).toHaveLength(0);
+        expect(writes).toHaveLength(0);
+        expect(updates).toHaveLength(0);
     });
 
     it('clears state even when closeZone rejects so subsequent calls do not see phantom state', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => { throw new Error('HA timeout'); },
@@ -328,11 +301,19 @@ describe('manual controller — close', () => {
 });
 
 describe('manual controller — run', () => {
+    let writes: WriteCall[];
+    let updates: UpdateCall[];
+
+    beforeEach(() => {
+        const r = fakeRepo();
+        writes = r.writes;
+        updates = r.updates;
+        bootManualService({ repo: r.repo });
+    });
+
     it('rejects with BusyError when another fire is active', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => {},
@@ -347,9 +328,7 @@ describe('manual controller — run', () => {
 
     it('rejects when durationMin is zero, negative, or NaN', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => {},
@@ -365,9 +344,7 @@ describe('manual controller — run', () => {
 
     it(`rejects when durationMin exceeds the cap of ${MAX_RUN_DURATION_MIN}`, async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => {},
@@ -379,13 +356,11 @@ describe('manual controller — run', () => {
         await expect(controller.run(buildZone(), MAX_RUN_DURATION_MIN + 1)).rejects.toThrow(/exceeds maximum/);
     });
 
-    it('opens, records DB rows synchronously, and schedules the auto-close', async () => {
+    it('opens, calls writeManualRecord upfront with the planned duration, and schedules the auto-close', async () => {
         const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
-        const { db, inserts, updates } = createDbStub();
         const closes: Zone[] = [];
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
@@ -399,12 +374,10 @@ describe('manual controller — run', () => {
 
         expect(result.since).toEqual(NOW);
         expect(result.willCloseAt).toEqual(new Date('2026-05-04T15:15:00.000Z'));
-        // DB rows written upfront with the planned duration.
-        const cycleInsert = inserts.find(c => c.table === irrigationCycles);
-        expect(cycleInsert?.rows[0]?.['durationMin']).toBe(15);
-        expect(cycleInsert?.rows[0]?.['firedAt']).toEqual(NOW);
-        expect(cycleInsert?.rows[0]?.['closedAt']).toBeNull();
-        expect(updates.some(u => u.table === zones)).toBe(true);
+        expect(writes).toHaveLength(1);
+        expect(writes[0]?.durationMin).toBe(15);
+        expect(writes[0]?.openedAt).toEqual(NOW);
+        expect(writes[0]?.closedAt).toBeNull();
         const started = calls.find(c => c.event === 'watering-started');
         expect(started?.context).toEqual({ zoneName: 'Front Lawn', durationMin: 15, reason: 'manual' });
         expect(getPendingCount()).toBe(1);
@@ -412,18 +385,18 @@ describe('manual controller — run', () => {
         await advanceTo(new Date('2026-05-04T15:15:30.000Z'));
 
         expect(closes).toHaveLength(1);
-        const closedAtUpdate = updates.find(u => u.table === irrigationCycles && u.values['closedAt'] instanceof Date);
-        expect(closedAtUpdate?.values['closedAt']).toEqual(new Date('2026-05-04T15:15:00.000Z'));
+        // Scheduled close path calls updateCycleClosedAt with the cycle id returned by writeManualRecord.
+        expect(updates).toHaveLength(1);
+        expect(updates[0]?.cycleId).toBe('cycle-1');
+        expect(updates[0]?.closedAt).toEqual(new Date('2026-05-04T15:15:00.000Z'));
         expect(controller.getActiveZone()).toBeNull();
         expect(calls.some(c => c.event === 'watering-ended')).toBe(true);
     });
 
     it('clears state and emits an error when the auto-close fires but closeZone rejects', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => { throw new Error('HA 504'); },
@@ -440,59 +413,18 @@ describe('manual controller — run', () => {
         const errorCall = calls.find(c => c.event === 'error' && c.context?.operation === 'close');
         expect(errorCall?.context?.reason).toBe('HA 504');
     });
-
-    it('falls back to the flow-rate / area precipitation rate when the zone has no precipitationRateMmPerHr', async () => {
-        const { clock } = createFakeClock(NOW);
-        const { db, inserts } = createDbStub();
-        const controller = createManualController({
-            db,
-            clock,
-            openZone: async () => {},
-            closeZone: async () => {},
-            notifier: async () => {},
-            isAnyScheduledInFlight: () => false,
-            isIrrigationEnabled: async () => true,
-        });
-        // flowRate 15 L/min, area 100 m² → 60*(15/100) = 9 mm/hr. Same as the explicit 9 default.
-        const zone = buildZone({ precipitationRateMmPerHr: undefined });
-
-        await controller.run(zone, 10);
-
-        const scheduleInsert = inserts.find(c => c.table === scheduleEntries);
-        // 10/60 * 9 = 1.5 mm.
-        expect(scheduleInsert?.rows[0]?.['appliedDepthMm']).toBeCloseTo(1.5, 1);
-    });
-
-    it('clamps depletionAfter at zero rather than going negative', async () => {
-        const { clock } = createFakeClock(NOW);
-        const { db, inserts } = createDbStub();
-        const controller = createManualController({
-            db,
-            clock,
-            openZone: async () => {},
-            closeZone: async () => {},
-            notifier: async () => {},
-            isAnyScheduledInFlight: () => false,
-            isIrrigationEnabled: async () => true,
-        });
-        // Tiny existing depletion + a long fire that would otherwise overshoot.
-        const zone = buildZone({ currentDepletionMm: 0.5 });
-
-        await controller.run(zone, 60);
-
-        const scheduleInsert = inserts.find(c => c.table === scheduleEntries);
-        expect(scheduleInsert?.rows[0]?.['depletionAfterMm']).toBe(0);
-    });
 });
 
 describe('manual controller — master kill switch', () => {
-    it('open rejects with SystemDisabledError when isIrrigationEnabled returns false; no HA call, no DB writes, no notifier', async () => {
+    beforeEach(() => {
+        bootManualService({ repo: fakeRepo().repo });
+    });
+
+    it('open rejects with SystemDisabledError when isIrrigationEnabled returns false; no HA call, no notifier', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db, inserts, updates } = createDbStub();
         let openCalls = 0;
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => { openCalls += 1; },
             closeZone: async () => {},
@@ -503,18 +435,14 @@ describe('manual controller — master kill switch', () => {
 
         await expect(controller.open(buildZone())).rejects.toBeInstanceOf(SystemDisabledError);
         expect(openCalls).toBe(0);
-        expect(inserts).toHaveLength(0);
-        expect(updates).toHaveLength(0);
         expect(calls).toHaveLength(0);
         expect(controller.getActiveZone()).toBeNull();
     });
 
-    it('run rejects with SystemDisabledError when isIrrigationEnabled returns false; no HA call, no DB writes', async () => {
+    it('run rejects with SystemDisabledError when isIrrigationEnabled returns false; no HA call', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db, inserts, updates } = createDbStub();
         let openCalls = 0;
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => { openCalls += 1; },
             closeZone: async () => {},
@@ -525,18 +453,13 @@ describe('manual controller — master kill switch', () => {
 
         await expect(controller.run(buildZone(), 5)).rejects.toBeInstanceOf(SystemDisabledError);
         expect(openCalls).toBe(0);
-        expect(inserts).toHaveLength(0);
-        expect(updates).toHaveLength(0);
     });
 
     it('close is NOT gated by the kill switch — an open relay must always be stoppable', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
-        // Start with the system enabled so we can open, then flip off and confirm close still works.
         let enabled = true;
         let closeCalls = 0;
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => { closeCalls += 1; },
@@ -558,10 +481,8 @@ describe('manual controller — master kill switch', () => {
 
     it('defensive close on an unknown zone is NOT gated either', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         let closeCalls = 0;
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => { closeCalls += 1; },
@@ -578,11 +499,17 @@ describe('manual controller — master kill switch', () => {
 });
 
 describe('manual controller — getActiveZone and shutdown', () => {
+    let updates: UpdateCall[];
+
+    beforeEach(() => {
+        const r = fakeRepo();
+        updates = r.updates;
+        bootManualService({ repo: r.repo });
+    });
+
     it('getActiveZone returns null when nothing is active and the snapshot when active', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async () => {},
@@ -600,11 +527,9 @@ describe('manual controller — getActiveZone and shutdown', () => {
 
     it('shutdown closes any active manual zone and cancels the close timer', async () => {
         const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
-        const { db, updates } = createDbStub();
         const closes: Zone[] = [];
         const { notifier, calls } = recordingNotifier();
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
@@ -623,7 +548,8 @@ describe('manual controller — getActiveZone and shutdown', () => {
         expect(controller.getActiveZone()).toBeNull();
         const ended = calls.find(c => c.event === 'watering-ended');
         expect(ended?.context).toEqual({ zoneName: 'Front Lawn', reason: 'shutdown' });
-        expect(updates.some(u => u.table === irrigationCycles && u.values['closedAt'] instanceof Date)).toBe(true);
+        // shutdown stamps closed_at via the repo.
+        expect(updates).toHaveLength(1);
 
         // Advancing time past the canceled timer must not re-fire the close.
         await advanceTo(new Date('2026-05-04T15:30:00.000Z'));
@@ -632,10 +558,8 @@ describe('manual controller — getActiveZone and shutdown', () => {
 
     it('shutdown is a no-op when nothing is active', async () => {
         const { clock } = createFakeClock(NOW);
-        const { db } = createDbStub();
         const closes: Zone[] = [];
         const controller = createManualController({
-            db,
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },

--- a/api/service/manual/index.ts
+++ b/api/service/manual/index.ts
@@ -1,9 +1,10 @@
-import dayjs from 'dayjs';
-import { eq } from 'drizzle-orm';
-import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
-import type { Clock, TimerHandle } from '@/service/daemon/runtime';
+import type { Database } from '@/db';
+import type { ActiveManualSnapshot, ManualController, ManualControllerDeps } from '@/models/manual';
 import type { Zone } from '@/models';
-import type { Notifier } from '@/notifications';
+import { createManualRepository, type ManualRepository } from '@/repositories/manual';
+import type { TimerHandle } from '@/service/daemon/runtime';
+
+export type { ActiveManualSnapshot, ManualController, ManualControllerDeps } from '@/models/manual';
 
 /**
  * Hard cap on `/run` duration. Manual fires are for testing and one-off
@@ -26,8 +27,7 @@ export class BusyError extends Error {
 /**
  * Sentinel error thrown by `open` and `run` when the master irrigation kill
  * switch is off. The HTTP layer maps this to a 409 with
- * `error: 'system-disabled'` so the mobile client can render a distinct
- * "irrigation is paused" message rather than a generic busy state.
+ * `error: 'system-disabled'`.
  */
 export class SystemDisabledError extends Error {
     constructor(message: string) {
@@ -37,81 +37,30 @@ export class SystemDisabledError extends Error {
 }
 
 /**
- * Minimal db interface needed by the manual controller. Mirrors the chained
- * Drizzle `insert/update` shapes the recording test stub already supports.
+ * Input to `bootManualService`. Production passes `{ db }`; tests pass
+ * `{ repo }` with an object-literal fake.
  */
-export type ManualControllerDb = {
-    insert: (table: typeof scheduleEntries | typeof irrigationCycles) => {
-        values: (rows: ReadonlyArray<Record<string, unknown>>) => {
-            returning: (cols: Record<string, unknown>) => Promise<Array<Record<string, unknown>>>;
-        };
-    };
-    update: (table: typeof zones | typeof irrigationCycles) => {
-        set: (values: Record<string, unknown>) => {
-            where: (cond: unknown) => Promise<unknown>;
-        };
-    };
-};
+export type BootManualServiceInput =
+    | { db: Database }
+    | { repo: ManualRepository };
+
+let repo: ManualRepository | null = null;
 
 /**
- * Collaborators injected at construction time so tests can substitute
- * deterministic stubs.
+ * Wires the manual service to its repository. Call once at process boot
+ * before `createManualController(...)`; call again in test `beforeEach` with
+ * a fake to isolate behavior.
  */
-export type ManualControllerDeps = {
-    db: ManualControllerDb;
-    clock: Clock;
-    openZone: (zone: Zone) => Promise<void>;
-    closeZone: (zone: Zone) => Promise<void>;
-    notifier: Notifier;
+export function bootManualService(input: BootManualServiceInput): void {
+    repo = 'repo' in input ? input.repo : createManualRepository(input.db);
+}
 
-    /**
-     * Returns true if a scheduled cycle is currently in-flight. The controller
-     * uses this to refuse manual fires while the daemon owns the relay.
-     */
-    isAnyScheduledInFlight: () => boolean;
-
-    /**
-     * Returns the current state of the master irrigation kill switch. The
-     * controller queries this at the top of `open` and `run` so a flipped-off
-     * system can't accept new manual fires. `close` and `shutdown` are NOT
-     * gated — closing an already-open relay must always be possible.
-     */
-    isIrrigationEnabled: () => Promise<boolean>;
-};
-
-export type ActiveManualSnapshot = {
-    zoneId: string;
-    zoneName: string;
-    since: Date;
-};
-
-/**
- * Public surface of the manual fire controller. Wired into HTTP routes.
- */
-export type ManualController = {
-    /** Opens the zone's relay. Returns when HA acknowledges the turn_on. */
-    open: (zone: Zone) => Promise<{ since: Date }>;
-
-    /**
-     * Closes the zone's relay. Idempotent: if the controller has no record
-     * of this zone being open, it still issues HA's `turn_off` (which is
-     * itself idempotent) and returns success.
-     */
-    close: (zone: Zone) => Promise<{ closed: boolean }>;
-
-    /**
-     * Opens the relay and schedules an automatic close after `durationMin`
-     * minutes. Equivalent to `open` followed by a deferred `close`, but
-     * records the planned duration in the irrigation_cycles row up front.
-     */
-    run: (zone: Zone, durationMin: number) => Promise<{ since: Date; willCloseAt: Date }>;
-
-    /** Snapshot of the active manual fire (if any). Drives the HTTP status. */
-    getActiveZone: () => ActiveManualSnapshot | null;
-
-    /** Closes the open relay (best-effort) and cancels any pending close timer. */
-    shutdown: () => Promise<void>;
-};
+function getRepo(): ManualRepository {
+    if (!repo) {
+        throw new Error('Manual service not booted — call bootManualService({ db }) at startup.');
+    }
+    return repo;
+}
 
 type ActiveManualFire = {
     zone: Zone;
@@ -126,14 +75,14 @@ type ActiveManualFire = {
  * single-slot lock plus the side effects required to keep zone state and
  * irrigation history coherent: it calls HA's open/close primitives, writes
  * matching `schedule_entries` (`source = 'manual'`) and `irrigation_cycles`
- * rows, and updates `zones.current_depletion_mm` so the planner's next
- * re-plan starts from the post-fire soil-moisture state.
+ * rows via the repository, and updates `zones.current_depletion_mm` so the
+ * planner's next re-plan starts from the post-fire soil-moisture state.
  *
- * @param deps - Collaborators and config.
- * @returns Wired controller ready to back the `/zones/:id/...` routes.
+ * Closure-held state (`current`, close timer, cycle id) lives on the
+ * service tier; the repository handles only persistence.
  */
 export function createManualController(deps: ManualControllerDeps): ManualController {
-    const { db, clock, openZone, closeZone, notifier, isAnyScheduledInFlight, isIrrigationEnabled } = deps;
+    const { clock, openZone, closeZone, notifier, isAnyScheduledInFlight, isIrrigationEnabled } = deps;
     let current: ActiveManualFire | null = null;
 
     const ensureSystemEnabled = async (action: string, zone: Zone): Promise<void> => {
@@ -149,70 +98,6 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         if (isAnyScheduledInFlight()) {
             throw new BusyError(`manual: cannot ${action} zone ${zone.id} — a scheduled cycle is currently in flight.`);
         }
-    };
-
-    const writeManualRecord = async (
-        zone: Zone,
-        openedAt: Date,
-        closedAt: Date | null,
-        durationMin: number,
-    ): Promise<string | null> => {
-        const today = dayjs(openedAt).format('YYYY-MM-DD');
-        const precipRate = zone.precipitationRateMmPerHr ?? (60 * (zone.flowRateLPerMin / zone.areaM2));
-        const appliedDepth = (durationMin / 60) * precipRate;
-        const netDepth = appliedDepth * zone.irrigationEfficiency;
-        const depletionBefore = zone.currentDepletionMm;
-        const depletionAfter = Math.max(0, depletionBefore - netDepth);
-
-        const insertedEntry = await db
-            .insert(scheduleEntries)
-            .values([
-                {
-                    zoneId: zone.id,
-                    scheduleId: null,
-                    date: today,
-                    appliedDepthMm: roundTo1Decimal(appliedDepth),
-                    depletionBeforeMm: roundTo1Decimal(depletionBefore),
-                    depletionAfterMm: roundTo1Decimal(depletionAfter),
-                    source: 'manual',
-                },
-            ])
-            .returning({ id: scheduleEntries.id });
-
-        const entryId = (insertedEntry[0] as { id: string } | undefined)?.id;
-        if (!entryId) {
-            console.warn(`manual: schedule_entries insert returned no id for zone ${zone.id}; skipping cycle row.`);
-            return null;
-        }
-
-        const insertedCycle = await db
-            .insert(irrigationCycles)
-            .values([
-                {
-                    scheduleEntryId: entryId,
-                    startTime: openedAt,
-                    durationMin,
-                    firedAt: openedAt,
-                    closedAt,
-                },
-            ])
-            .returning({ id: irrigationCycles.id });
-
-        const cycleId = (insertedCycle[0] as { id: string } | undefined)?.id ?? null;
-
-        await db
-            .update(zones)
-            .set({ currentDepletionMm: depletionAfter })
-            .where(eq(zones.id, zone.id));
-
-        return cycleId;
-    };
-
-    const updateCycleClosedAt = async (cycleId: string, closedAt: Date): Promise<void> => {
-        await db
-            .update(irrigationCycles)
-            .set({ closedAt })
-            .where(eq(irrigationCycles.id, cycleId));
     };
 
     const open: ManualController['open'] = async (zone) => {
@@ -270,10 +155,10 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         const closedAt = clock.now();
 
         if (runDurationMin !== undefined && cycleId !== undefined) {
-            await updateCycleClosedAt(cycleId, closedAt);
+            await getRepo().updateCycleClosedAt(cycleId, closedAt);
         } else {
             const elapsedMin = (closedAt.getTime() - openedAt.getTime()) / 60_000;
-            await writeManualRecord(zone, openedAt, closedAt, elapsedMin);
+            await getRepo().writeManualRecord(zone, openedAt, closedAt, elapsedMin);
         }
 
         console.log(`manual: closed zone ${zone.id} at ${closedAt.toISOString()}.`);
@@ -296,7 +181,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
 
         const closedAt = clock.now();
         if (cycleId !== null) {
-            await updateCycleClosedAt(cycleId, closedAt);
+            await getRepo().updateCycleClosedAt(cycleId, closedAt);
         }
 
         console.log(`manual: scheduled close for zone ${zone.id} at ${closedAt.toISOString()}.`);
@@ -324,7 +209,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
 
         const openedAt = clock.now();
         const willCloseAt = new Date(openedAt.getTime() + durationMin * 60_000);
-        const cycleId = await writeManualRecord(zone, openedAt, null, durationMin);
+        const cycleId = await getRepo().writeManualRecord(zone, openedAt, null, durationMin);
 
         const closeHandle = clock.setTimeout(() => {
             onScheduledCloseFire(zone, cycleId).catch(err => {
@@ -358,7 +243,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
             const closedAt = clock.now();
             console.log(`manual: closed zone ${active.zone.id} on shutdown.`);
             if (active.cycleId !== undefined) {
-                await updateCycleClosedAt(active.cycleId, closedAt);
+                await getRepo().updateCycleClosedAt(active.cycleId, closedAt);
             }
             await notifier('watering-ended', { zoneName: active.zone.name, reason: 'shutdown' });
         } catch (err) {
@@ -369,8 +254,4 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
     };
 
     return { open, close, run, getActiveZone, shutdown };
-}
-
-function roundTo1Decimal(value: number): number {
-    return Math.round(value * 10) / 10;
 }


### PR DESCRIPTION
## Ticket

[API-57](http://192.168.2.100:7123/irrigo/browse/API-57/) Refactor manual module into repositories + service + models

## Summary

Trickiest of the seven under [API-51](http://192.168.2.100:7123/irrigo/browse/API-51/) because the manual-fire controller is stateful — the active-fire reference, close-timer handle, and cycle id all live in closures.

- **Repository** (\`api/repositories/manual/\`) — \`writeManualRecord\` + \`updateCycleClosedAt\` behind a \`ManualRepository\` interface. Drizzle chain (entries INSERT + cycles INSERT + zones UPDATE for the write; cycle UPDATE for close stamping) all factor cleanly. Depletion math + clamping + \`precipRate\` fallback live in the repo now.
- **Service** (\`api/service/manual/\`) — module-level \`repo\` handle, \`bootManualService({ db } | { repo })\`, \`createManualController(deps)\` (no \`db\` in deps). Closure state stays here.
- **Model** (\`api/models/manual.ts\`) — \`ActiveManualSnapshot\`, \`ManualController\`, \`ManualControllerDeps\`.
- **\`api/manual/\` deleted** entirely; \`api/index.ts\` calls \`bootManualService({ db })\` and \`api/.test.ts\` switches its import.
- 708 tests passing across 41 files; type-check clean; \`git grep "from '@/manual'\" api/\` returns zero hits.