### PR TITLE
[APP-21] Root layout: dark theme + canvas background + light status bar

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "irrigo",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "dark",
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true
@@ -36,7 +36,7 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff",
           "dark": {
-            "backgroundColor": "#000000"
+            "backgroundColor": "#06090A"
           }
         }
       ]

--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react-native';
+
+const mockUseFonts = jest.fn();
+const mockHideAsync = jest.fn(() => Promise.resolve());
+const mockStatusBar = jest.fn();
+
+jest.mock('expo-font', () => ({
+    useFonts: (...args: unknown[]) => mockUseFonts(...args),
+}));
+
+jest.mock('expo-splash-screen', () => ({
+    preventAutoHideAsync: jest.fn(() => Promise.resolve()),
+    hideAsync: () => mockHideAsync(),
+}));
+
+jest.mock('expo-status-bar', () => ({
+    StatusBar: (props: { style?: string }) => {
+        mockStatusBar(props);
+        return null;
+    },
+}));
+
+jest.mock('expo-router', () => {
+    const { View } = require('react-native');
+    const Stack = ({ children }: { children?: React.ReactNode }) => (
+        <View accessibilityLabel='Stack'>{children}</View>
+    );
+    Stack.Screen = () => null;
+    return { Stack };
+});
+
+jest.mock('react-native-reanimated', () => ({}));
+
+import RootLayout, { irrigoDarkTheme } from './_layout';
+
+describe('RootLayout', () => {
+    beforeEach(() => {
+        mockUseFonts.mockReturnValue([true, null]);
+        mockStatusBar.mockClear();
+        mockHideAsync.mockClear();
+    });
+
+    it('renders the Irrigo canvas background under the navigation stack once fonts load.', () => {
+        render(<RootLayout />);
+
+        expect(screen.getByLabelText('Irrigo canvas')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Stack')).toBeOnTheScreen();
+    });
+
+    it('configures the status bar with the light style for the dark canvas.', () => {
+        render(<RootLayout />);
+
+        expect(mockStatusBar).toHaveBeenCalledWith(expect.objectContaining({ style: 'light' }));
+    });
+
+    it('exposes a dark-only theme whose background matches the canvas hex.', () => {
+        expect(irrigoDarkTheme.dark).toBe(true);
+        expect(irrigoDarkTheme.colors.background).toBe('#06090A');
+    });
+});

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,11 +1,11 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, ThemeProvider, type Theme } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import 'react-native-reanimated';
 
+import { CanvasBackground } from '@/components/canvas-background';
 import { FontLoader } from '@/components/font-loader';
-import { useColorScheme } from '@/hooks/use-color-scheme';
 import '../global.css';
 
 // Hold the native splash from auto-hiding so FontLoader can keep it visible
@@ -17,21 +17,34 @@ SplashScreen.preventAutoHideAsync().catch(err => {
 });
 
 export const unstable_settings = {
-  anchor: '(tabs)',
+    anchor: '(tabs)',
+};
+
+// Dark-only React Navigation theme. Irrigo has no light mode by design, so
+// we don't branch on `useColorScheme()` — the OS scheme is pinned to dark
+// via `userInterfaceStyle: "dark"` in app.json. Background overrides the
+// default `#000` so screens default to the canvas hex when they don't paint
+// their own backdrop.
+export const irrigoDarkTheme: Theme = {
+    ...DarkTheme,
+    colors: {
+        ...DarkTheme.colors,
+        background: '#06090A',
+    },
 };
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
-
-  return (
-    <FontLoader>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </FontLoader>
-  );
+    return (
+        <FontLoader>
+            <ThemeProvider value={irrigoDarkTheme}>
+                <CanvasBackground>
+                    <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: 'transparent' } }}>
+                        <Stack.Screen name='(tabs)' />
+                        <Stack.Screen name='modal' options={{ presentation: 'modal', title: 'Modal' }} />
+                    </Stack>
+                </CanvasBackground>
+                <StatusBar style='light' />
+            </ThemeProvider>
+        </FontLoader>
+    );
 }

--- a/app/components/canvas-background.test.tsx
+++ b/app/components/canvas-background.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet, Text } from 'react-native';
+
+import { CanvasBackground } from './canvas-background';
+
+describe('CanvasBackground', () => {
+    it('renders under the default `Irrigo canvas` accessibility label and passes children through.', () => {
+        render(
+            <CanvasBackground>
+                <Text>Welcome to Irrigo.</Text>
+            </CanvasBackground>,
+        );
+
+        expect(screen.getByLabelText('Irrigo canvas')).toBeOnTheScreen();
+        expect(screen.getByText('Welcome to Irrigo.')).toBeOnTheScreen();
+    });
+
+    it('honors a custom accessibility label.', () => {
+        render(
+            <CanvasBackground accessibilityLabel='canvas root'>
+                <Text>child</Text>
+            </CanvasBackground>,
+        );
+
+        expect(screen.getByLabelText('canvas root')).toBeOnTheScreen();
+    });
+
+    it('paints the canvas base color (#06090A) on the root view.', () => {
+        render(
+            <CanvasBackground>
+                <Text>child</Text>
+            </CanvasBackground>,
+        );
+
+        const root = screen.getByLabelText('Irrigo canvas');
+        const style = StyleSheet.flatten(root.props.style) as { backgroundColor?: string };
+        expect(style.backgroundColor).toBe('#06090A');
+    });
+});

--- a/app/components/canvas-background.tsx
+++ b/app/components/canvas-background.tsx
@@ -16,13 +16,10 @@ export type CanvasBackgroundProps = PropsWithChildren<{
 }>;
 
 const BACKGROUND_COLOR = colors.bg;
-const GREEN_GLOW = colors.accent;
-const BLUE_GLOW = colors.info;
-
-// Alphas are intentionally local — they describe this component's glow recipe,
-// not a generic design-system token. The hex values above come from Tailwind.
-const GREEN_GLOW_ALPHA = 0.07;
-const BLUE_GLOW_ALPHA = 0.04;
+// Soft canvas-backdrop tints shared with the modal scrim (grass-glow-3) and
+// info-tinted surfaces (water-glow). See `tailwind.config.js`.
+const GREEN_GLOW = colors['grass-glow-3'];
+const BLUE_GLOW = colors['water-glow'];
 
 const GREEN_GRADIENT_ID = 'irrigoCanvasGreenGlow';
 const BLUE_GRADIENT_ID = 'irrigoCanvasBlueGlow';
@@ -40,11 +37,11 @@ export function CanvasBackground({ accessibilityLabel = 'Irrigo canvas', childre
             <Svg style={StyleSheet.absoluteFill} width='100%' height='100%' pointerEvents='none'>
                 <Defs>
                     <RadialGradient id={GREEN_GRADIENT_ID} cx='20%' cy='-5%' r='50%' fx='20%' fy='-5%'>
-                        <Stop offset='0%' stopColor={GREEN_GLOW} stopOpacity={GREEN_GLOW_ALPHA} />
+                        <Stop offset='0%' stopColor={GREEN_GLOW} />
                         <Stop offset='100%' stopColor={GREEN_GLOW} stopOpacity={0} />
                     </RadialGradient>
                     <RadialGradient id={BLUE_GRADIENT_ID} cx='90%' cy='50%' r='50%' fx='90%' fy='50%'>
-                        <Stop offset='0%' stopColor={BLUE_GLOW} stopOpacity={BLUE_GLOW_ALPHA} />
+                        <Stop offset='0%' stopColor={BLUE_GLOW} />
                         <Stop offset='100%' stopColor={BLUE_GLOW} stopOpacity={0} />
                     </RadialGradient>
                 </Defs>

--- a/app/components/canvas-background.tsx
+++ b/app/components/canvas-background.tsx
@@ -2,6 +2,11 @@ import type { PropsWithChildren } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Svg, { Defs, RadialGradient, Rect, Stop } from 'react-native-svg';
 
+const tailwindConfig = require('../tailwind.config.js') as {
+    theme: { extend: { colors: Record<string, string> } };
+};
+const colors = tailwindConfig.theme.extend.colors;
+
 /**
  * Props for the Irrigo canvas background.
  */
@@ -10,12 +15,13 @@ export type CanvasBackgroundProps = PropsWithChildren<{
     accessibilityLabel?: string;
 }>;
 
-const BACKGROUND_COLOR = '#06090A';
+const BACKGROUND_COLOR = colors.bg;
+const GREEN_GLOW = colors.accent;
+const BLUE_GLOW = colors.info;
 
-const GREEN_GLOW = '#6FE39B';
+// Alphas are intentionally local — they describe this component's glow recipe,
+// not a generic design-system token. The hex values above come from Tailwind.
 const GREEN_GLOW_ALPHA = 0.07;
-
-const BLUE_GLOW = '#7CD4FB';
 const BLUE_GLOW_ALPHA = 0.04;
 
 const GREEN_GRADIENT_ID = 'irrigoCanvasGreenGlow';

--- a/app/components/canvas-background.tsx
+++ b/app/components/canvas-background.tsx
@@ -1,0 +1,61 @@
+import type { PropsWithChildren } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Svg, { Defs, RadialGradient, Rect, Stop } from 'react-native-svg';
+
+/**
+ * Props for the Irrigo canvas background.
+ */
+export type CanvasBackgroundProps = PropsWithChildren<{
+    /** Optional. Accessibility label for the canvas root. Defaults to `Irrigo canvas`. */
+    accessibilityLabel?: string;
+}>;
+
+const BACKGROUND_COLOR = '#06090A';
+
+const GREEN_GLOW = '#6FE39B';
+const GREEN_GLOW_ALPHA = 0.07;
+
+const BLUE_GLOW = '#7CD4FB';
+const BLUE_GLOW_ALPHA = 0.04;
+
+const GREEN_GRADIENT_ID = 'irrigoCanvasGreenGlow';
+const BLUE_GRADIENT_ID = 'irrigoCanvasBlueGlow';
+
+/**
+ * The Irrigo dark canvas backdrop — `#06090A` base painted under two soft
+ * radial gradients (green at top-left, blue at mid-right) that mirror the
+ * `ui_kit/index.html` canvas recipe from the design source. The gradient
+ * SVG is positioned absolutely behind children and ignores touches so it
+ * never intercepts taps.
+ */
+export function CanvasBackground({ accessibilityLabel = 'Irrigo canvas', children }: CanvasBackgroundProps) {
+    return (
+        <View style={styles.canvas} accessibilityLabel={accessibilityLabel}>
+            <Svg style={StyleSheet.absoluteFill} width='100%' height='100%' pointerEvents='none'>
+                <Defs>
+                    <RadialGradient id={GREEN_GRADIENT_ID} cx='20%' cy='-5%' r='50%' fx='20%' fy='-5%'>
+                        <Stop offset='0%' stopColor={GREEN_GLOW} stopOpacity={GREEN_GLOW_ALPHA} />
+                        <Stop offset='100%' stopColor={GREEN_GLOW} stopOpacity={0} />
+                    </RadialGradient>
+                    <RadialGradient id={BLUE_GRADIENT_ID} cx='90%' cy='50%' r='50%' fx='90%' fy='50%'>
+                        <Stop offset='0%' stopColor={BLUE_GLOW} stopOpacity={BLUE_GLOW_ALPHA} />
+                        <Stop offset='100%' stopColor={BLUE_GLOW} stopOpacity={0} />
+                    </RadialGradient>
+                </Defs>
+                <Rect width='100%' height='100%' fill={`url(#${GREEN_GRADIENT_ID})`} />
+                <Rect width='100%' height='100%' fill={`url(#${BLUE_GRADIENT_ID})`} />
+            </Svg>
+            <View style={styles.content}>{children}</View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    canvas: {
+        flex: 1,
+        backgroundColor: BACKGROUND_COLOR,
+    },
+    content: {
+        flex: 1,
+    },
+});

--- a/app/jest-style-mock.js
+++ b/app/jest-style-mock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,9 @@
     "setupFilesAfterEnv": [
       "<rootDir>/jest-setup.ts"
     ],
+    "moduleNameMapper": {
+      "\\.css$": "<rootDir>/jest-style-mock.js"
+    },
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|react-native-css-interop))"
     ]

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -37,10 +37,12 @@ module.exports = {
                 'grass-900': '#0F2A1C',
                 'grass-glow': 'rgba(111, 227, 155, 0.18)',
                 'grass-glow-2': 'rgba(111, 227, 155, 0.06)',
+                'grass-glow-3': 'rgba(111, 227, 155, 0.07)',
 
                 // Accent supplemental.
                 'water-500': '#7CD4FB',
                 'water-700': '#2E7FA8',
+                'water-glow': 'rgba(124, 212, 251, 0.04)',
                 'amber-500': '#FFBE6B',
                 'amber-700': '#B07B2A',
                 'rose-500': '#FF6B7B',

--- a/app/tailwind.config.test.ts
+++ b/app/tailwind.config.test.ts
@@ -46,6 +46,12 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
             expect(colors['grass-glow']).toBe('rgba(111, 227, 155, 0.18)');
         });
 
+        it('exposes the soft-glow tints used by canvas, modal, and info surfaces.', () => {
+            expect(colors['grass-glow-2']).toBe('rgba(111, 227, 155, 0.06)');
+            expect(colors['grass-glow-3']).toBe('rgba(111, 227, 155, 0.07)');
+            expect(colors['water-glow']).toBe('rgba(124, 212, 251, 0.04)');
+        });
+
         it('exposes the accent-supplemental ramps (water / amber / rose / moon).', () => {
             expect(colors['water-500']).toBe('#7CD4FB');
             expect(colors['amber-500']).toBe('#FFBE6B');


### PR DESCRIPTION
## Ticket

[APP-21](http://192.168.2.100:7123/irrigo/browse/APP-21/) Expo Router root layout — dark theme, safe areas, status bar.

## Summary

- `app/components/canvas-background.tsx` — new full-screen wrapper that paints the `#06090A` canvas and overlays two soft radial gradients (green at top-left, blue at mid-right) via `react-native-svg`'s `RadialGradient`. Mirrors the canvas recipe in `app/design/irrigo/project/ui_kit/index.html`. The SVG layer has `pointerEvents='none'` so it never intercepts taps.
- `app/app/_layout.tsx` — drops the conditional `useColorScheme` / `DefaultTheme` branch; exports `irrigoDarkTheme` (DarkTheme with `colors.background: '#06090A'`); wraps the Stack in `<CanvasBackground>`; sets `Stack` `screenOptions.contentStyle.backgroundColor: 'transparent'` so the canvas shows through screens that don't paint their own; pins `<StatusBar style='light' />`.
- `app/app.json` — `userInterfaceStyle: 'automatic'` → `'dark'` so the OS color scheme is pinned to dark inside the app; splash `dark.backgroundColor: '#000000'` → `'#06090A'` so the launch handoff is seamless (no flash from black to the canvas hex).
- `app/package.json` jest config gains a `moduleNameMapper` stubbing `*.css` imports (needed for `_layout.test.tsx`, which previously couldn't parse `global.css`).
- 6 new tests across `canvas-background.test.tsx` (3) and `_layout.test.tsx` (3). Suite total: 55/55 passing.

## Test plan

- [x] Type-check: `bun --cwd=./app run typecheck` — passes.
- [x] Tests: `bun --cwd=./app run test` — 7 suites, 55/55 passing.
- [ ] On-device smoke: rebuild the Expo dev client / refresh Metro and confirm: light status-bar icons over dark canvas, faint green tint top-left + faint blue mid-right, no white flash from splash → app handoff. The existing template tabs (`Home` / `Explore`) still paint their own `ThemedView` backgrounds — expected; future screen tickets replace them.