### PR TITLE
[APP-12] BrandGlyph + 13 react-native-svg icons

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -33,6 +33,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-svg": "^15.15.5",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
       },
@@ -714,6 +715,8 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "bplist-creator": ["bplist-creator@0.1.0", "", { "dependencies": { "stream-buffers": "2.2.x" } }, "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg=="],
 
     "bplist-parser": ["bplist-parser@0.3.2", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ=="],
@@ -810,6 +813,12 @@
 
     "css-in-js-utils": ["css-in-js-utils@3.1.0", "", { "dependencies": { "hyphenate-style-name": "^1.0.3" } }, "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A=="],
 
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
@@ -868,7 +877,15 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
     "domexception": ["domexception@4.0.0", "", { "dependencies": { "webidl-conversions": "^7.0.0" } }, "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
@@ -1402,6 +1419,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
+
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
@@ -1489,6 +1508,8 @@
     "npm-package-arg": ["npm-package-arg@11.0.3", "", { "dependencies": { "hosted-git-info": "^7.0.0", "proc-log": "^4.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^5.0.0" } }, "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "nullthrows": ["nullthrows@1.1.1", "", {}, "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="],
 
@@ -1655,6 +1676,8 @@
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 
     "react-native-screens": ["react-native-screens@4.16.0", "", { "dependencies": { "react-freeze": "^1.0.0", "react-native-is-edge-to-edge": "^1.2.1", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q=="],
+
+    "react-native-svg": ["react-native-svg@15.15.5", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w=="],
 
     "react-native-web": ["react-native-web@0.21.2", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@react-native/normalize-colors": "^0.74.1", "fbjs": "^3.0.4", "inline-style-prefixer": "^7.0.1", "memoize-one": "^6.0.0", "nullthrows": "^1.1.1", "postcss-value-parser": "^4.2.0", "styleq": "^0.1.3" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg=="],
 
@@ -2146,7 +2169,11 @@
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "css-tree/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "cssstyle/cssom": ["cssom@0.3.8", "", {}, "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "domexception/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 

--- a/app/components/brand-glyph.test.tsx
+++ b/app/components/brand-glyph.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { BrandGlyph } from './brand-glyph';
+
+describe('BrandGlyph', () => {
+    it('renders under the default `Irrigo` accessibility label.', () => {
+        render(<BrandGlyph />);
+
+        expect(screen.getByLabelText('Irrigo')).toBeOnTheScreen();
+    });
+
+    it('honors a custom accessibility label.', () => {
+        render(<BrandGlyph accessibilityLabel='Irrigo brand mark' />);
+
+        expect(screen.getByLabelText('Irrigo brand mark')).toBeOnTheScreen();
+    });
+
+    it('reflects the size prop on the rendered SVG.', () => {
+        render(<BrandGlyph size={64} />);
+
+        const svg = screen.getByLabelText('Irrigo');
+        expect(svg.props.width).toBe(64);
+        expect(svg.props.height).toBe(64);
+    });
+});

--- a/app/components/brand-glyph.tsx
+++ b/app/components/brand-glyph.tsx
@@ -1,0 +1,34 @@
+import Svg, { Ellipse, Path } from 'react-native-svg';
+
+/**
+ * Props for the Irrigo brand glyph (sprinkler arc + droplet + soil ellipse).
+ * Colors are fixed brand artwork and not configurable.
+ */
+export type BrandGlyphProps = {
+    /** Optional. Pixel size for the rendered square. Defaults to 28. */
+    size?: number;
+
+    /** Optional. Accessibility label. Defaults to `Irrigo`. */
+    accessibilityLabel?: string;
+};
+
+const SOIL_FILL = '#1B231F';
+const SOIL_STROKE = '#344239';
+const ACCENT = '#6FE39B';
+
+/**
+ * The Irrigo brand mark — a dashed sprinkler arc spraying down to a droplet
+ * over a soil ellipse. Scales as a single 84×84 vector unit; pass `size`
+ * to control the rendered square. Colors are fixed (matches the design
+ * source); do not theme this glyph.
+ */
+export function BrandGlyph({ size = 28, accessibilityLabel = 'Irrigo' }: BrandGlyphProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 84 84' fill='none' accessibilityLabel={accessibilityLabel}>
+            <Ellipse cx={42} cy={64} rx={32} ry={6} fill={SOIL_FILL} stroke={SOIL_STROKE} strokeWidth={1.2} />
+            <Path d='M10 46 A 32 30 0 0 1 74 46' stroke={ACCENT} strokeWidth={2.4} strokeLinecap='round' fill='none' strokeDasharray='2.4 4' />
+            <Path d='M42 46 L 42 60' stroke={ACCENT} strokeWidth={2.4} strokeLinecap='round' />
+            <Path d='M42 22 C 36 30, 36 38, 42 40 C 48 38, 48 30, 42 22 Z' fill={ACCENT} />
+        </Svg>
+    );
+}

--- a/app/components/icons.test.tsx
+++ b/app/components/icons.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react-native';
+import type { ComponentType } from 'react';
+
+import {
+    Bell,
+    Cal,
+    ChevL,
+    ChevR,
+    Drop,
+    History,
+    Home,
+    type IconProps,
+    Menu,
+    More,
+    Play,
+    Refresh,
+    X,
+    Zone,
+} from './icons';
+
+const icons: ReadonlyArray<readonly [string, ComponentType<IconProps>]> = [
+    ['Drop', Drop],
+    ['ChevR', ChevR],
+    ['ChevL', ChevL],
+    ['Refresh', Refresh],
+    ['Bell', Bell],
+    ['More', More],
+    ['Play', Play],
+    ['Zone', Zone],
+    ['Cal', Cal],
+    ['History', History],
+    ['Home', Home],
+    ['Menu', Menu],
+    ['X', X],
+];
+
+describe('Irrigo icons', () => {
+    describe.each(icons)('%s', (name, Component) => {
+        it('renders under the supplied accessibility label.', () => {
+            render(<Component accessibilityLabel={name} />);
+
+            expect(screen.getByLabelText(name)).toBeOnTheScreen();
+        });
+    });
+
+    it('renders Drop at the default 16px size.', () => {
+        render(<Drop accessibilityLabel='Drop' />);
+
+        const svg = screen.getByLabelText('Drop');
+        expect(svg.props.width).toBe(16);
+        expect(svg.props.height).toBe(16);
+    });
+
+    it('renders Drop at the explicit size override.', () => {
+        render(<Drop size={40} accessibilityLabel='Drop' />);
+
+        const svg = screen.getByLabelText('Drop');
+        expect(svg.props.width).toBe(40);
+        expect(svg.props.height).toBe(40);
+    });
+
+    it('applies the color prop to the stroke of a stroke-based icon.', () => {
+        render(<Drop color='#6FE39B' accessibilityLabel='Drop' />);
+
+        const svg = screen.getByLabelText('Drop');
+        expect(svg.props.stroke).toBe('#6FE39B');
+        expect(svg.props.fill).toBe('none');
+    });
+
+    it('applies the color prop to the fill of a fill-based icon.', () => {
+        render(<More color='#FF6B7B' accessibilityLabel='More' />);
+
+        const svg = screen.getByLabelText('More');
+        expect(svg.props.fill).toBe('#FF6B7B');
+    });
+
+    it('honors a custom strokeWidth on a stroke-based icon.', () => {
+        render(<Bell strokeWidth={2.5} accessibilityLabel='Bell' />);
+
+        const svg = screen.getByLabelText('Bell');
+        expect(svg.props.strokeWidth).toBe(2.5);
+    });
+
+    it('uses the source 1.6 stroke weight by default on the chevrons, menu, and close icons.', () => {
+        render(
+            <>
+                <ChevR accessibilityLabel='ChevR' />
+                <ChevL accessibilityLabel='ChevL' />
+                <Menu accessibilityLabel='Menu' />
+                <X accessibilityLabel='X' />
+            </>,
+        );
+
+        expect(screen.getByLabelText('ChevR').props.strokeWidth).toBe(1.6);
+        expect(screen.getByLabelText('ChevL').props.strokeWidth).toBe(1.6);
+        expect(screen.getByLabelText('Menu').props.strokeWidth).toBe(1.6);
+        expect(screen.getByLabelText('X').props.strokeWidth).toBe(1.6);
+    });
+
+    it('uses the source 1.4 stroke weight by default on the rest of the stroke-based icons.', () => {
+        render(
+            <>
+                <Drop accessibilityLabel='Drop' />
+                <Refresh accessibilityLabel='Refresh' />
+                <Bell accessibilityLabel='Bell' />
+                <Zone accessibilityLabel='Zone' />
+                <Cal accessibilityLabel='Cal' />
+                <History accessibilityLabel='History' />
+                <Home accessibilityLabel='Home' />
+            </>,
+        );
+
+        for (const name of ['Drop', 'Refresh', 'Bell', 'Zone', 'Cal', 'History', 'Home']) {
+            expect(screen.getByLabelText(name).props.strokeWidth).toBe(1.4);
+        }
+    });
+});

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -1,0 +1,131 @@
+import Svg, { Circle, Path, Rect } from 'react-native-svg';
+
+/**
+ * Shared shape for every icon in the Irrigo icon set. Mirrors the design
+ * source's Lucide-style recipe: 16×16 viewBox, stroke-based geometry with
+ * an optional 1.4–1.6 stroke width, all coloring controlled via props
+ * (no CSS `currentColor` — React Native doesn't propagate it).
+ */
+export type IconProps = {
+    /** Optional. Pixel size for the rendered square. Defaults to 16. */
+    size?: number;
+
+    /** Optional. Stroke or fill color. Defaults to the `fg` token hex (`#ECF1ED`). */
+    color?: string;
+
+    /** Optional. Override stroke width on stroke-based icons. Ignored by fill-based icons (`More`, `Play`). */
+    strokeWidth?: number;
+
+    /** Optional. Accessibility label exposed to assistive tech. Omit for decorative icons paired with text. */
+    accessibilityLabel?: string;
+};
+
+const DEFAULT_COLOR = '#ECF1ED';
+const DEFAULT_SIZE = 16;
+
+export function Drop({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M8 1.5 C 4 6, 3 9, 3 11 a 5 5 0 0 0 10 0 C 13 9, 12 6, 8 1.5 Z' />
+        </Svg>
+    );
+}
+
+export function ChevR({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.6, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M6 3 l 5 5 l -5 5' />
+        </Svg>
+    );
+}
+
+export function ChevL({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.6, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M10 3 l -5 5 l 5 5' />
+        </Svg>
+    );
+}
+
+export function Refresh({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M13 8 a 5 5 0 1 1 -1.5 -3.5 M13 2 v 3 h -3' />
+        </Svg>
+    );
+}
+
+export function Bell({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M4 11 V 7 a 4 4 0 0 1 8 0 v 4 M3 11 h 10 M6.5 13 a 1.5 1.5 0 0 0 3 0' />
+        </Svg>
+    );
+}
+
+export function More({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill={color} accessibilityLabel={accessibilityLabel}>
+            <Circle cx={3} cy={8} r={1} />
+            <Circle cx={8} cy={8} r={1} />
+            <Circle cx={13} cy={8} r={1} />
+        </Svg>
+    );
+}
+
+export function Play({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill={color} accessibilityLabel={accessibilityLabel}>
+            <Path d='M4 3 L 13 8 L 4 13 Z' />
+        </Svg>
+    );
+}
+
+export function Zone({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M3 4 C 4 2, 12 2, 13 5 C 14 8, 12 12, 8 13 C 4 13, 2 9, 3 4 Z' />
+        </Svg>
+    );
+}
+
+export function Cal({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' accessibilityLabel={accessibilityLabel}>
+            <Rect x={2.5} y={3.5} width={11} height={10} rx={1.5} />
+            <Path d='M2.5 6 H 13.5 M5 2 v 3 M11 2 v 3' />
+        </Svg>
+    );
+}
+
+export function History({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M2 8 a 6 6 0 1 0 2 -4.3 M2 3 v 3 h 3 M8 5 v 3 l 2 1.5' />
+        </Svg>
+    );
+}
+
+export function Home({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M2.5 7.5 L 8 3 L 13.5 7.5 V 13 H 2.5 Z' />
+        </Svg>
+    );
+}
+
+export function Menu({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.6, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M2.5 4.5 H 13.5 M2.5 8 H 13.5 M2.5 11.5 H 9.5' />
+        </Svg>
+    );
+}
+
+export function X({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.6, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' accessibilityLabel={accessibilityLabel}>
+            <Path d='M4 4 L 12 12 M12 4 L 4 12' />
+        </Svg>
+    );
+}

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-svg": "^15.15.5",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1"
   },


### PR DESCRIPTION
## Ticket

[APP-12](http://192.168.2.100:7123/irrigo/browse/APP-12/) BrandGlyph + icon set as RN SVG components.

## Summary

- Adds `react-native-svg@^15.15.5` as an `app/` dependency (Jest's `transformIgnorePatterns` already listed it, but the package wasn't actually installed).
- `app/components/icons.tsx` exports 13 named icons — `Drop, ChevR, ChevL, Refresh, Bell, More, Play, Zone, Cal, History, Home, Menu, X` — ported verbatim from the design source at `app/design/irrigo/project/ui_kit/components.jsx` (the `Icon` map). All share a single `IconProps` shape: `size?` (defaults 16), `color?` (defaults `#ECF1ED` / `fg` token), `strokeWidth?` (defaults 1.4 or 1.6 to match the source per-icon), `accessibilityLabel?`. No CSS `currentColor` — React Native doesn't propagate it; callers pass explicit hex (typically a design-token color).
- `app/components/brand-glyph.tsx` exports the Irrigo brand mark — soil ellipse + dashed sprinkler arc + droplet — from `Mobile.jsx:244-254`. Fixed brand colors (not themeable); accepts `size` (defaults 28) and `accessibilityLabel` (defaults `Irrigo`).
- 23 new tests across `icons.test.tsx` and `brand-glyph.test.tsx`. Suite total: 49/49 passing.