### PR TITLE
[API-62] Split CLAUDE.md into root, api, and app scoped files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
             "Bash(gh pr *)",
             "Bash(bun --cwd=./api test *)",
             "Bash(bun --cwd=./api run *)",
+            "Bash(bun --cwd=./app run *)",
             "Bash(bun run *)",
             "Bash(bun test *)",
             "Bash(bun install *)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 Irrigation control system. The repo contains:
 
-- **`api/`** — Bun + TypeScript backend that generates irrigation schedules from weather data (Open-Meteo).
-- **`app/`** — Expo / React Native client (NativeWind, Jest).
+- **`api/`** — Bun + TypeScript backend that generates irrigation schedules from weather data (Open-Meteo). See `api/CLAUDE.md` for backend-specific conventions.
+- **`app/`** — Expo / React Native client (NativeWind, Jest). See `app/CLAUDE.md` for client-specific conventions.
 - **`shared/`** — Code shared between `api` and `app`. See `shared/CLAUDE.md` for code style conventions.
 
 ## Local development
@@ -12,29 +12,33 @@ First-time setup:
 
 1. `cp .env.example .env` — at the repo root. Docker Compose loads `.env` from the directory containing the compose file.
 2. Edit `.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them. To opt into push notifications via Home Assistant, set `HA_NOTIFY_SERVICE` (e.g. `mobile_app_pixel_8`); the `NOTIFY_ON_WATERING_START` / `NOTIFY_ON_WATERING_END` / `NOTIFY_ON_ERROR` flags toggle each event type (defaults: `false`/`false`/`true`).
-3. From the repo root, bring the stack up: `docker compose up` (or `bun --cwd api run up` for the variant that includes pgAdmin via the `tools` profile).
+3. From the repo root, bring the stack up: `docker compose up` (or `bun --cwd=./api run up` for the variant that includes pgAdmin via the `tools` profile).
 
 `.env` is gitignored — never commit credentials.
 
 ## General Code Guidelines
 
 - Strict typing throughout. Prefer `unknown` over `any`. Treat state as readonly/immutable where possible.
-- Object property names are **lowerCamelCase** in TS, JSON, and config files alike — matches the existing Drizzle TS layer and `api/models.ts`. The only place snake_case is allowed is when a contract is owned by an external system (DB column names at the SQL level, third-party API request/response bodies, etc.).
+- Object property names are **lowerCamelCase** in TS, JSON, and config files alike. The only place snake_case is allowed is when a contract is owned by an external system (DB column names at the SQL level, third-party API request/response bodies, etc.).
 - Single quotes for string literals. If a string contains an apostrophe, use backticks (`) instead of double quotes to avoid escaping.
 - Dates as ISO-8601 UTC; align DTOs with server contracts. This codebase uses `dayjs` for date handling.
 - Type-check after making changes — run the project's type-check script before declaring work complete.
-- Log liberally via `console.log` / `console.warn` / `console.error` — external calls, state transitions, errors, scheduling decisions. The daemon runs unattended; logs are the only window into what it's doing.
-- Every database table includes `created_at` and `updated_at` `timestamptz` columns (both default `now()`). Use Drizzle's `defaultNow()` for `created_at` and `$onUpdate(() => new Date())` for `updated_at` so the timestamps maintain themselves on insert and update. Applies to all schema migrations going forward.
-
-Detailed frontend conventions (component structure, hooks, Tailwind/NativeWind) live in `shared/CLAUDE.md`.
+- Log liberally via `console.log` / `console.warn` / `console.error` for external calls, state transitions, errors, and significant decisions.
 
 ## Shell commands
 
 - Never prepend `cd /app` (or any other current-directory `cd`) to a command. The working directory is already `/app` — run the command directly. Prepending `cd` triggers a separate permission prompt for every invocation.
-- For commands that need a different cwd, prefer the tool's `--cwd` flag over `cd && …`, and **use a relative path** (`./api`, not `/app/api`) so the permission matcher can pre-approve by prefix across worktrees. Examples: `bun --cwd=./api test`, `bun --cwd=./api run type-check`, `bun --cwd=./api run db:generate`. Same shape for `docker compose --project-directory=./api …`.
+- For commands that need a different cwd, prefer the tool's `--cwd` flag over `cd && …`, and **use a relative path** (`./api`, not `/app/api`) so the permission matcher can pre-approve by prefix across worktrees. The canonical form for `bun` is **always** `bun --cwd=./<dir> run <command>` with the equals sign and the leading `./` — e.g. `bun --cwd=./api run test`, `bun --cwd=./api run type-check`, `bun --cwd=./app run typecheck`. Do not write the space form (`bun --cwd ./api …`) or omit the `./` prefix. Same shape for `docker compose --project-directory=./api …`.
 - `git` always operates on the current working tree — never prefix git commands with `cd`.
 - **No compound commands.** Don't chain shell expressions with `&&`, `||`, or `;` — each Bash call should run exactly one logical command so the permission matcher can pre-approve it by prefix. Run multi-step verification (type-check + tests) as separate Bash calls. The only exception is `git commit -m "$(cat <<'EOF' … EOF)"` heredoc for multi-line messages — that's still one logical command.
 - **No `| tail` / `| head` / `2>&1` redirection.** The Bash tool already captures stdout + stderr in full. Trimming output in the shell triggers a fresh permission prompt for every distinct compound; if a result is too long for context, truncate it when summarizing rather than in the pipe.
+
+## Running package.json scripts
+
+- **Always invoke package.json scripts as `bun --cwd=./<dir> run <script>`** — never the bare `bun --cwd=./<dir> <script>` form. The bare form invokes Bun's own subcommands (e.g. `bun test` runs Bun's native test runner, not the `test` script), which silently does the wrong thing in `app/` where Jest is required to parse React Native flow syntax.
+- If a one-off command isn't already a script, **add it to the relevant `package.json` first** and then call it via `run`. Don't sprinkle ad-hoc `bun <command>` invocations across the codebase — each fresh shape triggers a permission prompt and erodes the allow-list discipline.
+- The corresponding allow-list entries in `.claude/settings.json` are `Bash(bun --cwd=./api run *)` and `Bash(bun --cwd=./app run *)`. Any new script you add is covered automatically; you don't have to touch `settings.json`.
+- Subproject-specific script tables live in `api/CLAUDE.md` and `app/CLAUDE.md`.
 
 ## Testing
 
@@ -45,32 +49,14 @@ Detailed frontend conventions (component structure, hooks, Tailwind/NativeWind) 
 - Place test files alongside the source they test, named `test.ts` or `test.tsx`.
 - Run the project's test command after making changes.
 
-Detailed React Native testing patterns (libraries, render helpers) live in `shared/CLAUDE.md`.
-
-## Database
-
-Postgres (service `db` in `docker-compose.yml`) is the data store; **Drizzle ORM** wraps it, **drizzle-kit** manages schema and migrations.
-
-- Schema lives in `api/db/schema/` — one file per table plus a barrel `index.ts`.
-- Migrations are written to `api/drizzle/` by `bun run db:generate` after schema changes — commit these.
-- The runtime client is the typed `db` exported from `api/db/index.ts`. It reads `DATABASE_URL` from the environment; `api/docker-compose.yml` plumbs a default into the api container.
-- A fresh environment runs `bun run db:migrate` (schema-only) and then `bun run seed` (API-6, JSON-driven).
-- Inside Docker, run migrations with `docker compose run --rm api bun run db:migrate`. Migrations are applied via this explicit step — not on app startup — to keep startup deterministic for the single-instance deploy.
-
-Available scripts (run from `api/`):
-
-- `bun run db:generate` — generate a migration from the current schema diff
-- `bun run db:migrate` — apply pending migrations
-- `bun run db:push` — push the schema directly to the database (dev only; bypasses migrations)
-- `bun run db:studio` — launch Drizzle Studio against `DATABASE_URL`
-
-## Security
-
-The api container exposes manual zone-control endpoints (`POST /zones/:id/open`, `/close`, `/run`) with **no authentication** — they assume a trusted LAN. Bind the api port to LAN-only or run it behind a VPN. **Never expose the api container's port to the public internet.**
-
 ## Tickets
 
-Tickets are tracked in **Plane**, in the `api` project (`API-XXX` keys). Categorization is via labels, not work-item types — every ticket gets exactly one of Epic / Feature / Bug.
+Tickets are tracked in **Plane**, across two projects:
+
+- `irrigo_api` (`API-XXX` keys) — backend work.
+- `irrigo_app` (`APP-XXX` keys) — client work.
+
+Categorization is via labels, not work-item types — every ticket gets exactly one of Epic / Feature / Bug.
 
 Invoke the `/plane` skill before creating, searching, or updating tickets. Use `/write-ticket` to draft a new one.
 
@@ -79,9 +65,9 @@ Invoke the `/plane` skill before creating, searching, or updating tickets. Use `
 ## Git workflow
 
 - **Main branch**: `main`
-- **Branch naming**: `(feature|bug)/<short-description>` — e.g., `feature/weather-cache`, `bug/schedule-overlap`. Keep descriptions lowercase, hyphenated.
-- **Commit messages**: short and direct. Include the `API-XXX` reference when the work is tied to a ticket (e.g., `API-12: Cache Open-Meteo responses for 1h`).
-- **PR title**: short and descriptive. Prefix with `[API-XXX]` when there's a ticket.
+- **Branch naming**: `(feature|bug)/<short-description>` — e.g., `feature/weather-cache`, `bug/schedule-overlap`. Keep descriptions lowercase, hyphenated. When tied to a ticket, the convention is `feature/<KEY-XXX>` or `bug/<KEY-XXX>` (e.g. `feature/API-12`, `bug/APP-15`).
+- **Commit messages**: short and direct. Include the ticket reference (`API-XXX` or `APP-XXX`) when the work is tied to a ticket (e.g., `API-12: Cache Open-Meteo responses for 1h`, `APP-15: Add depletion battery primitive`).
+- **PR title**: short and descriptive. Prefix with `[API-XXX]` or `[APP-XXX]` when there's a ticket.
 - **PR body**: link the ticket if there is one. Brief summary of the change. No template required.
 - After a PR for a ticket merges, update the ticket's state to `Done` via `mcp__plane__update_work_item`.
 
@@ -142,4 +128,6 @@ The shared `irrigo-gradle` / `irrigo-android` volumes survive because they're ex
 
 ## Working in subprojects
 
+- `api/CLAUDE.md` — backend conventions: Postgres / Drizzle, security, daemon-specific logging, available scripts.
+- `app/CLAUDE.md` — client conventions: Expo versioned-docs reminder, available scripts.
 - `shared/CLAUDE.md` — typing, components, comments, file structure, Tailwind/NativeWind.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,50 @@
+# Irrigo API
+
+Backend daemon for the Irrigo irrigation control system — **Bun + TypeScript + Fastify + Drizzle + Postgres**. Reads forecasts from Open-Meteo, computes irrigation schedules, controls relays via Home Assistant, and exposes a Fastify API for the client.
+
+Shared conventions (typing, shell rules, ticket workflow, git workflow) live in the root `CLAUDE.md`. This file holds backend-only guidance.
+
+## Database
+
+Postgres (service `db` in `docker-compose.yml`) is the data store; **Drizzle ORM** wraps it, **drizzle-kit** manages schema and migrations.
+
+- Schema lives in `api/db/schema/` — one file per table plus a barrel `index.ts`.
+- Migrations are written to `api/drizzle/` by `bun --cwd=./api run db:generate` after schema changes — commit these.
+- The runtime client is the typed `db` exported from `api/db/index.ts`. It reads `DATABASE_URL` from the environment; `api/docker-compose.yml` plumbs a default into the api container.
+- A fresh environment runs `bun --cwd=./api run db:migrate` (schema-only) and then `bun --cwd=./api run seed` (API-6, JSON-driven).
+- Inside Docker, run migrations with `docker compose run --rm api bun run db:migrate`. Migrations are applied via this explicit step — not on app startup — to keep startup deterministic for the single-instance deploy.
+
+## Conventions
+
+- **Every database table includes `created_at` and `updated_at` `timestamptz` columns** (both default `now()`). Use Drizzle's `defaultNow()` for `created_at` and `$onUpdate(() => new Date())` for `updated_at` so the timestamps maintain themselves on insert and update. Applies to all schema migrations going forward.
+- **The daemon runs unattended.** Logs are the only window into what it's doing — log liberally via `console.log` / `console.warn` / `console.error` for external calls (Open-Meteo, HA), state transitions (zone open/close), scheduling decisions, and errors. Prefer the noisy log over the quiet one; nobody is watching the terminal in real time.
+
+## Security
+
+The api container exposes manual zone-control endpoints (`POST /zones/:id/open`, `/close`, `/run`) with **no authentication** — they assume a trusted LAN. Bind the api port to LAN-only or run it behind a VPN. **Never expose the api container's port to the public internet.**
+
+## Scripts
+
+Always invoke via `bun --cwd=./api run <script>`. Never the bare `bun --cwd=./api <script>` form — see the root `CLAUDE.md` "Running package.json scripts" section.
+
+| Script | Purpose |
+|---|---|
+| `start` | Boot the API (`bun index.ts`). |
+| `dev` | Boot with `--watch` for local development. |
+| `test` | Run the test suite (Bun's native test runner — fine for backend; the bundle has no flow syntax). |
+| `type-check` | `tsc --noEmit`. Run before declaring work complete. |
+| `seed` | Seed the database from JSON fixtures (API-6). |
+| `db:generate` | Generate a migration from the current schema diff. Commit the new file in `api/drizzle/`. |
+| `db:migrate` | Apply pending migrations. |
+| `db:push` | Push the schema directly to the DB (dev only — bypasses migrations). |
+| `db:studio` | Launch Drizzle Studio against `DATABASE_URL`. |
+| `up` | `docker compose --profile tools up -d` from the api directory (brings up pgAdmin too). |
+| `down` | Tear down the stack. |
+| `logs` | Tail the api container's logs (last 100 lines, follow). |
+| `replan` | Operator script — re-run the planner from current state. |
+| `next-runs` | Operator script — list the next scheduled cycle starts. |
+| `enable-schedule` / `disable-schedule` | Toggle a named schedule active/inactive. |
+| `toggle-zone` | Manually flip a zone's relay state via HA. |
+| `notify:test` | Send a test notification through the configured HA notify service. |
+
+If a common operation needs an entry, add a script to `api/package.json` rather than running it ad-hoc — the allow-list entry `Bash(bun --cwd=./api run *)` picks new scripts up automatically.

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,1 +1,25 @@
+# Irrigo App
+
+Expo / React Native client for Irrigo — **Expo SDK 54, React Native 0.81, NativeWind, Jest**. Single-screen-at-a-time operator UI for the homeowner; talks to the `irrigo_api` backend.
+
+Shared conventions (typing, shell rules, ticket workflow, git workflow) live in the root `CLAUDE.md`. Detailed frontend conventions (component structure, hooks, comments, NativeWind organization, testing patterns) live in `shared/CLAUDE.md`. This file holds client-only guidance and the scripts table.
+
 @AGENTS.md
+
+## Scripts
+
+Always invoke via `bun --cwd=./app run <script>`. Never the bare `bun --cwd=./app <script>` form — see the root `CLAUDE.md` "Running package.json scripts" section. In particular, **`bun --cwd=./app test` is broken** for this project: it triggers Bun's native test runner, which can't parse React Native's flow type syntax and dies on the first import of `react-native`. Use `bun --cwd=./app run test` so Bun dispatches to the `test` script and Jest takes over.
+
+| Script | Purpose |
+|---|---|
+| `start` | `expo start` — launch Metro and the Expo dev tools. |
+| `android` | `expo run:android` — build & run on a connected Android device/emulator. |
+| `ios` | `expo run:ios` — build & run on an iOS simulator. |
+| `web` | `expo start --web` — run the app in the browser. |
+| `test` | `jest` — run the test suite. Use `run test`, not bare `test`. |
+| `test:watch` | `jest --watch`. |
+| `typecheck` | `tsc --noEmit`. Run before declaring work complete. |
+| `lint` | `expo lint`. |
+| `reset-project` | Reset the Expo project scaffolding (rarely used). |
+
+If a common operation needs an entry, add a script to `app/package.json` rather than running it ad-hoc — the allow-list entry `Bash(bun --cwd=./app run *)` picks new scripts up automatically.


### PR DESCRIPTION
## Ticket

[API-62](http://192.168.2.100:7123/irrigo/browse/API-62/) Split CLAUDE.md into root (shared), api/, and app/ scoped files.

## Summary

- Trims the root `CLAUDE.md` down to shared conventions only — repo overview, local-dev setup, general code guidelines (no Drizzle / daemon-specific language), shell rules, testing principles, tickets, git workflow, worktrees.
- New `api/CLAUDE.md` holds backend-specific guidance: the `## Database` section (verbatim move), the `## Security` LAN-only zone-control warning (verbatim move), Drizzle `created_at` / `updated_at` rule, daemon-logging framing, and a full `## Scripts` table for every entry in `api/package.json`.
- Replaces `app/CLAUDE.md` (previously a single-line `@AGENTS.md` import) with a header, the `@AGENTS.md` import (Expo versioned-docs reminder is preserved), a pointer to `shared/CLAUDE.md` for detailed frontend conventions, and a `## Scripts` table for `app/package.json`. The table explicitly flags that bare `bun --cwd=./app test` is broken (Bun's native runner can't parse RN flow syntax) and mandates `bun --cwd=./app run test`.
- Adds a new `## Running package.json scripts` section to the root `CLAUDE.md` enforcing the canonical `bun --cwd=./<dir> run <script>` shape and the "if it isn't a script yet, add it before running" rule.
- Adds `Bash(bun --cwd=./app run *)` to `.claude/settings.json`, mirroring the existing `./api` allow entry — any new script in either subproject is now auto-covered.
- Updates `## Tickets` and `## Git workflow` in the root to acknowledge both `irrigo_api` (`API-XXX`) and `irrigo_app` (`APP-XXX`).

## Test plan

- Docs/config-only change — no `.test.ts` added.
- Smoke: `bun --cwd=./app run typecheck` and `bun --cwd=./app run test` both pass via the canonical invocation form (no permission prompts).
- The `bun --cwd=./api run type-check` smoke surfaces a **pre-existing** failure unrelated to this PR: `expo-server-sdk` is missing from `api/node_modules` though it's in `api/bun.lock`. Stale dev-container state — `bun install` inside `api/` fixes it. Not addressed here.