### PR TITLE
[API-56] Refactor schedules-list module into repositories + service + models

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -4,7 +4,7 @@ import { encodeCursor } from '@/util/cursor';
 import type { AlertDto } from '@/alerts';
 import { buildApp, gracefulShutdown, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
 import type { TonightDto } from '@/tonight';
-import type { ScheduleListItem } from '@/schedules-list';
+import type { ScheduleListItem } from '@/service/schedules-list';
 import type { DaemonControl, DaemonStatus } from '@/service/daemon';
 import type { ZoneSummary } from '@/models/zone';
 import { BusyError, SystemDisabledError, type ManualController } from '@/service/manual';

--- a/api/index.ts
+++ b/api/index.ts
@@ -40,7 +40,11 @@ import { bootSystemService, getSystemState, setIrrigationEnabled } from '@/servi
 import type { Database } from '@/db';
 import type { SystemStateDto } from '@/models/system';
 import { getTonightSummary, type TonightDb, type TonightDto } from '@/tonight';
-import { listSchedules, type ScheduleListDb, type ScheduleListItem } from '@/schedules-list';
+import {
+    bootSchedulesListService,
+    listSchedules,
+    type ScheduleListItem,
+} from '@/service/schedules-list';
 import { queryLatestMigrationViaDrizzle, readJournalFile, verifyMigrations } from '@/db/verify-migrations';
 import {
     bootManualService,
@@ -720,6 +724,7 @@ if (import.meta.main) {
     bootSchedulesService({ db: typedDb });
     bootZonesService({ db: typedDb });
     bootManualService({ db: typedDb });
+    bootSchedulesListService({ db: typedDb });
     bootDaemonService({ db: typedDb });
     const daemon = await daemonStart({
         notifier,
@@ -761,7 +766,7 @@ if (import.meta.main) {
         system: wrapSystemWithReplan(baseSystem, () => daemon.rePlan()),
         activity: params => listActivity(db as unknown as ActivityDb, params),
         tonight: () => getTonightSummary(db as unknown as TonightDb, realClock.now()),
-        schedulesList: () => listSchedules(db as unknown as ScheduleListDb, realClock.now()),
+        schedulesList: () => listSchedules(realClock.now()),
     });
 
     const onSignal = (signal: NodeJS.Signals): void => {

--- a/api/models/schedules-list.ts
+++ b/api/models/schedules-list.ts
@@ -1,0 +1,41 @@
+/**
+ * One allowed irrigation window within a day. `start` and `end` are `HH:MM`
+ * strings interpreted in the site's local timezone. Mirrors the
+ * `ScheduleTimeWindow` shape from the schema so the wire payload doesn't
+ * leak Drizzle types.
+ */
+export type ScheduleAllowedTimeWindow = {
+    start: string;
+    end: string;
+};
+
+/**
+ * Derived "next run" labels rendered on the active-schedule chip and the
+ * Schedules screen's active row. Formatted server-side so each client (app,
+ * eventually a web dashboard) doesn't reimplement the rules.
+ */
+export type ScheduleNextRun = {
+    inLabel: string;
+    whenLabel: string;
+    zonesLabel: string;
+};
+
+/**
+ * Wire shape served by `GET /schedules` — one item per row in the `schedules`
+ * table. `nextRun` and `skippedTonight` are present only on the active row
+ * (and only when there's actually a next run to describe). Inactive rows
+ * omit them so the client doesn't have to disambiguate `null` vs missing.
+ */
+export type ScheduleListItem = {
+    id: string;
+    slug: string;
+    name: string;
+    isActive: boolean;
+    allowedDays: number[] | null;
+    allowedTimeWindows: ScheduleAllowedTimeWindow[] | null;
+    rootDepthMOverride: number | null;
+    allowableDepletionFractionOverride: number | null;
+    endBySunrise: boolean | null;
+    nextRun?: ScheduleNextRun | null;
+    skippedTonight?: boolean;
+};

--- a/api/repositories/schedule-entries/.test.ts
+++ b/api/repositories/schedule-entries/.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@/db/schema';
 import type { IrrigationScheduleEntry } from '@/models';
 import type { ZoneJoinedRow } from '@/repositories/zones';
-import { createScheduleEntriesRepository } from '.';
+import { createScheduleEntriesRepository, type NextRunJoinedRow } from '.';
 
 const NOW = new Date('2026-05-04T12:00:00.000Z');
 
@@ -504,5 +504,63 @@ describe('createScheduleEntriesRepository.markCycleClosed', () => {
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.table).toBe(irrigationCycles);
         expect(updateCalls[0]?.values).toEqual({ closedAt });
+    });
+});
+
+function stubNextRunDb(rows: NextRunJoinedRow[]): { db: Database; limits: number[] } {
+    const limits: number[] = [];
+    const runLimit = async (n: number): Promise<NextRunJoinedRow[]> => {
+        limits.push(n);
+        return rows;
+    };
+    const db = {
+        select: () => ({
+            from: () => ({ innerJoin: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: runLimit }) }) }) }) }),
+        }),
+    } as unknown as Database;
+    return { db, limits };
+}
+
+function buildNextRunRow(overrides?: Partial<NextRunJoinedRow>): NextRunJoinedRow {
+    return {
+        entry: {
+            id: 'entry-1',
+            zoneId: 'zone-1',
+            scheduleId: 'sched-1',
+            date: '2026-05-22',
+            appliedDepthMm: 5,
+            depletionBeforeMm: 10,
+            depletionAfterMm: 5,
+            source: 'scheduled',
+            sunriseAt: null,
+            sunsetAt: null,
+            createdAt: NOW,
+            updatedAt: NOW,
+        },
+        cycle: null,
+        zone: { id: 'zone-1', name: 'North' },
+        ...overrides,
+    };
+}
+
+describe('createScheduleEntriesRepository.findScheduledFromDate', () => {
+    it('returns the joined rows produced by the chain and forwards the limit', async () => {
+        const seeded = [buildNextRunRow({ entry: { ...buildNextRunRow().entry, date: '2026-05-22' } })];
+        const { db, limits } = stubNextRunDb(seeded);
+        const repo = createScheduleEntriesRepository(db);
+
+        const result = await repo.findScheduledFromDate('2026-05-22', 150);
+
+        expect(result).toEqual(seeded);
+        expect(limits).toEqual([150]);
+    });
+
+    it('returns an empty array when the join yields no rows', async () => {
+        const { db } = stubNextRunDb([]);
+        const repo = createScheduleEntriesRepository(db);
+
+        const result = await repo.findScheduledFromDate('2026-05-22', 200);
+
+        expect(result).toEqual([]);
     });
 });

--- a/api/repositories/schedule-entries/index.ts
+++ b/api/repositories/schedule-entries/index.ts
@@ -1,5 +1,5 @@
 import type dayjs from 'dayjs';
-import { and, eq, gt, gte, isNotNull, isNull } from 'drizzle-orm';
+import { and, asc, eq, gt, gte, isNotNull, isNull } from 'drizzle-orm';
 import type { Database } from '@/db';
 import {
     grassTypes,
@@ -27,6 +27,18 @@ type FutureCycleJoinedRow = {
  */
 export type ReplaceForZoneResult = {
     cycles: PersistedCycle[];
+};
+
+/**
+ * Shape of one row from the schedules-list / tonight join — `scheduleEntries
+ * × zones × leftJoin irrigationCycles`. Each row is one (entry, cycle) pair;
+ * `cycle` is `null` for entries whose cycles haven't been inserted yet (or
+ * for non-scheduled sources like `manual`, though this method filters those out).
+ */
+export type NextRunJoinedRow = {
+    entry: typeof scheduleEntries.$inferSelect;
+    cycle: typeof irrigationCycles.$inferSelect | null;
+    zone: { id: string; name: string };
 };
 
 /**
@@ -65,6 +77,15 @@ export interface ScheduleEntriesRepository {
 
     /** Stamps the cycle's `closed_at` column. Called after a successful HA close. */
     markCycleClosed(cycleId: string, closedAt: Date): Promise<void>;
+
+    /**
+     * Returns up to `limit` rows of the `scheduleEntries × zones × leftJoin
+     * irrigationCycles` join filtered by `date >= fromDate` and
+     * `source = 'scheduled'`. Ordered by date, then zone id, then cycle
+     * start time. Used by the schedules-list and tonight modules to derive
+     * the next upcoming irrigation night.
+     */
+    findScheduledFromDate(fromDate: string, limit: number): Promise<NextRunJoinedRow[]>;
 }
 
 /**
@@ -192,6 +213,21 @@ export function createScheduleEntriesRepository(db: Database): ScheduleEntriesRe
 
         markCycleClosed: async (cycleId, closedAt) => {
             await db.update(irrigationCycles).set({ closedAt }).where(eq(irrigationCycles.id, cycleId));
+        },
+
+        findScheduledFromDate: async (fromDate, limit) => {
+            return db
+                .select({
+                    entry: scheduleEntries,
+                    cycle: irrigationCycles,
+                    zone: { id: zones.id, name: zones.name },
+                })
+                .from(scheduleEntries)
+                .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
+                .leftJoin(irrigationCycles, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+                .where(and(gte(scheduleEntries.date, fromDate), eq(scheduleEntries.source, 'scheduled')))
+                .orderBy(asc(scheduleEntries.date), asc(zones.id), asc(irrigationCycles.startTime))
+                .limit(limit);
         },
     };
 }

--- a/api/repositories/schedules/.test.ts
+++ b/api/repositories/schedules/.test.ts
@@ -39,9 +39,14 @@ function createStub(rowsByPredicate: Schedule[]) {
     const runSelectWhere = async (cond: unknown): Promise<Array<{ schedule: Schedule }>> => {
         selectCalls.push({ where: cond });
         const params = extractParamValues(cond);
-        // No string params: probably `eq(isActive, true)` — boolean param is
-        // encoded differently. Otherwise treat the first param as a slug.
-        if (params.length === 0) return rows.filter(r => r.isActive).map(s => ({ schedule: s }));
+        if (params.length === 0) {
+            // No string params. Distinguish `eq(isActive, true)` (has a boolean
+            // Param node) from `sql\`true\`` (no Param nodes at all). The
+            // former wants active-only rows; the latter wants every row.
+            return hasAnyParam(cond)
+                ? rows.filter(r => r.isActive).map(s => ({ schedule: s }))
+                : rows.map(s => ({ schedule: s }));
+        }
         const slug = params[0]!;
         return rows.filter(r => r.slug === slug).map(s => ({ schedule: s }));
     };
@@ -88,6 +93,47 @@ function extractParamValues(cond: unknown): string[] {
     walk(cond);
     return values;
 }
+
+/** Returns true if the condition tree contains any Drizzle Param node (string or otherwise). */
+function hasAnyParam(cond: unknown): boolean {
+    const seen = new WeakSet<object>();
+    let found = false;
+    function walk(node: unknown): void {
+        if (found) return;
+        if (typeof node !== 'object' || node === null) return;
+        if (seen.has(node)) return;
+        seen.add(node);
+        const obj = node as Record<string, unknown>;
+        if ('encoder' in obj && 'value' in obj) { found = true; return; }
+        if (Array.isArray(node)) { for (const item of node) walk(item); return; }
+        for (const value of Object.values(obj)) walk(value);
+    }
+    walk(cond);
+    return found;
+}
+
+describe('createSchedulesRepository.listAll', () => {
+    it('returns every schedule in insertion order, regardless of active state', async () => {
+        const a = buildSchedule({ id: 'sched-A', siteId: 'site-A', isActive: true });
+        const b = buildSchedule({ id: 'sched-B', siteId: 'site-A', isActive: false });
+        const c = buildSchedule({ id: 'sched-C', siteId: 'site-B', isActive: false });
+        const { db } = createStub([a, b, c]);
+        const repo = createSchedulesRepository(db);
+
+        const result = await repo.listAll();
+
+        expect(result.map(s => s.id)).toEqual(['sched-A', 'sched-B', 'sched-C']);
+    });
+
+    it('returns an empty array when the schedules table is empty', async () => {
+        const { db } = createStub([]);
+        const repo = createSchedulesRepository(db);
+
+        const result = await repo.listAll();
+
+        expect(result).toEqual([]);
+    });
+});
 
 describe('createSchedulesRepository.loadActiveBySite', () => {
     it('returns a Map<siteId, Schedule> for every active row', async () => {

--- a/api/repositories/schedules/index.ts
+++ b/api/repositories/schedules/index.ts
@@ -1,5 +1,5 @@
 import type dayjs from 'dayjs';
-import { and, eq, isNotNull, lt, ne } from 'drizzle-orm';
+import { and, eq, isNotNull, lt, ne, sql } from 'drizzle-orm';
 import type { Database } from '@/db';
 import { schedules } from '@/db/schema';
 
@@ -17,6 +17,13 @@ export type Schedule = typeof schedules.$inferSelect;
  * service layer can be a thin pass-through.
  */
 export interface SchedulesRepository {
+    /**
+     * Returns every row from the `schedules` table, in the database's
+     * insertion order. Used by the schedules-list module to render the full
+     * Schedules screen + drawer footer.
+     */
+    listAll(): Promise<Schedule[]>;
+
     /**
      * Returns a `Map<siteId, Schedule>` of every active schedule. The partial
      * unique index `schedules_one_active_per_site` guarantees at most one row
@@ -75,6 +82,14 @@ export function createSchedulesRepository(db: Database): SchedulesRepository {
     };
 
     return {
+        listAll: async () => {
+            const rows = await db
+                .select({ schedule: schedules })
+                .from(schedules)
+                .where(sql`true`);
+            return rows.map(r => r.schedule);
+        },
+
         loadActiveBySite: async () => {
             const rows = await db
                 .select({ schedule: schedules })

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -282,6 +282,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
     };
 
     const schedulesRepo: SchedulesRepository = {
+        listAll: async () => [],
         loadActiveBySite: async () => {
             if (firstActiveScheduleReadOrder === null) firstActiveScheduleReadOrder = ++callOrder;
             const map = new Map<string, Schedule>();
@@ -371,6 +372,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         markCycleClosed: async (cycleId, closedAt) => {
             cycleUpdates.push({ cycleId, closedAt });
         },
+        findScheduledFromDate: async () => [],
     };
 
     const runAlertsUpdate = async (values: Record<string, unknown>, cond: unknown): Promise<void> => {

--- a/api/service/daemon/reconcile.test.ts
+++ b/api/service/daemon/reconcile.test.ts
@@ -73,6 +73,7 @@ function recordingScheduleEntriesRepo(): { repo: ScheduleEntriesRepository; upda
         markCycleClosed: async (cycleId, closedAt) => {
             updates.push({ cycleId, closedAt });
         },
+        findScheduledFromDate: async () => [],
     };
     return { repo, updates };
 }
@@ -88,6 +89,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonService
         },
         sites: { loadTimezone: async () => 'UTC' },
         schedules: {
+            listAll: async () => [],
             loadActiveBySite: async () => new Map(),
             findBySlug: async () => null,
             enable: async () => null,

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -107,6 +107,7 @@ function recordingScheduleEntriesRepo(): { repo: ScheduleEntriesRepository; upda
         markCycleClosed: async (cycleId, closedAt) => {
             updates.push({ cycleId, closedAt });
         },
+        findScheduledFromDate: async () => [],
     };
     return { repo, updates };
 }
@@ -122,6 +123,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonService
         },
         sites: { loadTimezone: async () => 'UTC' },
         schedules: {
+            listAll: async () => [],
             loadActiveBySite: async () => new Map(),
             findBySlug: async () => null,
             enable: async () => null,

--- a/api/service/schedules-list/.test.ts
+++ b/api/service/schedules-list/.test.ts
@@ -2,14 +2,15 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
-import { irrigationCycles, scheduleEntries, schedules, zones } from '@/db/schema';
+import { irrigationCycles, scheduleEntries } from '@/db/schema';
+import type { NextRunJoinedRow, ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { Schedule, SchedulesRepository } from '@/repositories/schedules';
 import { bootSitesService } from '@/service/sites';
-import type { Schedule } from '@/service/schedules';
 import {
+    bootSchedulesListService,
     formatInLabel,
     formatWhenLabel,
     listSchedules,
-    type ScheduleListDb,
 } from '.';
 
 dayjs.extend(utc);
@@ -17,8 +18,6 @@ dayjs.extend(timezone);
 
 type EntryRow = typeof scheduleEntries.$inferSelect;
 type CycleRow = typeof irrigationCycles.$inferSelect;
-type ZoneSubset = { id: string; name: string };
-type JoinedRow = { entry: EntryRow; cycle: CycleRow | null; zone: ZoneSubset };
 
 const NOW = new Date('2026-05-21T22:00:00.000Z'); // 22:00 UTC, before any night cycles
 const SITE_TZ = 'UTC';
@@ -74,44 +73,35 @@ function buildCycle(overrides?: Partial<CycleRow>): CycleRow {
     };
 }
 
-type StubInputs = {
-    schedules?: Schedule[];
-    nextRunRows?: JoinedRow[];
-};
-
-function createStub(inputs?: StubInputs): ScheduleListDb {
-    const scheduleRows = inputs?.schedules ?? [];
-    const nextRunRows = inputs?.nextRunRows ?? [];
-
-    // Leaf handlers per query shape. The schedules-list service dispatches on
-    // the columns argument to `select()`; we mirror that here and return the
-    // matching one-line chain from each branch.
-    const runTimezoneFrom = async () => [{ timezone: SITE_TZ }];
-    const runSchedulesWhere = async () => scheduleRows.map(s => ({ schedule: s }));
-    const runNextRunQuery = async () => nextRunRows;
-
-    const runSelect = (cols: unknown) => {
-        const c = cols as Record<string, unknown>;
-        if ('timezone' in c && Object.keys(c).length === 1) {
-            return { from: runTimezoneFrom } as never;
-        }
-        if ('schedule' in c && Object.keys(c).length === 1) {
-            return { from: () => ({ where: runSchedulesWhere }) } as never;
-        }
-        if ('entry' in c && 'cycle' in c && 'zone' in c) {
-            return {
-                from: () => ({ innerJoin: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: runNextRunQuery }) }) }) }) }),
-            } as never;
-        }
-        return {} as never;
+function fakeSchedulesRepo(schedules: Schedule[]): SchedulesRepository {
+    return {
+        listAll: async () => schedules,
+        loadActiveBySite: async () => new Map(),
+        findBySlug: async () => null,
+        enable: async () => null,
+        disable: async () => null,
+        skipActiveTonight: async () => null,
+        resumeActiveTonight: async () => null,
+        clearStaleSkipMarkers: async () => undefined,
     };
+}
 
-    const db: ScheduleListDb = {
-        select: runSelect,
-        update: () => ({ set: () => ({ where: async () => undefined }) }),
-        transaction: async (cb) => cb(db as never),
+function fakeScheduleEntriesRepo(nextRunRows: NextRunJoinedRow[]): ScheduleEntriesRepository {
+    return {
+        loadFutureCycles: async () => [],
+        loadInFlightCycles: async () => [],
+        replaceForZone: async () => ({ cycles: [] }),
+        markCycleFired: async () => undefined,
+        markCycleClosed: async () => undefined,
+        findScheduledFromDate: async () => nextRunRows,
     };
-    return db;
+}
+
+function bootWith(inputs?: { schedules?: Schedule[]; nextRunRows?: NextRunJoinedRow[] }) {
+    bootSchedulesListService({
+        schedulesRepo: fakeSchedulesRepo(inputs?.schedules ?? []),
+        scheduleEntriesRepo: fakeScheduleEntriesRepo(inputs?.nextRunRows ?? []),
+    });
 }
 
 describe('listSchedules', () => {
@@ -120,18 +110,18 @@ describe('listSchedules', () => {
     });
 
     it('returns an empty array when no schedules exist', async () => {
-        const db = createStub();
+        bootWith();
 
-        const result = await listSchedules(db, NOW);
+        const result = await listSchedules(NOW);
 
         expect(result).toEqual([]);
     });
 
     it('maps a single inactive schedule with no nextRun or skippedTonight fields', async () => {
         const inactive = buildSchedule({ id: 'sched-X', slug: 'overseeding', name: 'Overseeding', isActive: false });
-        const db = createStub({ schedules: [inactive] });
+        bootWith({ schedules: [inactive] });
 
-        const result = await listSchedules(db, NOW);
+        const result = await listSchedules(NOW);
 
         expect(result).toHaveLength(1);
         const item = result[0]!;
@@ -161,9 +151,9 @@ describe('listSchedules', () => {
             allowableDepletionFractionOverride: 0.35,
             endBySunrise: true,
         });
-        const db = createStub({ schedules: [sched] });
+        bootWith({ schedules: [sched] });
 
-        const [item] = await listSchedules(db, NOW);
+        const [item] = await listSchedules(NOW);
 
         expect(item?.allowedDays).toEqual([3, 5, 7]);
         expect(item?.allowedTimeWindows).toEqual([
@@ -177,9 +167,9 @@ describe('listSchedules', () => {
 
     it('emits nextRun: null on the active schedule when no upcoming entries exist', async () => {
         const active = buildSchedule({ isActive: true });
-        const db = createStub({ schedules: [active], nextRunRows: [] });
+        bootWith({ schedules: [active], nextRunRows: [] });
 
-        const [item] = await listSchedules(db, NOW);
+        const [item] = await listSchedules(NOW);
 
         expect(item?.nextRun).toBeNull();
         expect(item?.skippedTonight).toBe(false);
@@ -188,7 +178,7 @@ describe('listSchedules', () => {
     it('emits nextRun: null when all returned cycles have already ended (past-only rows)', async () => {
         const active = buildSchedule({ isActive: true });
         const past = new Date('2026-05-21T06:00:00.000Z'); // before NOW (22:00)
-        const db = createStub({
+        bootWith({
             schedules: [active],
             nextRunRows: [{
                 entry: buildEntry({ date: '2026-05-21' }),
@@ -197,7 +187,7 @@ describe('listSchedules', () => {
             }],
         });
 
-        const [item] = await listSchedules(db, NOW);
+        const [item] = await listSchedules(NOW);
 
         expect(item?.nextRun).toBeNull();
     });
@@ -205,7 +195,7 @@ describe('listSchedules', () => {
     it('builds nextRun on the active schedule when an upcoming night exists', async () => {
         const active = buildSchedule({ id: 'sched-active', isActive: true });
         const start = new Date('2026-05-22T03:00:00.000Z'); // 5h after NOW
-        const db = createStub({
+        bootWith({
             schedules: [active],
             nextRunRows: [
                 {
@@ -225,7 +215,7 @@ describe('listSchedules', () => {
             ],
         });
 
-        const [item] = await listSchedules(db, NOW);
+        const [item] = await listSchedules(NOW);
 
         expect(item?.nextRun).toEqual({
             // NOW is 22:00 on the 21st; start is 03:00 on the 22nd → 5h.
@@ -240,7 +230,7 @@ describe('listSchedules', () => {
     it('only carries nextRun and skippedTonight on the active row when multiple schedules exist', async () => {
         const inactive = buildSchedule({ id: 'sched-other', slug: 'overseeding', name: 'Overseeding', isActive: false });
         const active = buildSchedule({ id: 'sched-active', slug: 'maintenance', isActive: true });
-        const db = createStub({
+        bootWith({
             schedules: [inactive, active],
             nextRunRows: [
                 {
@@ -251,7 +241,7 @@ describe('listSchedules', () => {
             ],
         });
 
-        const result = await listSchedules(db, NOW);
+        const result = await listSchedules(NOW);
 
         expect(result).toHaveLength(2);
         const inactiveItem = result.find(i => i.id === 'sched-other')!;
@@ -265,18 +255,18 @@ describe('listSchedules', () => {
     it('sets skippedTonight: true when the active schedule’s skip marker matches today site-local', async () => {
         // NOW = 2026-05-21 22:00 UTC; site-local YYYY-MM-DD is 2026-05-21.
         const active = buildSchedule({ isActive: true, skippedNightDate: '2026-05-21' });
-        const db = createStub({ schedules: [active], nextRunRows: [] });
+        bootWith({ schedules: [active], nextRunRows: [] });
 
-        const [item] = await listSchedules(db, NOW);
+        const [item] = await listSchedules(NOW);
 
         expect(item?.skippedTonight).toBe(true);
     });
 
     it('sets skippedTonight: false when the active schedule’s skip marker is stale (not today)', async () => {
         const active = buildSchedule({ isActive: true, skippedNightDate: '2026-05-18' });
-        const db = createStub({ schedules: [active], nextRunRows: [] });
+        bootWith({ schedules: [active], nextRunRows: [] });
 
-        const [item] = await listSchedules(db, NOW);
+        const [item] = await listSchedules(NOW);
 
         expect(item?.skippedTonight).toBe(false);
     });
@@ -329,9 +319,3 @@ describe('formatWhenLabel', () => {
         expect(formatWhenLabel(start, now)).toBe('Sunday at 3:00 AM');
     });
 });
-
-// Keep table imports alive when Drizzle tree-shakes the refs.
-void schedules;
-void scheduleEntries;
-void irrigationCycles;
-void zones;

--- a/api/service/schedules-list/index.ts
+++ b/api/service/schedules-list/index.ts
@@ -1,130 +1,91 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
-import { and, asc, eq, gte, sql } from 'drizzle-orm';
-import { irrigationCycles, scheduleEntries, schedules, zones } from '@/db/schema';
+import type { Database } from '@/db';
+import type {
+    ScheduleAllowedTimeWindow,
+    ScheduleListItem,
+    ScheduleNextRun,
+} from '@/models/schedules-list';
+import {
+    createScheduleEntriesRepository,
+    type NextRunJoinedRow,
+    type ScheduleEntriesRepository,
+} from '@/repositories/schedule-entries';
+import { createSchedulesRepository, type Schedule, type SchedulesRepository } from '@/repositories/schedules';
 import { getSiteTimezone } from '@/service/sites';
-import type { Schedule } from '@/service/schedules';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+export type { ScheduleAllowedTimeWindow, ScheduleListItem, ScheduleNextRun } from '@/models/schedules-list';
+
 /**
  * Hard cap on how many entry/cycle rows we'll read for the active-schedule
- * next-run lookup. Same rationale as `TONIGHT_FETCH_LIMIT` — well above any
- * realistic single-night row count.
+ * next-run lookup. One night × all zones × handful of cycles is well under
+ * 50 rows even for the largest realistic installs; 200 is room to spare.
  */
 const NEXT_RUN_FETCH_LIMIT = 200;
 
 /**
- * One allowed irrigation window within a day. `start` and `end` are `HH:MM`
- * strings interpreted in the site's local timezone. Mirrors the
- * `ScheduleTimeWindow` shape from the schema so the wire payload doesn't
- * leak Drizzle types.
+ * Input to `bootSchedulesListService`. Production passes `{ db }`; tests
+ * pass object-literal repos.
  */
-export type ScheduleAllowedTimeWindow = {
-    start: string;
-    end: string;
-};
+export type BootSchedulesListServiceInput =
+    | { db: Database }
+    | { schedulesRepo: SchedulesRepository; scheduleEntriesRepo: ScheduleEntriesRepository };
+
+let schedulesRepo: SchedulesRepository | null = null;
+let scheduleEntriesRepo: ScheduleEntriesRepository | null = null;
 
 /**
- * Derived "next run" labels rendered on the active-schedule chip and the
- * Schedules screen's active row. Formatted server-side so each client (app,
- * eventually a web dashboard) doesn't reimplement the rules.
+ * Wires the schedules-list service to its repository dependencies. Call once
+ * at process boot; call again in test `beforeEach` with fakes.
  */
-export type ScheduleNextRun = {
-    inLabel: string;
-    whenLabel: string;
-    zonesLabel: string;
-};
+export function bootSchedulesListService(input: BootSchedulesListServiceInput): void {
+    if ('db' in input) {
+        schedulesRepo = createSchedulesRepository(input.db);
+        scheduleEntriesRepo = createScheduleEntriesRepository(input.db);
+    } else {
+        schedulesRepo = input.schedulesRepo;
+        scheduleEntriesRepo = input.scheduleEntriesRepo;
+    }
+}
 
-/**
- * Wire shape served by `GET /schedules` — one item per row in the `schedules`
- * table. `nextRun` and `skippedTonight` are present only on the active row
- * (and only when there's actually a next run to describe). Inactive rows
- * omit them so the client doesn't have to disambiguate `null` vs missing.
- */
-export type ScheduleListItem = {
-    id: string;
-    slug: string;
-    name: string;
-    isActive: boolean;
-    allowedDays: number[] | null;
-    allowedTimeWindows: ScheduleAllowedTimeWindow[] | null;
-    rootDepthMOverride: number | null;
-    allowableDepletionFractionOverride: number | null;
-    endBySunrise: boolean | null;
-    nextRun?: ScheduleNextRun | null;
-    skippedTonight?: boolean;
-};
+function getSchedulesRepo(): SchedulesRepository {
+    if (!schedulesRepo) {
+        throw new Error('Schedules-list service not booted — call bootSchedulesListService({ db }) at startup.');
+    }
+    return schedulesRepo;
+}
 
-type NextRunJoinedRow = {
-    entry: typeof scheduleEntries.$inferSelect;
-    cycle: typeof irrigationCycles.$inferSelect | null;
-    zone: { id: string; name: string };
-};
-
-/**
- * Minimal db interface for the active schedule's next-night query. Mirrors
- * the shape used by `api/tonight/` for the same data.
- */
-export type ScheduleListLoaderDb = {
-    select: (columns: {
-        entry: typeof scheduleEntries;
-        cycle: typeof irrigationCycles;
-        zone: { id: typeof zones.id; name: typeof zones.name };
-    }) => {
-        from: (table: typeof scheduleEntries) => {
-            innerJoin: (table: typeof zones, on: unknown) => {
-                leftJoin: (table: typeof irrigationCycles, on: unknown) => {
-                    where: (cond: unknown) => {
-                        orderBy: (...exprs: ReadonlyArray<unknown>) => {
-                            limit: (n: number) => Promise<NextRunJoinedRow[]>;
-                        };
-                    };
-                };
-            };
-        };
-    };
-};
-
-/**
- * Composite db interface for the schedules list query (the schedules table
- * read + the next-night join). Site timezone reads go through
- * `@/service/sites` — tests boot that service with a fake.
- */
-export type ScheduleListDb = ScheduleListLoaderDb & {
-    select: (columns: { schedule: unknown }) => {
-        from: (table: unknown) => {
-            where: (cond: unknown) => Promise<Array<{ schedule: Schedule }>>;
-        };
-    };
-};
+function getScheduleEntriesRepo(): ScheduleEntriesRepository {
+    if (!scheduleEntriesRepo) {
+        throw new Error('Schedules-list service not booted — call bootSchedulesListService({ db }) at startup.');
+    }
+    return scheduleEntriesRepo;
+}
 
 /**
  * Lists every schedule for the mobile app's Schedules screen + drawer footer
  * + Home active-schedule chip. The active schedule additionally carries
  * `skippedTonight` and a derived `nextRun` label block.
  *
- * @param db - Drizzle client (or compatible stub).
  * @param now - Wall-clock reference. Drives both the `skippedTonight`
  *   comparison and the `nextRun` "in X" / "Tonight at Y" formatting.
  */
-export async function listSchedules(db: ScheduleListDb, now: Date): Promise<ScheduleListItem[]> {
+export async function listSchedules(now: Date): Promise<ScheduleListItem[]> {
     const siteTimezone = await getSiteTimezone();
     const nowInTz = dayjs(now).tz(siteTimezone);
     const todaySiteLocal = nowInTz.format('YYYY-MM-DD');
 
-    const rows = await db
-        .select({ schedule: schedules })
-        .from(schedules)
-        .where(sql`true`);
+    const rows = await getSchedulesRepo().listAll();
 
     const items: ScheduleListItem[] = [];
     const activeSchedules: Schedule[] = [];
     for (const row of rows) {
-        items.push(toBaseDto(row.schedule));
-        if (row.schedule.isActive) activeSchedules.push(row.schedule);
+        items.push(toBaseDto(row));
+        if (row.isActive) activeSchedules.push(row);
     }
 
     if (activeSchedules.length === 0) return items;
@@ -132,7 +93,7 @@ export async function listSchedules(db: ScheduleListDb, now: Date): Promise<Sche
     // The single-site deploy means there's at most one active schedule; the
     // next-night query doesn't filter by site. If multi-site arrives, this is
     // the spot to filter cycles by `zones.siteId === schedule.siteId`.
-    const nextNight = await loadNextNight(db, now, todaySiteLocal);
+    const nextNight = await loadNextNight(now, todaySiteLocal);
 
     for (const active of activeSchedules) {
         const item = items.find(i => i.id === active.id);
@@ -163,19 +124,8 @@ type NextNight = {
     zoneOrder: string[];
 };
 
-async function loadNextNight(db: ScheduleListLoaderDb, now: Date, todaySiteLocal: string): Promise<NextNight | null> {
-    const rows = await db
-        .select({
-            entry: scheduleEntries,
-            cycle: irrigationCycles,
-            zone: { id: zones.id, name: zones.name },
-        })
-        .from(scheduleEntries)
-        .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
-        .leftJoin(irrigationCycles, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
-        .where(and(gte(scheduleEntries.date, todaySiteLocal), eq(scheduleEntries.source, 'scheduled')))
-        .orderBy(asc(scheduleEntries.date), asc(zones.id), asc(irrigationCycles.startTime))
-        .limit(NEXT_RUN_FETCH_LIMIT);
+async function loadNextNight(now: Date, todaySiteLocal: string): Promise<NextNight | null> {
+    const rows = await getScheduleEntriesRepo().findScheduledFromDate(todaySiteLocal, NEXT_RUN_FETCH_LIMIT);
 
     const byDate = new Map<string, NextRunJoinedRow[]>();
     for (const row of rows) {


### PR DESCRIPTION
## Ticket

[API-56](http://192.168.2.100:7123/irrigo/browse/API-56/) Refactor schedules-list module into repositories + service + models

## Summary

- **Repositories extended**: \`SchedulesRepository.listAll()\` returns every row; \`ScheduleEntriesRepository.findScheduledFromDate(fromDate, limit)\` returns the joined scheduled-source rows used by the next-night pick. \`NextRunJoinedRow\` type exported.
- **Service** (\`api/service/schedules-list/\`) — module-level repo handles + \`bootSchedulesListService({ db } | { schedulesRepo, scheduleEntriesRepo })\`, \`listSchedules(now)\`, pure \`formatInLabel\` / \`formatWhenLabel\` helpers. Reads timezone via \`getSiteTimezone()\` from \`@/service/sites\`.
- **Model** (\`api/models/schedules-list.ts\`) — \`ScheduleListItem\`, \`ScheduleNextRun\`, \`ScheduleAllowedTimeWindow\`.
- **\`api/schedules-list/\` deleted**; \`api/index.ts\` now calls \`bootSchedulesListService({ db })\` and the route handler is \`() => listSchedules(realClock.now())\` (no more \`ScheduleListDb\` cast).
- 712 tests passing across 41 files; type-check clean; \`git grep \"from '@/schedules-list\" api/\` returns zero hits.