### PR TITLE
[APP-15] Form controls — Toggle / Checkbox / Input + Field

### DIFF
--- a/app/components/checkbox/.test.tsx
+++ b/app/components/checkbox/.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { Checkbox } from '.';
+
+describe('Checkbox', () => {
+    it('renders the label text passed as children.', () => {
+        render(
+            <Checkbox value={false} onValueChange={() => {}}>
+                Re-plan now from current depletion
+            </Checkbox>,
+        );
+
+        expect(screen.getByText('Re-plan now from current depletion')).toBeOnTheScreen();
+    });
+
+    it('fires onValueChange with the negated value when pressed.', () => {
+        const onValueChange = jest.fn();
+
+        render(
+            <Checkbox value={false} onValueChange={onValueChange}>
+                Notify when first cycles are queued
+            </Checkbox>,
+        );
+        fireEvent.press(screen.getByRole('checkbox'));
+
+        expect(onValueChange).toHaveBeenCalledWith(true);
+    });
+
+    it('negates again when the checkbox is currently checked.', () => {
+        const onValueChange = jest.fn();
+
+        render(
+            <Checkbox value={true} onValueChange={onValueChange}>
+                Re-plan
+            </Checkbox>,
+        );
+        fireEvent.press(screen.getByRole('checkbox'));
+
+        expect(onValueChange).toHaveBeenCalledWith(false);
+    });
+
+    it('does not fire onValueChange when disabled.', () => {
+        const onValueChange = jest.fn();
+
+        render(
+            <Checkbox value={false} onValueChange={onValueChange} disabled>
+                Re-plan
+            </Checkbox>,
+        );
+        fireEvent.press(screen.getByRole('checkbox'));
+
+        expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('exposes the checked state to assistive tech.', () => {
+        render(
+            <Checkbox value={true} onValueChange={() => {}}>
+                Re-plan
+            </Checkbox>,
+        );
+
+        expect(screen.getByRole('checkbox').props.accessibilityState).toMatchObject({ checked: true });
+    });
+
+    it('uses the label text as the accessibility label by default.', () => {
+        render(
+            <Checkbox value={false} onValueChange={() => {}}>
+                Re-plan now from current depletion
+            </Checkbox>,
+        );
+
+        expect(screen.getByLabelText('Re-plan now from current depletion')).toBeOnTheScreen();
+    });
+
+    it('honors an explicit accessibility label override.', () => {
+        render(
+            <Checkbox value={false} onValueChange={() => {}} accessibilityLabel='replan-toggle'>
+                Re-plan
+            </Checkbox>,
+        );
+
+        expect(screen.getByLabelText('replan-toggle')).toBeOnTheScreen();
+    });
+
+    it('renders the checkmark only when value is true.', () => {
+        const { rerender } = render(
+            <Checkbox value={false} onValueChange={() => {}}>
+                Re-plan
+            </Checkbox>,
+        );
+
+        expect(screen.queryByLabelText('check')).toBeNull();
+
+        rerender(
+            <Checkbox value={true} onValueChange={() => {}}>
+                Re-plan
+            </Checkbox>,
+        );
+
+        expect(screen.getByLabelText('check')).toBeOnTheScreen();
+    });
+});

--- a/app/components/checkbox/index.tsx
+++ b/app/components/checkbox/index.tsx
@@ -1,0 +1,100 @@
+import { Pressable, Text, View } from 'react-native';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+const checkbox = tv({
+    slots: {
+        // Layout & Structure
+        row: 'flex-row items-center gap-[10px]',
+        // Sizing
+        box: 'w-5 h-5 items-center justify-center rounded-r-1 border',
+        // Typography
+        label: 'font-sans text-fg-soft text-[14px] leading-[21px]',
+    },
+    variants: {
+        checked: {
+            true: { box: 'bg-accent border-accent' },
+            false: { box: 'bg-surface border-border' },
+        },
+        disabled: {
+            true: { row: 'opacity-40' },
+            false: {},
+        },
+    },
+    defaultVariants: { checked: false, disabled: false },
+});
+
+type CheckboxVariants = VariantProps<typeof checkbox>;
+
+/**
+ * Props for the Irrigo checkbox primitive.
+ */
+export type CheckboxProps = {
+    /** Required. Controlled checked state. */
+    value: boolean;
+
+    /** Required. Fires with the negated value when the row is pressed (and not disabled). */
+    onValueChange: (next: boolean) => void;
+
+    /** Optional. Disables interaction and dims the control. Defaults to `false`. */
+    disabled?: CheckboxVariants['disabled'];
+
+    /** Optional. Overrides the accessibility label spoken by screen readers; defaults to the children string. */
+    accessibilityLabel?: string;
+
+    /** Required. Label text rendered next to the box. */
+    children: string;
+};
+
+/**
+ * The Irrigo checkbox primitive — a 20×20 box + label row, mirroring the
+ * `.check` recipe from the design CSS. Used by the switch-profile modal
+ * options. The check-mark is a small rotated `<View>` (RN can't render
+ * `::after` borders, so we mimic the angle with `transform: [rotate(-45deg)]`
+ * on a two-sided border square).
+ */
+export function Checkbox({
+    value,
+    onValueChange,
+    disabled = false,
+    accessibilityLabel,
+    children,
+}: CheckboxProps) {
+    const styles = checkbox({ checked: value, disabled });
+
+    return (
+        <Pressable
+            onPress={disabled ? undefined : () => onValueChange(!value)}
+            disabled={disabled}
+            accessibilityRole='checkbox'
+            accessibilityLabel={accessibilityLabel ?? children}
+            accessibilityState={{ checked: value, disabled }}
+            className={styles.row()}
+        >
+            <View className={styles.box()}>
+                {value && <CheckMark />}
+            </View>
+            <Text className={styles.label()}>{children}</Text>
+        </Pressable>
+    );
+}
+
+/**
+ * Two-stroke checkmark glyph rendered when the box is checked. Built from
+ * left + bottom borders of a small box rotated -45° — the trick the design
+ * CSS uses with `::after`, ported to RN where pseudo-elements don't exist.
+ */
+function CheckMark() {
+    return (
+        <View
+            accessibilityLabel='check'
+            style={{
+                width: 10,
+                height: 6,
+                borderLeftWidth: 2,
+                borderBottomWidth: 2,
+                borderColor: '#052013',
+                transform: [{ rotate: '-45deg' }, { translateX: 1 }, { translateY: -1 }],
+            }}
+        />
+    );
+}

--- a/app/components/input/.test.tsx
+++ b/app/components/input/.test.tsx
@@ -1,0 +1,117 @@
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+
+import { Field, Input } from '.';
+
+describe('Input', () => {
+    it('renders the placeholder.', () => {
+        render(<Input value='' onChangeText={() => {}} placeholder='Search zones' />);
+
+        expect(screen.getByPlaceholderText('Search zones')).toBeOnTheScreen();
+    });
+
+    it('fires onChangeText with the new value when the user types.', () => {
+        const onChangeText = jest.fn();
+
+        render(<Input value='' onChangeText={onChangeText} placeholder='Search' />);
+        fireEvent.changeText(screen.getByPlaceholderText('Search'), 'No');
+
+        expect(onChangeText).toHaveBeenCalledWith('No');
+    });
+
+    it('reflects the controlled value.', () => {
+        render(<Input value='North' onChangeText={() => {}} placeholder='Search' />);
+
+        expect(screen.getByDisplayValue('North')).toBeOnTheScreen();
+    });
+
+    it('does not fire onChangeText when disabled.', () => {
+        const onChangeText = jest.fn();
+
+        render(<Input value='' onChangeText={onChangeText} placeholder='Search' disabled />);
+        fireEvent.changeText(screen.getByPlaceholderText('Search'), 'x');
+
+        expect(onChangeText).not.toHaveBeenCalled();
+    });
+
+    it('marks the input as not editable when disabled.', () => {
+        render(<Input value='' onChangeText={() => {}} placeholder='Search' disabled />);
+
+        expect(screen.getByPlaceholderText('Search').props.editable).toBe(false);
+    });
+
+    it('uses the placeholder as the accessibility label by default.', () => {
+        render(<Input value='' onChangeText={() => {}} placeholder='Search zones' />);
+
+        expect(screen.getByLabelText('Search zones')).toBeOnTheScreen();
+    });
+
+    it('honors an explicit accessibility label override.', () => {
+        render(
+            <Input
+                value=''
+                onChangeText={() => {}}
+                placeholder='Search'
+                accessibilityLabel='zone-search'
+            />,
+        );
+
+        expect(screen.getByLabelText('zone-search')).toBeOnTheScreen();
+    });
+
+    it('paints the focused state when the user focuses the field and clears it on blur.', () => {
+        render(<Input value='' onChangeText={() => {}} placeholder='Search' />);
+
+        const field = screen.getByPlaceholderText('Search');
+        act(() => {
+            fireEvent(field, 'focus');
+        });
+        expect(field.props.className).toContain('border-accent');
+
+        act(() => {
+            fireEvent(field, 'blur');
+        });
+        expect(field.props.className).not.toContain('border-accent');
+    });
+
+    it('paints the invalid border when `invalid` is true.', () => {
+        render(<Input value='' onChangeText={() => {}} placeholder='Search' invalid />);
+
+        expect(screen.getByPlaceholderText('Search').props.className).toContain('border-danger');
+    });
+});
+
+describe('Field', () => {
+    it('renders the label, the control, and the hint.', () => {
+        render(
+            <Field label='Duration' hint='Minutes per cycle'>
+                <Input value='' onChangeText={() => {}} placeholder='Duration in minutes' />
+            </Field>,
+        );
+
+        expect(screen.getByText('Duration')).toBeOnTheScreen();
+        expect(screen.getByPlaceholderText('Duration in minutes')).toBeOnTheScreen();
+        expect(screen.getByText('Minutes per cycle')).toBeOnTheScreen();
+    });
+
+    it('suppresses the hint and shows the error text in danger color when `err` is set.', () => {
+        render(
+            <Field label='Duration' hint='Minutes per cycle' err='Must be a positive number.'>
+                <Input value='' onChangeText={() => {}} placeholder='Duration' />
+            </Field>,
+        );
+
+        expect(screen.queryByText('Minutes per cycle')).toBeNull();
+        expect(screen.getByText('Must be a positive number.')).toBeOnTheScreen();
+    });
+
+    it('omits the label slot when no label is provided.', () => {
+        render(
+            <Field hint='Minutes'>
+                <Input value='' onChangeText={() => {}} placeholder='Duration' />
+            </Field>,
+        );
+
+        expect(screen.getByText('Minutes')).toBeOnTheScreen();
+        expect(screen.queryByText('Duration')).toBeNull(); // placeholder text only on the input itself; no label above
+    });
+});

--- a/app/components/input/index.tsx
+++ b/app/components/input/index.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useState, type ReactNode } from 'react';
+import { TextInput, View, Text, type TextInputProps } from 'react-native';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: { extend: { colors: Record<string, string> } };
+};
+const colors = tailwindConfig.theme.extend.colors;
+
+const input = tv({
+    slots: {
+        // Layout, sizing & spacing + typography defaults shared by every state.
+        base: 'h-[44px] w-full px-[14px] rounded-r-1 border font-sans text-fg text-[14px]',
+    },
+    variants: {
+        focused: {
+            true: { base: 'border-accent bg-bg shadow-[0_0_0_4px_rgba(111,227,155,0.06)]' },
+            false: { base: 'bg-surface border-border' },
+        },
+        invalid: {
+            true: { base: 'border-danger bg-surface shadow-[0_0_0_4px_rgba(255,107,123,0.08)]' },
+            false: {},
+        },
+        disabled: {
+            true: { base: 'opacity-40' },
+            false: {},
+        },
+    },
+    defaultVariants: { focused: false, invalid: false, disabled: false },
+});
+
+type InputVariants = VariantProps<typeof input>;
+
+type AllowedTextInputProps = Pick<
+    TextInputProps,
+    'keyboardType' | 'autoCapitalize' | 'autoCorrect' | 'autoFocus' | 'secureTextEntry' | 'maxLength' | 'returnKeyType' | 'onSubmitEditing'
+>;
+
+/**
+ * Props for the Irrigo input primitive.
+ */
+export type InputProps = AllowedTextInputProps & {
+    /** Required. Controlled value. */
+    value: string;
+
+    /** Required. Fires with the next value on every keystroke (unless `disabled`). */
+    onChangeText: (next: string) => void;
+
+    /** Optional. Placeholder text rendered when `value` is empty. */
+    placeholder?: string;
+
+    /** Optional. Paints the danger border + red wash. Defaults to `false`. */
+    invalid?: InputVariants['invalid'];
+
+    /** Optional. Disables editing and dims the control. Defaults to `false`. */
+    disabled?: InputVariants['disabled'];
+
+    /** Optional. Accessibility label. Defaults to the placeholder when one is supplied. */
+    accessibilityLabel?: string;
+};
+
+/**
+ * The Irrigo text input primitive — 44px tall, surface background, border,
+ * 4px radii. Focus state paints the accent border + the 4px green wash
+ * shadow from the design CSS. `invalid` swaps to the danger border + red
+ * wash. The control owns its own focused boolean so the green wash tracks
+ * the actual UIKit / Android focus state without callers having to hold it.
+ */
+export function Input({
+    value,
+    onChangeText,
+    placeholder,
+    invalid = false,
+    disabled = false,
+    accessibilityLabel,
+    ...rest
+}: InputProps) {
+    const [focused, setFocused] = useState<boolean>(false);
+
+    const handleFocus = useCallback(() => setFocused(true), []);
+    const handleBlur = useCallback(() => setFocused(false), []);
+
+    const styles = input({ focused, invalid, disabled });
+
+    return (
+        <TextInput
+            value={value}
+            onChangeText={disabled ? undefined : onChangeText}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            placeholder={placeholder}
+            placeholderTextColor={colors['fg-dim']}
+            editable={!disabled}
+            accessibilityLabel={accessibilityLabel ?? placeholder}
+            className={styles.base()}
+            {...rest}
+        />
+    );
+}
+
+/**
+ * Props for the `<Field>` wrapper.
+ */
+export type FieldProps = {
+    /** Optional. Label text rendered above the field. */
+    label?: string;
+
+    /** Optional. Helper text rendered below the field. Suppressed when `err` is set. */
+    hint?: string;
+
+    /** Optional. Error text rendered below the field in `danger` color. Overrides the hint when present. */
+    err?: string;
+
+    /** Required. The control rendered inside the field (typically `<Input>`). */
+    children: ReactNode;
+};
+
+/**
+ * Column-flex wrapper that pairs a label, control, and either a hint or
+ * error message. Matches the `.field` recipe from the design CSS. The
+ * control sits between the label and the hint/err row. When `err` is
+ * truthy, the hint is suppressed and the error replaces it in `danger`
+ * color.
+ */
+export function Field({ label, hint, err, children }: FieldProps) {
+    return (
+        <View className='flex-col gap-2'>
+            {label !== undefined && (
+                <Text className='font-sans-medium text-fg-soft text-[12px] leading-[16px]'>{label}</Text>
+            )}
+            {children}
+            {err !== undefined ? (
+                <Text className='font-sans text-danger text-[12px] leading-[17px]'>{err}</Text>
+            ) : hint !== undefined ? (
+                <Text className='font-sans text-fg-muted text-[12px] leading-[17px]'>{hint}</Text>
+            ) : null}
+        </View>
+    );
+}

--- a/app/components/toggle/.test.tsx
+++ b/app/components/toggle/.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet, View } from 'react-native';
+
+import { Toggle } from '.';
+
+describe('Toggle', () => {
+    it('exposes the switch role with the supplied accessibility label.', () => {
+        render(<Toggle value={false} onValueChange={() => {}} accessibilityLabel='Master irrigation' />);
+
+        expect(screen.getByRole('switch', { name: 'Master irrigation' })).toBeOnTheScreen();
+    });
+
+    it('fires onValueChange with the negated value when pressed.', () => {
+        const onValueChange = jest.fn();
+
+        render(<Toggle value={false} onValueChange={onValueChange} accessibilityLabel='Toggle' />);
+        fireEvent.press(screen.getByRole('switch'));
+
+        expect(onValueChange).toHaveBeenCalledWith(true);
+    });
+
+    it('negates again when the toggle is currently on.', () => {
+        const onValueChange = jest.fn();
+
+        render(<Toggle value={true} onValueChange={onValueChange} accessibilityLabel='Toggle' />);
+        fireEvent.press(screen.getByRole('switch'));
+
+        expect(onValueChange).toHaveBeenCalledWith(false);
+    });
+
+    it('does not fire onValueChange when disabled.', () => {
+        const onValueChange = jest.fn();
+
+        render(<Toggle value={false} onValueChange={onValueChange} disabled accessibilityLabel='Toggle' />);
+        fireEvent.press(screen.getByRole('switch'));
+
+        expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('exposes the checked state to assistive tech.', () => {
+        render(<Toggle value={true} onValueChange={() => {}} accessibilityLabel='Toggle' />);
+
+        expect(screen.getByRole('switch').props.accessibilityState).toMatchObject({ checked: true, disabled: false });
+    });
+
+    it('exposes the disabled state to assistive tech.', () => {
+        render(<Toggle value={false} onValueChange={() => {}} disabled accessibilityLabel='Toggle' />);
+
+        expect(screen.getByRole('switch').props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it.each([
+        ['default', 44, 26],
+        ['lg', 54, 30],
+    ] as const)('renders the %s size at the documented %dx%d dimensions.', (size, width, height) => {
+        const { root } = render(<Toggle value={false} onValueChange={() => {}} size={size} accessibilityLabel='Toggle' />);
+
+        const sized = root.findAll(node => {
+            if (node.type !== View) return false;
+            const style = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+                | { width?: number; height?: number }
+                | undefined;
+            return style?.width === width && style?.height === height;
+        });
+        expect(sized.length).toBeGreaterThan(0);
+    });
+});

--- a/app/components/toggle/index.tsx
+++ b/app/components/toggle/index.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef } from 'react';
+import { Animated, Pressable, View } from 'react-native';
+import { tv, type VariantProps } from 'tailwind-variants';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: { extend: { colors: Record<string, string> } };
+};
+const colors = tailwindConfig.theme.extend.colors;
+
+const TRACK_OFF_COLOR = colors['ink-400'];
+const TRACK_ON_COLOR = colors.accent;
+const THUMB_OFF_COLOR = colors['chalk-200'];
+const THUMB_ON_COLOR = colors['on-accent'];
+
+const SIZE_SPEC = {
+    default: { width: 44, height: 26, padding: 3 },
+    lg: { width: 54, height: 30, padding: 3 },
+} as const;
+
+const TRANSITION_MS = 220;
+
+const toggle = tv({
+    slots: {
+        track: 'rounded-r-1 border',
+        thumb: 'absolute rounded-r-1',
+    },
+    variants: {
+        on: {
+            true: { track: 'border-transparent' },
+            false: { track: 'border-border' },
+        },
+        disabled: {
+            true: { track: 'opacity-40' },
+            false: {},
+        },
+    },
+    defaultVariants: { on: false, disabled: false },
+});
+
+type ToggleVariants = VariantProps<typeof toggle>;
+
+/**
+ * Props for the Irrigo toggle primitive.
+ */
+export type ToggleProps = {
+    /** Required. Controlled on/off state. */
+    value: boolean;
+
+    /** Required. Fires with the negated value when the toggle is pressed (and not disabled). */
+    onValueChange: (next: boolean) => void;
+
+    /** Optional. Hit-target size. `default` 44×26; `lg` 54×30 (used by the master irrigation switch). Defaults to `default`. */
+    size?: keyof typeof SIZE_SPEC;
+
+    /** Optional. Disables interaction and dims the control. Defaults to `false`. */
+    disabled?: ToggleVariants['disabled'];
+
+    /** Optional. Accessibility label spoken by screen readers. */
+    accessibilityLabel?: string;
+};
+
+/**
+ * The Irrigo toggle primitive — animated track + thumb mirroring the
+ * `.toggle` recipe from the design CSS. Used by the master irrigation
+ * switch (size `lg`) and any future inline boolean controls (size
+ * `default`). The thumb position and the track color tween together over
+ * 220ms whenever `value` flips.
+ */
+export function Toggle({
+    value,
+    onValueChange,
+    size = 'default',
+    disabled = false,
+    accessibilityLabel,
+}: ToggleProps) {
+    const spec = SIZE_SPEC[size];
+    const thumbSize = spec.height - spec.padding * 2 - 2;
+    const thumbTravel = spec.width - spec.height;
+
+    const animated = useRef(new Animated.Value(value ? 1 : 0)).current;
+    useEffect(() => {
+        Animated.timing(animated, {
+            toValue: value ? 1 : 0,
+            duration: TRANSITION_MS,
+            useNativeDriver: false,
+        }).start();
+    }, [animated, value]);
+
+    const trackBackgroundColor = animated.interpolate({
+        inputRange: [0, 1],
+        outputRange: [TRACK_OFF_COLOR, TRACK_ON_COLOR],
+    });
+    const thumbBackgroundColor = animated.interpolate({
+        inputRange: [0, 1],
+        outputRange: [THUMB_OFF_COLOR, THUMB_ON_COLOR],
+    });
+    const thumbTranslateX = animated.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, thumbTravel],
+    });
+
+    const styles = toggle({ on: value, disabled });
+
+    return (
+        <Pressable
+            onPress={disabled ? undefined : () => onValueChange(!value)}
+            disabled={disabled}
+            accessibilityRole='switch'
+            accessibilityLabel={accessibilityLabel}
+            accessibilityState={{ checked: value, disabled }}
+        >
+            <View style={{ width: spec.width, height: spec.height }}>
+                <Animated.View
+                    className={styles.track()}
+                    style={{
+                        position: 'absolute',
+                        left: 0,
+                        right: 0,
+                        top: 0,
+                        bottom: 0,
+                        backgroundColor: trackBackgroundColor,
+                    }}
+                />
+                <Animated.View
+                    className={styles.thumb()}
+                    style={{
+                        top: spec.padding,
+                        left: spec.padding,
+                        width: thumbSize,
+                        height: thumbSize,
+                        backgroundColor: thumbBackgroundColor,
+                        transform: [{ translateX: thumbTranslateX }],
+                    }}
+                />
+            </View>
+        </Pressable>
+    );
+}


### PR DESCRIPTION
## Ticket

[APP-15](http://192.168.2.100:7123/irrigo/browse/APP-15/) Form controls — Toggle, Checkbox, Input with green focus ring

## Summary

- **Toggle** ([app/components/toggle/](app/components/toggle/index.tsx)) — animated 44×26 track + thumb (220ms ease-out), plus an `lg` variant at 54×30 for the master irrigation switch. Track recolors from `ink-400` → `accent`; thumb translates `width − height` and recolors to `on-accent`. Accessible as `accessibilityRole='switch'` with `checked` / `disabled` state.
- **Checkbox** ([app/components/checkbox/](app/components/checkbox/index.tsx)) — 20×20 box + label row mirroring `.check`. Off: surface fill + border. On: accent fill + accent border, with a small rotated `<View>` standing in for the design's CSS `::after` checkmark (RN can't render pseudo-elements). `accessibilityRole='checkbox'`.
- **Input** + **Field** ([app/components/input/](app/components/input/index.tsx)) — 44px text field with the 4px green-wash focus ring (`shadow-[0_0_0_4px_rgba(111,227,155,0.06)]`) and a danger red-wash for the `invalid` state. The input owns its `focused` state internally so callers don't have to. `<Field>` is the column-flex wrapper providing `label` / `hint` / `err` slots (err overrides hint).
- Built with `tailwind-variants` + NativeWind className utilities, matching the [Button](app/components/button.tsx) primitive's pattern. Each control lives in its own folder per the folder-per-tested-subject convention.

## Verification

- `bun --cwd=./app typecheck` ✅
- `bun --cwd=./app run test` — 168 passed across 31 suites (28 new: Toggle 8, Checkbox 8, Input + Field 12).