### PR TITLE
[API-61] Wire EXPO_ACCESS_TOKEN into push dispatcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,14 @@ NOTIFY_ON_ERROR=true
 # every request. Leave unset to use the free-tier endpoint.
 # OPEN_METEO_API_KEY=
 
+# --- Expo push notifications (optional) ---
+# Server access token for Expo's push API. When set, requests to /push/send
+# and /push/getReceipts include `Authorization: Bearer <token>` and Expo
+# rejects unauthenticated calls — protects users whose push tokens leak from
+# being targeted by third parties. Mint one at expo.dev → Account Settings →
+# Access Tokens. Leave unset for dev; required in any production deploy.
+EXPO_ACCESS_TOKEN=
+
 # --- Postgres ---
 # Used by the bundled `db` container. Change all three (and DATABASE_URL
 # below) if you point the api at an external database instead.

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import type { ActivityDto, ActivityListParams, ActivityListResult } from '@/activity';
 import { encodeCursor } from '@/util/cursor';
 import type { AlertDto } from '@/alerts';
-import { buildApp, gracefulShutdown, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
+import { buildApp, gracefulShutdown, readExpoAccessToken, wrapScheduleWithReplan, wrapSystemWithReplan, type ScheduleApi, type SystemApi } from '@/index';
 import type { TonightDto } from '@/models/tonight';
 import type { ScheduleListItem } from '@/service/schedules-list';
 import type { DaemonControl, DaemonStatus } from '@/service/daemon';
@@ -1678,5 +1678,19 @@ describe('buildApp GET /schedules', () => {
         expect(res.statusCode).toBe(200);
         expect(res.json()).toEqual([]);
         await app.close();
+    });
+});
+
+describe('readExpoAccessToken', () => {
+    it('returns undefined when EXPO_ACCESS_TOKEN is unset', () => {
+        expect(readExpoAccessToken({})).toBeUndefined();
+    });
+
+    it('returns undefined when EXPO_ACCESS_TOKEN is an empty string', () => {
+        expect(readExpoAccessToken({ EXPO_ACCESS_TOKEN: '' })).toBeUndefined();
+    });
+
+    it('returns the token verbatim when EXPO_ACCESS_TOKEN is set to a non-empty string', () => {
+        expect(readExpoAccessToken({ EXPO_ACCESS_TOKEN: 'expo-token-abc123' })).toBe('expo-token-abc123');
     });
 });

--- a/api/index.ts
+++ b/api/index.ts
@@ -47,6 +47,7 @@ import {
     registerPushToken,
     unregisterPushToken,
 } from '@/service/push-tokens';
+import Expo from 'expo-server-sdk';
 import { bootTonightService, getTonightSummary } from '@/service/tonight';
 import {
     bootSchedulesListService,
@@ -158,6 +159,18 @@ export function wrapScheduleWithReplan(base: ScheduleApi, replan: () => Promise<
             return result;
         },
     };
+}
+
+/**
+ * Reads `EXPO_ACCESS_TOKEN` from the given environment object. Returns the
+ * token verbatim when present and non-empty; returns `undefined` when unset
+ * or empty so the caller can fall back to an unauthenticated `new Expo()`.
+ * Pulled out as a pure helper so the conditional is unit-testable without
+ * mutating `process.env`.
+ */
+export function readExpoAccessToken(env: NodeJS.ProcessEnv): string | undefined {
+    const value = env['EXPO_ACCESS_TOKEN'];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 export type BuildAppOptions = {
@@ -774,6 +787,14 @@ if (import.meta.main) {
     } else {
         console.log('startup: OPEN_METEO_ENABLED=false — Open-Meteo weather integration is disabled; the planner will not be able to fetch forecasts.');
     }
+
+    const expoAccessToken = readExpoAccessToken(process.env);
+    if (expoAccessToken) {
+        console.log('startup: EXPO_ACCESS_TOKEN is set; Expo push API calls will include the bearer token.');
+    } else {
+        console.log('startup: EXPO_ACCESS_TOKEN is unset; Expo push API calls will be unauthenticated (publicly callable — anyone with a leaked push token can target users).');
+    }
+    const expo = expoAccessToken ? new Expo({ accessToken: expoAccessToken }) : new Expo();
     const effectiveOpenZone: typeof openZone =
         dryRun ?
             async zone => {
@@ -796,7 +817,7 @@ if (import.meta.main) {
     bootManualService({ db: typedDb });
     bootSchedulesListService({ db: typedDb });
     bootTonightService({ db: typedDb });
-    bootPushTokensService({ db: typedDb });
+    bootPushTokensService({ db: typedDb, expo });
     bootDaemonService({ db: typedDb });
     const alerter = createAlerter(alertsDb, notifier, dispatchAlertPush);
     const daemon = await daemonStart({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
             NOTIFY_ON_WATERING_END: ${NOTIFY_ON_WATERING_END}
             NOTIFY_ON_ERROR: ${NOTIFY_ON_ERROR}
             DRY_RUN: ${DRY_RUN}
+            EXPO_ACCESS_TOKEN: ${EXPO_ACCESS_TOKEN}
         ports:
             - "${PORT}:9753"
         command: sh -c "bun run start"


### PR DESCRIPTION
## Ticket

[API-61](http://192.168.2.100:7123/irrigo/browse/API-61/) Wire EXPO_ACCESS_TOKEN into push dispatcher

## Summary

- Reads `EXPO_ACCESS_TOKEN` from `process.env` via a new pure `readExpoAccessToken(env)` helper in `api/index.ts`. When set, builds `new Expo({ accessToken })` and passes it to `bootPushTokensService({ db, expo })`; when unset, falls back to `new Expo()` so dev keeps working without credentials.
- Logs token presence at startup next to the existing `DRY_RUN` / `OPEN_METEO_ENABLED` lines — explicitly calls out the unauthenticated case as "publicly callable" so it's visible in logs.
- Plumbs `EXPO_ACCESS_TOKEN` through `docker-compose.yml`'s `api` service environment block and documents it in `.env.example` with a pointer to expo.dev → Account Settings → Access Tokens.
- Adds 3 tests for `readExpoAccessToken` (unset / empty / non-empty). Full suite green (767/767).