### PR TITLE
[APP-13] Button primitive: primary/secondary/ghost × sm/default/lg + icon-only

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -37,6 +37,8 @@
         "react-native-svg": "^15.15.5",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
+        "tailwind-merge": "^3.6.0",
+        "tailwind-variants": "^3.2.2",
       },
       "devDependencies": {
         "@testing-library/jest-native": "^5.4.3",
@@ -1883,6 +1885,10 @@
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
+
+    "tailwind-variants": ["tailwind-variants@3.2.2", "", { "peerDependencies": { "tailwind-merge": ">=3.0.0", "tailwindcss": "*" }, "optionalPeers": ["tailwind-merge"] }, "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 

--- a/app/components/button.test.tsx
+++ b/app/components/button.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { Button } from './button';
+import { More } from './icons';
+
+describe('Button', () => {
+    it('renders the text passed as children.', () => {
+        render(<Button>Run now</Button>);
+
+        expect(screen.getByText('Run now')).toBeOnTheScreen();
+    });
+
+    it('calls onPress when the user taps the button.', () => {
+        const onPress = jest.fn();
+
+        render(<Button onPress={onPress}>Run now</Button>);
+        fireEvent.press(screen.getByText('Run now'));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onPress when the button is disabled.', () => {
+        const onPress = jest.fn();
+
+        render(
+            <Button onPress={onPress} disabled>
+                Run now
+            </Button>,
+        );
+        fireEvent.press(screen.getByText('Run now'));
+
+        expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('exposes the disabled state to assistive tech.', () => {
+        render(<Button disabled>Run now</Button>);
+
+        expect(screen.getByRole('button').props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it('reports an enabled state by default.', () => {
+        render(<Button>Run now</Button>);
+
+        expect(screen.getByRole('button').props.accessibilityState).toMatchObject({ disabled: false });
+    });
+
+    it('uses the supplied accessibility label on icon-only buttons.', () => {
+        render(
+            <Button iconOnly accessibilityLabel='More'>
+                <More accessibilityLabel='More icon' />
+            </Button>,
+        );
+
+        expect(screen.getByLabelText('More')).toBeOnTheScreen();
+        expect(screen.getByLabelText('More icon')).toBeOnTheScreen();
+    });
+
+    it.each(['primary', 'secondary', 'ghost'] as const)('renders the %s variant without crashing.', variant => {
+        render(<Button variant={variant}>Run now</Button>);
+
+        expect(screen.getByText('Run now')).toBeOnTheScreen();
+    });
+
+    it.each(['sm', 'default', 'lg'] as const)('renders the %s size without crashing.', size => {
+        render(<Button size={size}>Run now</Button>);
+
+        expect(screen.getByText('Run now')).toBeOnTheScreen();
+    });
+
+    it('renders with default props (primary / default / no iconOnly).', () => {
+        const onPress = jest.fn();
+
+        render(<Button onPress={onPress}>Run now</Button>);
+        fireEvent.press(screen.getByText('Run now'));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes icon-only children through without wrapping them in a Text node.', () => {
+        render(
+            <Button iconOnly accessibilityLabel='More options'>
+                <More accessibilityLabel='More glyph' />
+            </Button>,
+        );
+
+        // If the icon were wrapped in <Text>, React Native would crash trying
+        // to render a non-string child; the icon being queryable proves the
+        // bare-child pass-through.
+        expect(screen.getByLabelText('More glyph')).toBeOnTheScreen();
+    });
+});

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from 'react';
+import { Pressable, Text } from 'react-native';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+const button = tv({
+    slots: {
+        // Layout & Structure
+        base: 'flex-row items-center justify-center gap-2 rounded-r-2 border border-transparent active:translate-y-[0.5px]',
+        // Typography
+        label: 'font-medium font-body leading-none tracking-[-0.005em]',
+    },
+    variants: {
+        variant: {
+            primary: {
+                base: 'bg-accent active:bg-accent-deep shadow-glow-accent',
+                label: 'text-on-accent active:text-chalk-50',
+            },
+            secondary: {
+                base: 'bg-surface border-border active:bg-surface-2 active:border-border-strong',
+                label: 'text-fg',
+            },
+            ghost: {
+                base: 'active:bg-surface',
+                label: 'text-fg-soft active:text-fg',
+            },
+        },
+        size: {
+            sm: {
+                base: 'h-[32px] px-3',
+                label: 'text-[12px]',
+            },
+            default: {
+                base: 'h-[44px] px-[18px]',
+                label: 'text-[14px]',
+            },
+            lg: {
+                base: 'h-[56px] px-6',
+                label: 'text-[15px]',
+            },
+        },
+        iconOnly: {
+            true: { base: 'px-0' },
+            false: {},
+        },
+        disabled: {
+            true: { base: 'opacity-40' },
+            false: {},
+        },
+    },
+    compoundVariants: [
+        { iconOnly: true, size: 'sm', class: { base: 'w-[32px]' } },
+        { iconOnly: true, size: 'default', class: { base: 'w-[44px]' } },
+        { iconOnly: true, size: 'lg', class: { base: 'w-[56px]' } },
+    ],
+    defaultVariants: {
+        variant: 'primary',
+        size: 'default',
+        iconOnly: false,
+        disabled: false,
+    },
+});
+
+type ButtonVariants = VariantProps<typeof button>;
+
+/**
+ * Props interface for the Button primitive.
+ */
+export type ButtonProps = {
+    /** Optional. Color variant. Defaults to `primary`. */
+    variant?: ButtonVariants['variant'];
+
+    /** Optional. Pixel size of the hit target. `sm` 32px, `default` 44px, `lg` 56px. Defaults to `default`. */
+    size?: ButtonVariants['size'];
+
+    /** Optional. Renders a square icon-only button (no horizontal padding). Children should be a single icon element rather than a text label. Defaults to `false`. */
+    iconOnly?: boolean;
+
+    /** Optional. Disables the button — skips `onPress`, applies opacity 0.4, and exposes the disabled state to assistive tech. Defaults to `false`. */
+    disabled?: boolean;
+
+    /** Optional. Press handler. */
+    onPress?: () => void;
+
+    /** Optional. Accessibility label. Required when `iconOnly` is true since there is no text label for screen readers. */
+    accessibilityLabel?: string;
+
+    /** Optional. Button contents. A plain string for labeled buttons, or an icon element when `iconOnly` is true. */
+    children?: ReactNode;
+};
+
+/**
+ * The Irrigo button primitive. Mirrors the four CSS button recipes from
+ * `app/design/irrigo/project/components.css`: primary (accent fill, deep on
+ * press, glow shadow), secondary (surface fill, border, lifts to surface-2
+ * on press), and ghost (transparent, fills to surface on press). The
+ * `iconOnly` prop drops horizontal padding and locks the width equal to the
+ * height for a square hit target.
+ *
+ * Web hover styling is intentionally not wired here — the design source's
+ * "hover lifts surface" rule is web-only and reliably testing it across
+ * RN + react-native-web is out of scope for this primitive.
+ */
+export function Button({
+    variant = 'primary',
+    size = 'default',
+    iconOnly = false,
+    disabled = false,
+    onPress,
+    accessibilityLabel,
+    children,
+}: ButtonProps) {
+    const styles = button({ variant, size, iconOnly, disabled });
+    return (
+        <Pressable
+            onPress={disabled ? undefined : onPress}
+            disabled={disabled}
+            accessibilityRole='button'
+            accessibilityState={{ disabled }}
+            accessibilityLabel={accessibilityLabel}
+            className={styles.base()}
+        >
+            {iconOnly ? (
+                children
+            ) : (
+                <Text className={styles.label()} numberOfLines={1}>
+                    {children}
+                </Text>
+            )}
+        </Pressable>
+    );
+}

--- a/app/package.json
+++ b/app/package.json
@@ -57,7 +57,9 @@
     "react-native-screens": "~4.16.0",
     "react-native-svg": "^15.15.5",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.5.1"
+    "react-native-worklets": "0.5.1",
+    "tailwind-merge": "^3.6.0",
+    "tailwind-variants": "^3.2.2"
   },
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.3",


### PR DESCRIPTION
## Ticket

[APP-13](http://192.168.2.100:7123/irrigo/browse/APP-13/) Button system (primary / secondary / ghost / icon × sizes).

## Summary

- Adds `tailwind-variants` (and its peer `tailwind-merge`) to `app/`. This is the first variant-bearing primitive in the codebase — sets the pattern for future ones (Badge, Battery, AlertRow, etc.) per `shared/CLAUDE.md`'s mandate.
- `app/components/button.tsx` exports `Button` with three variants (`primary` / `secondary` / `ghost`), three sizes (`sm` / `default` / `lg`), `iconOnly` shape modifier, and `disabled` state — all composed via `tv()` slots (`base` Pressable + `label` Text). Mirrors the recipes in `app/design/irrigo/project/components.css`: primary fills `accent` with the `glow-accent` shadow and shifts to `accent-deep` on press, secondary fills `surface` and lifts to `surface-2` on press, ghost is transparent until pressed. All variants nudge 0.5px down on press via NativeWind's `active:translate-y-[0.5px]`.
- `iconOnly` drops horizontal padding and locks width to height (32 / 44 / 56 px square targets), and bypasses the inner `<Text>` wrapper so consumers can drop an icon element from APP-12 straight in.
- Disabled state sets opacity to 0.4, blocks `onPress`, and exposes `accessibilityState.disabled = true` to assistive tech.
- `danger` variant is intentionally out of scope (paired with the AlertRow work in APP-19 per the ticket).
- Web hover styling (`hover:` modifier) deferred — RN doesn't expose hover; reliably wiring it through react-native-web is out of scope here. Documented in the component JSDoc.
- 14 new test executions across 11 assertions (render, onPress, disabled, accessibility state, all 3 variants, all 3 sizes, default-props, icon child pass-through). Suite total: 130/130 passing.

## Test plan

- [x] Type-check: `bun --cwd=./app run typecheck` — passes.
- [x] Tests: `bun --cwd=./app run test` — 27 suites, 130/130 passing.
- [ ] On-device smoke deferred — no screen renders the button yet (APP-22 / APP-26 land that).