### PR TITLE
[APP-14] Badge primitive (neutral / active / warn / danger / info)

### DIFF
--- a/app/components/badge/.test.tsx
+++ b/app/components/badge/.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet, View } from 'react-native';
+
+import { Badge, type BadgeTone } from '.';
+
+const TONE_EXPECTATIONS: Readonly<Record<BadgeTone, { text: string; border: string; dot: string }>> = {
+    // Neutral is the one case where the dot deliberately stays muted while
+    // the label text reads fg-soft — every other tone matches dot to text.
+    neutral: { text: '#C7CFC9', border: '#232E29', dot: '#8A9690' },
+    active: { text: '#6FE39B', border: 'rgba(111, 227, 155, 0.4)', dot: '#6FE39B' },
+    warn: { text: '#FFBE6B', border: 'rgba(255, 190, 107, 0.4)', dot: '#FFBE6B' },
+    danger: { text: '#FF6B7B', border: 'rgba(255, 107, 123, 0.4)', dot: '#FF6B7B' },
+    info: { text: '#7CD4FB', border: 'rgba(124, 212, 251, 0.4)', dot: '#7CD4FB' },
+};
+
+function findDotSibling(container: ReturnType<typeof render>['root']) {
+    // The dot is a 6×6 View sibling of the text; we identify it by its size
+    // since it has no text or accessibility label of its own.
+    return container.findAll(node => {
+        if (node.type !== View) return false;
+        const style = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+            | { width?: number; height?: number }
+            | undefined;
+        return style?.width === 6 && style?.height === 6;
+    });
+}
+
+describe('Badge', () => {
+    it('renders the children text.', () => {
+        render(<Badge>Active</Badge>);
+
+        expect(screen.getByText('Active')).toBeOnTheScreen();
+    });
+
+    it('renders the dot by default.', () => {
+        const { root } = render(<Badge>Active</Badge>);
+
+        expect(findDotSibling(root)).toHaveLength(1);
+    });
+
+    it('hides the dot when `dot={false}`.', () => {
+        const { root } = render(<Badge dot={false}>Active</Badge>);
+
+        expect(findDotSibling(root)).toHaveLength(0);
+    });
+
+    it.each(Object.entries(TONE_EXPECTATIONS) as ReadonlyArray<[BadgeTone, { text: string; border: string; dot: string }]>)(
+        'applies the %s tone palette to the container border, dot, and label color.',
+        (tone, expected) => {
+            const { root } = render(<Badge tone={tone}>Label</Badge>);
+
+            const container = screen.getByLabelText('Label');
+            const label = screen.getByText('Label');
+            const dot = findDotSibling(root)[0];
+
+            const containerStyle = StyleSheet.flatten(container.props.style) as { borderColor?: string };
+            const textStyle = StyleSheet.flatten(label.props.style) as { color?: string };
+            const dotStyle = StyleSheet.flatten(dot?.props.style) as { backgroundColor?: string };
+
+            expect(containerStyle.borderColor).toBe(expected.border);
+            expect(textStyle.color).toBe(expected.text);
+            expect(dotStyle.backgroundColor).toBe(expected.dot);
+        },
+    );
+
+    it(`adds a green box-shadow on the dot only for the 'active' tone.`, () => {
+        const { root: activeRoot, rerender } = render(<Badge tone='active'>Running</Badge>);
+
+        const activeDot = findDotSibling(activeRoot)[0];
+        const activeDotStyle = StyleSheet.flatten(activeDot?.props.style) as { boxShadow?: string };
+        expect(activeDotStyle.boxShadow).toContain('#6FE39B');
+
+        rerender(<Badge tone='neutral'>Idle</Badge>);
+        const neutralDot = findDotSibling(activeRoot)[0];
+        const neutralDotStyle = StyleSheet.flatten(neutralDot?.props.style) as { boxShadow?: string };
+        expect(neutralDotStyle.boxShadow).toBeUndefined();
+    });
+});

--- a/app/components/badge/index.tsx
+++ b/app/components/badge/index.tsx
@@ -1,0 +1,126 @@
+import { StyleSheet, Text, View, type ViewStyle, type TextStyle } from 'react-native';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: { extend: { colors: Record<string, string> } };
+};
+const colors = tailwindConfig.theme.extend.colors;
+
+/**
+ * Visual tone selecting the badge's color, border tint, background tint, and
+ * dot color. RN port of the `.badge--<tone>` modifiers in the design CSS.
+ */
+export type BadgeTone = 'neutral' | 'active' | 'warn' | 'danger' | 'info';
+
+/**
+ * Props for the Irrigo badge primitive.
+ */
+export type BadgeProps = {
+    /** Optional. Visual tone — selects color, border, and dot palette. Defaults to `neutral`. */
+    tone?: BadgeTone;
+    /** Optional. Show the colored dot prefix. Defaults to `true`. */
+    dot?: boolean;
+    /** Required. Badge label text. */
+    children: string;
+};
+
+type TonePalette = {
+    text: string;
+    border: string;
+    background: string;
+    dot: string;
+};
+
+const TONE_PALETTE: Readonly<Record<BadgeTone, TonePalette>> = {
+    neutral: {
+        text: colors['fg-soft'],
+        border: colors.border,
+        background: colors.surface,
+        dot: colors['fg-muted'],
+    },
+    active: {
+        text: colors.accent,
+        border: 'rgba(111, 227, 155, 0.4)',
+        background: 'rgba(111, 227, 155, 0.06)',
+        dot: colors.accent,
+    },
+    warn: {
+        text: colors.warn,
+        border: 'rgba(255, 190, 107, 0.4)',
+        background: 'rgba(255, 190, 107, 0.06)',
+        dot: colors.warn,
+    },
+    danger: {
+        text: colors.danger,
+        border: 'rgba(255, 107, 123, 0.4)',
+        background: 'rgba(255, 107, 123, 0.06)',
+        dot: colors.danger,
+    },
+    info: {
+        text: colors.info,
+        border: 'rgba(124, 212, 251, 0.4)',
+        background: 'rgba(124, 212, 251, 0.06)',
+        dot: colors.info,
+    },
+};
+
+/**
+ * Irrigo badge primitive — a small 22px-tall tag that labels state with a
+ * tinted background, border, dot, and label color per tone. RN port of
+ * `Badge` from the design system's `components.jsx`.
+ */
+export function Badge({ tone = 'neutral', dot = true, children }: BadgeProps) {
+    const palette = TONE_PALETTE[tone];
+
+    const containerStyle: ViewStyle = {
+        ...styles.container,
+        backgroundColor: palette.background,
+        borderColor: palette.border,
+    };
+
+    const textStyle: TextStyle = {
+        ...styles.text,
+        color: palette.text,
+    };
+
+    const dotStyle: ViewStyle = {
+        ...styles.dot,
+        backgroundColor: palette.dot,
+        // Source `.badge--active .dot` carries a green glow. RN 0.81+ accepts
+        // CSS-style `boxShadow` strings, so the design intent translates
+        // verbatim. Other tones leave the shadow off.
+        ...(tone === 'active'
+            ? { boxShadow: `0 0 8px ${colors.accent}` }
+            : {}),
+    };
+
+    return (
+        <View style={containerStyle} accessibilityRole='text' accessibilityLabel={children}>
+            {dot && <View style={dotStyle} />}
+            <Text style={textStyle}>{children}</Text>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        alignSelf: 'flex-start',
+        gap: 6,
+        height: 22,
+        paddingHorizontal: 10,
+        borderWidth: 1,
+        borderRadius: 4,
+    },
+    dot: {
+        width: 6,
+        height: 6,
+        borderRadius: 4,
+    },
+    text: {
+        fontFamily: 'Geist_500Medium',
+        fontSize: 11,
+        lineHeight: 11,
+        letterSpacing: 0.11,
+    },
+});

--- a/app/components/badge/index.tsx
+++ b/app/components/badge/index.tsx
@@ -1,5 +1,7 @@
 import { StyleSheet, Text, View, type ViewStyle, type TextStyle } from 'react-native';
 
+import { FontFamily } from '../../constants/fonts';
+
 const tailwindConfig = require('../../tailwind.config.js') as {
     theme: { extend: { colors: Record<string, string> } };
 };
@@ -39,26 +41,26 @@ const TONE_PALETTE: Readonly<Record<BadgeTone, TonePalette>> = {
     },
     active: {
         text: colors.accent,
-        border: 'rgba(111, 227, 155, 0.4)',
-        background: 'rgba(111, 227, 155, 0.06)',
+        border: colors['accent-border'],
+        background: colors['accent-tint'],
         dot: colors.accent,
     },
     warn: {
         text: colors.warn,
-        border: 'rgba(255, 190, 107, 0.4)',
-        background: 'rgba(255, 190, 107, 0.06)',
+        border: colors['warn-border'],
+        background: colors['warn-tint'],
         dot: colors.warn,
     },
     danger: {
         text: colors.danger,
-        border: 'rgba(255, 107, 123, 0.4)',
-        background: 'rgba(255, 107, 123, 0.06)',
+        border: colors['danger-border'],
+        background: colors['danger-tint'],
         dot: colors.danger,
     },
     info: {
         text: colors.info,
-        border: 'rgba(124, 212, 251, 0.4)',
-        background: 'rgba(124, 212, 251, 0.06)',
+        border: colors['info-border'],
+        background: colors['info-tint'],
         dot: colors.info,
     },
 };
@@ -118,7 +120,7 @@ const styles = StyleSheet.create({
         borderRadius: 4,
     },
     text: {
-        fontFamily: 'Geist_500Medium',
+        fontFamily: FontFamily.sansMedium,
         fontSize: 11,
         lineHeight: 11,
         letterSpacing: 0.11,

--- a/app/constants/fonts.ts
+++ b/app/constants/fonts.ts
@@ -1,0 +1,24 @@
+/**
+ * Brand font family names — the exact identifiers registered by FontLoader's
+ * `useFonts` call. React Native resolves custom fonts by family name, not by
+ * family-name + weight, so each weight is its own family. Use these constants
+ * in `StyleSheet` (where Tailwind `font-*` classes don't apply) so the magic
+ * strings stay co-located with the tailwind config they mirror.
+ */
+export const FontFamily = {
+    // Bricolage Grotesque — display weights.
+    display: 'BricolageGrotesque_400Regular',
+    displayMedium: 'BricolageGrotesque_500Medium',
+    displaySemibold: 'BricolageGrotesque_600SemiBold',
+    displayBold: 'BricolageGrotesque_700Bold',
+    // Geist — body / UI weights.
+    sansLight: 'Geist_300Light',
+    sans: 'Geist_400Regular',
+    sansMedium: 'Geist_500Medium',
+    sansSemibold: 'Geist_600SemiBold',
+    sansBold: 'Geist_700Bold',
+    // Geist Mono — numeric weights.
+    mono: 'GeistMono_400Regular',
+    monoMedium: 'GeistMono_500Medium',
+    monoSemibold: 'GeistMono_600SemiBold',
+} as const;

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -67,9 +67,17 @@ module.exports = {
                 'accent-press': '#4FCB7E',
                 'accent-deep': '#2C8F5A',
                 'accent-glow': 'rgba(111, 227, 155, 0.18)',
+                'accent-border': 'rgba(111, 227, 155, 0.4)',
+                'accent-tint': 'rgba(111, 227, 155, 0.06)',
                 info: '#7CD4FB',
+                'info-border': 'rgba(124, 212, 251, 0.4)',
+                'info-tint': 'rgba(124, 212, 251, 0.06)',
                 warn: '#FFBE6B',
+                'warn-border': 'rgba(255, 190, 107, 0.4)',
+                'warn-tint': 'rgba(255, 190, 107, 0.06)',
                 danger: '#FF6B7B',
+                'danger-border': 'rgba(255, 107, 123, 0.4)',
+                'danger-tint': 'rgba(255, 107, 123, 0.06)',
                 'on-accent': '#052013',
 
                 // Depletion ramp (saturated → past RAW).

--- a/app/tailwind.config.test.ts
+++ b/app/tailwind.config.test.ts
@@ -75,6 +75,17 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
             expect(colors['on-accent']).toBe('#052013');
         });
 
+        it('exposes tinted border / fill aliases (0.4 / 0.06 alpha) per semantic tone for tag-style chrome.', () => {
+            expect(colors['accent-border']).toBe('rgba(111, 227, 155, 0.4)');
+            expect(colors['accent-tint']).toBe('rgba(111, 227, 155, 0.06)');
+            expect(colors['warn-border']).toBe('rgba(255, 190, 107, 0.4)');
+            expect(colors['warn-tint']).toBe('rgba(255, 190, 107, 0.06)');
+            expect(colors['danger-border']).toBe('rgba(255, 107, 123, 0.4)');
+            expect(colors['danger-tint']).toBe('rgba(255, 107, 123, 0.06)');
+            expect(colors['info-border']).toBe('rgba(124, 212, 251, 0.4)');
+            expect(colors['info-tint']).toBe('rgba(124, 212, 251, 0.06)');
+        });
+
         it('exposes the seven-stop depletion ramp end-to-end.', () => {
             expect(colors['depletion-0']).toBe('#6FE39B');
             expect(colors['depletion-3']).toBe('#E9C96D');


### PR DESCRIPTION
## Ticket

[APP-14](http://192.168.2.100:7123/irrigo/browse/APP-14/) Badge component (neutral / active / warn / danger tones)

## Summary

- RN port of `Badge` from [app/design/irrigo/project/ui_kit/components.jsx](app/design/irrigo/project/ui_kit/components.jsx) and the `.badge` rules in [app/design/irrigo/project/components.css](app/design/irrigo/project/components.css).
- New [app/components/badge/index.tsx](app/components/badge/index.tsx) + paired `.test.tsx`. 22px-tall tag, optional 6×6 dot prefix (`dot={true}` by default), 5 tones — `neutral` / `active` / `warn` / `danger` / `info` — each shifting label color, border tint, background tint, and dot color per the design CSS. `active` adds the `0 0 8px <accent>` glow on the dot via RN 0.81+ `boxShadow`.
- Container exposes `accessibilityRole='text'` + `accessibilityLabel={children}` so screen readers announce the badge's label.
- 9 behaviour tests covering children rendering, dot toggle, full tone palette (border/text/dot per tone), and the active-tone glow. Full app jest suite green (125/125).