### PR TITLE
[APP-16] Card / Modal / Sheet primitives with scrim + blur

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.100.13",
         "expo": "~54.0.33",
+        "expo-blur": "^56.0.3",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.21",
         "expo-font": "~14.0.11",
@@ -989,6 +990,8 @@
     "expo": ["expo@54.0.34", "", { "dependencies": { "@babel/runtime": "^7.20.0", "@expo/cli": "54.0.24", "@expo/config": "~12.0.13", "@expo/config-plugins": "~54.0.4", "@expo/devtools": "0.1.8", "@expo/fingerprint": "0.15.5", "@expo/metro": "~54.2.0", "@expo/metro-config": "54.0.15", "@expo/vector-icons": "^15.0.3", "@ungap/structured-clone": "^1.3.0", "babel-preset-expo": "~54.0.10", "expo-asset": "~12.0.13", "expo-constants": "~18.0.13", "expo-file-system": "~19.0.22", "expo-font": "~14.0.11", "expo-keep-awake": "~15.0.8", "expo-modules-autolinking": "3.0.25", "expo-modules-core": "3.0.30", "pretty-format": "^29.7.0", "react-refresh": "^0.14.2", "whatwg-url-without-unicode": "8.0.0-3" }, "peerDependencies": { "@expo/dom-webview": "*", "@expo/metro-runtime": "*", "react": "*", "react-native": "*", "react-native-webview": "*" }, "optionalPeers": ["@expo/dom-webview", "@expo/metro-runtime", "react-native-webview"], "bin": { "expo": "bin/cli", "fingerprint": "bin/fingerprint", "expo-modules-autolinking": "bin/autolinking" } }, "sha512-XkVHguZZDC8BcTQxHAd14/TQFbDp1Wt0Z/KApO9t68Ll5A127hLCPzU+a9gytfCIiyL/V1IpF1vIcOLKEVAoNQ=="],
 
     "expo-asset": ["expo-asset@12.0.13", "", { "dependencies": { "@expo/image-utils": "^0.8.8", "expo-constants": "~18.0.13" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ=="],
+
+    "expo-blur": ["expo-blur@56.0.3", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-KDDtrpWc2tYlm1WCPaOgBtv+YEGqe5ELheFPIgSNgHt28NQUDcfBcFsA9Us2StDh6osmSD6NbKxOt5bU6PcDbQ=="],
 
     "expo-constants": ["expo-constants@18.0.13", "", { "dependencies": { "@expo/config": "~12.0.13", "@expo/env": "~2.0.8" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ=="],
 

--- a/app/components/card/.test.tsx
+++ b/app/components/card/.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet, Text } from 'react-native';
+
+import { Card } from '.';
+
+type FlatStyle = {
+    backgroundColor?: string;
+    padding?: number;
+    borderRadius?: number;
+    borderWidth?: number;
+    borderColor?: string;
+    boxShadow?: string;
+};
+
+describe('Card', () => {
+    it('renders its children.', () => {
+        render(
+            <Card>
+                <Text>Inside card</Text>
+            </Card>,
+        );
+
+        expect(screen.getByText('Inside card')).toBeOnTheScreen();
+    });
+
+    it('defaults to the surface variant — surface bg, 16px padding, 4px radius, no shadow.', () => {
+        const { root } = render(
+            <Card>
+                <Text>Body</Text>
+            </Card>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle;
+
+        expect(style.backgroundColor).toBe('#0E1412');
+        expect(style.padding).toBe(16);
+        expect(style.borderRadius).toBe(4);
+        expect(style.borderWidth).toBe(1);
+        expect(style.boxShadow).toBeUndefined();
+    });
+
+    it('applies the elevated variant — elevated bg, 20px padding, shadow-2 inset highlight.', () => {
+        const { root } = render(
+            <Card variant='elevated'>
+                <Text>Body</Text>
+            </Card>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle;
+
+        expect(style.backgroundColor).toBe('#1B231F');
+        expect(style.padding).toBe(20);
+        expect(style.borderRadius).toBe(4);
+        expect(style.boxShadow).toContain('rgba(0, 0, 0, 0.45)');
+        expect(style.boxShadow).toContain('inset');
+    });
+
+    it('layers the accent-glow ring on top of the surface variant when `glow` is on.', () => {
+        const { root } = render(
+            <Card glow>
+                <Text>Body</Text>
+            </Card>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle;
+
+        expect(style.boxShadow).toContain('rgba(111, 227, 155, 0.28)');
+        expect(style.boxShadow).toContain('inset');
+    });
+
+    it('layers the accent-glow ring on top of the elevated shadow when both are on.', () => {
+        const { root } = render(
+            <Card variant='elevated' glow>
+                <Text>Body</Text>
+            </Card>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle;
+
+        // Both the shadow-2 ambient drop and the glow-accent ring must be in
+        // the composed boxShadow string.
+        expect(style.boxShadow).toContain('rgba(0, 0, 0, 0.45)');
+        expect(style.boxShadow).toContain('rgba(111, 227, 155, 0.28)');
+    });
+
+    it('merges the caller-provided style override onto the container.', () => {
+        const { root } = render(
+            <Card style={{ marginTop: 42 }}>
+                <Text>Body</Text>
+            </Card>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle & { marginTop?: number };
+
+        expect(style.marginTop).toBe(42);
+    });
+});

--- a/app/components/card/index.tsx
+++ b/app/components/card/index.tsx
@@ -1,0 +1,91 @@
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import type { ReactNode } from 'react';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: {
+        extend: {
+            colors: Record<string, string>;
+            boxShadow: Record<string, string>;
+        };
+    };
+};
+const colors = tailwindConfig.theme.extend.colors;
+const shadows = tailwindConfig.theme.extend.boxShadow;
+
+/**
+ * Visual variant selecting the card's background, padding, radius, and base
+ * shadow. RN port of `.card-surface` / `.card-elev` in the design CSS.
+ */
+export type CardVariant = 'surface' | 'elevated';
+
+/**
+ * Props for the Irrigo card primitive.
+ */
+export type CardProps = {
+    /** Optional. Visual variant — selects bg, radius, padding, and base shadow. Defaults to `surface`. */
+    variant?: CardVariant;
+    /** Optional. Add the accent-glow ring on top of the base shadow. Defaults to `false`. */
+    glow?: boolean;
+    /** Optional. Style overrides merged onto the container. */
+    style?: StyleProp<ViewStyle>;
+    /** Required. Card contents. */
+    children: ReactNode;
+};
+
+type VariantStyle = {
+    backgroundColor: string;
+    padding: number;
+    borderRadius: number;
+    boxShadow?: string;
+};
+
+const VARIANT_STYLE: Readonly<Record<CardVariant, VariantStyle>> = {
+    surface: {
+        backgroundColor: colors.surface,
+        padding: 16,
+        borderRadius: 4,
+    },
+    elevated: {
+        backgroundColor: colors.elevated,
+        padding: 20,
+        borderRadius: 4,
+        boxShadow: shadows['2'],
+    },
+};
+
+/**
+ * Irrigo card primitive — a bordered container with surface / elevated tones
+ * and an optional accent-glow ring. RN port of `.card-surface` / `.card-elev`
+ * from `components.css`.
+ */
+export function Card({ variant = 'surface', glow = false, style, children }: CardProps) {
+    const variantStyle = VARIANT_STYLE[variant];
+
+    // Compose the base shadow (if any) with the accent-glow ring when `glow`
+    // is on. RN 0.81+ accepts CSS-style `boxShadow` strings, so a comma-joined
+    // string layers the two shadows the same way the source CSS does.
+    const baseShadow = variantStyle.boxShadow;
+    const glowShadow = shadows['glow-accent'];
+    const boxShadow = glow
+        ? baseShadow
+            ? `${baseShadow}, ${glowShadow}`
+            : glowShadow
+        : baseShadow;
+
+    const containerStyle: ViewStyle = {
+        ...styles.container,
+        backgroundColor: variantStyle.backgroundColor,
+        padding: variantStyle.padding,
+        borderRadius: variantStyle.borderRadius,
+        ...(boxShadow ? { boxShadow } : {}),
+    };
+
+    return <View style={[containerStyle, style]}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+    container: {
+        borderWidth: 1,
+        borderColor: colors.border,
+    },
+});

--- a/app/components/modal/.test.tsx
+++ b/app/components/modal/.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet, Text } from 'react-native';
+import { BlurView } from 'expo-blur';
+
+import { Modal } from '.';
+
+describe('Modal', () => {
+    it('renders its children when visible.', () => {
+        render(
+            <Modal visible onRequestClose={() => {}}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        expect(screen.getByText('Dialog body')).toBeOnTheScreen();
+    });
+
+    it('hides its children when not visible.', () => {
+        render(
+            <Modal visible={false} onRequestClose={() => {}}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        expect(screen.queryByText('Dialog body')).toBeNull();
+    });
+
+    it('calls `onRequestClose` when the user taps the backdrop.', () => {
+        const onRequestClose = jest.fn();
+        const { root } = render(
+            <Modal visible onRequestClose={onRequestClose}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        // The container sets `accessibilityViewIsModal`, which hides sibling
+        // a11y nodes (including the backdrop Pressable) from a11y queries —
+        // exactly what screen readers expect. Reach the press target via
+        // host-tree lookup instead so we can still exercise the tap.
+        const backdrop = root.find(
+            node =>
+                typeof node.type === 'string' &&
+                node.props.accessibilityLabel === 'Dismiss modal',
+        );
+        fireEvent.press(backdrop);
+
+        expect(onRequestClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('paints the scrim layer with the design rgba(2, 4, 3, 0.66) colour.', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        // Walk host nodes only (string `type`) to avoid double-counting the
+        // React component wrapper that shares props with its underlying host.
+        const scrim = root.findAll(node => {
+            if (typeof node.type !== 'string') return false;
+            const style = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+                | { backgroundColor?: string }
+                | undefined;
+            return style?.backgroundColor === 'rgba(2, 4, 3, 0.66)';
+        });
+
+        expect(scrim).toHaveLength(1);
+    });
+
+    it('renders a BlurView in the backdrop for the 8px-equivalent backdrop blur.', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        const blurs = root.findAllByType(BlurView);
+
+        expect(blurs).toHaveLength(1);
+        expect(blurs[0].props.intensity).toBe(50);
+        expect(blurs[0].props.tint).toBe('dark');
+    });
+
+    it('exposes the caller-provided accessibility label on the container.', () => {
+        render(
+            <Modal visible onRequestClose={() => {}} accessibilityLabel='Switch schedule'>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        expect(screen.getByLabelText('Switch schedule')).toBeOnTheScreen();
+    });
+});

--- a/app/components/modal/index.tsx
+++ b/app/components/modal/index.tsx
@@ -1,0 +1,96 @@
+import {
+    Modal as RNModal,
+    Pressable,
+    StyleSheet,
+    View,
+    type ViewStyle,
+} from 'react-native';
+import { BlurView } from 'expo-blur';
+import type { ReactNode } from 'react';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: {
+        extend: {
+            colors: Record<string, string>;
+            boxShadow: Record<string, string>;
+        };
+    };
+};
+const colors = tailwindConfig.theme.extend.colors;
+const shadows = tailwindConfig.theme.extend.boxShadow;
+
+/**
+ * Props for the Irrigo modal primitive.
+ */
+export type ModalProps = {
+    /** Required. Whether the modal is visible. */
+    visible: boolean;
+    /** Required. Called when the user taps the backdrop or triggers the platform-native dismiss (Android back). */
+    onRequestClose: () => void;
+    /** Optional. Accessibility label for the modal container, announced when it opens. */
+    accessibilityLabel?: string;
+    /** Required. Modal contents — typically header / body / footer composed by the caller. */
+    children: ReactNode;
+};
+
+/**
+ * Irrigo modal primitive — a centred dialog with a dim+blur backdrop. Wraps
+ * React Native's built-in `Modal` so platform overlay handling (Android back
+ * button, focus traps) Just Works. RN port of `.modal` + `.scrim` from
+ * `components.css`.
+ */
+export function Modal({ visible, onRequestClose, accessibilityLabel, children }: ModalProps) {
+    return (
+        <RNModal
+            visible={visible}
+            onRequestClose={onRequestClose}
+            transparent
+            animationType='fade'
+            statusBarTranslucent
+        >
+            <View style={styles.overlay}>
+                <Pressable
+                    style={StyleSheet.absoluteFill}
+                    onPress={onRequestClose}
+                    accessibilityRole='button'
+                    accessibilityLabel='Dismiss modal'
+                >
+                    <BlurView intensity={50} tint='dark' style={StyleSheet.absoluteFill} />
+                    <View style={styles.scrim} />
+                </Pressable>
+
+                <View
+                    style={styles.container}
+                    accessibilityViewIsModal
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    {children}
+                </View>
+            </View>
+        </RNModal>
+    );
+}
+
+const container: ViewStyle = {
+    backgroundColor: colors['ink-300'],
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    width: '100%',
+    maxWidth: 440,
+    marginHorizontal: 16,
+    boxShadow: shadows['3'],
+};
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    scrim: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: colors.scrim,
+    },
+    container,
+});

--- a/app/components/sheet/.test.tsx
+++ b/app/components/sheet/.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet, Text } from 'react-native';
+import { BlurView } from 'expo-blur';
+
+import { Sheet } from '.';
+
+describe('Sheet', () => {
+    it('renders its children when visible.', () => {
+        render(
+            <Sheet visible onRequestClose={() => {}}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        expect(screen.getByText('Sheet body')).toBeOnTheScreen();
+    });
+
+    it('hides its children when not visible.', () => {
+        render(
+            <Sheet visible={false} onRequestClose={() => {}}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        expect(screen.queryByText('Sheet body')).toBeNull();
+    });
+
+    it('calls `onRequestClose` when the user taps the backdrop.', () => {
+        const onRequestClose = jest.fn();
+        const { root } = render(
+            <Sheet visible onRequestClose={onRequestClose}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        const backdrop = root.find(
+            node =>
+                typeof node.type === 'string' &&
+                node.props.accessibilityLabel === 'Dismiss sheet',
+        );
+        fireEvent.press(backdrop);
+
+        expect(onRequestClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('paints the scrim layer with the design rgba(2, 4, 3, 0.66) colour.', () => {
+        const { root } = render(
+            <Sheet visible onRequestClose={() => {}}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        const scrim = root.findAll(node => {
+            if (typeof node.type !== 'string') return false;
+            const style = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+                | { backgroundColor?: string }
+                | undefined;
+            return style?.backgroundColor === 'rgba(2, 4, 3, 0.66)';
+        });
+
+        expect(scrim).toHaveLength(1);
+    });
+
+    it('renders a BlurView in the backdrop for the 8px-equivalent backdrop blur.', () => {
+        const { root } = render(
+            <Sheet visible onRequestClose={() => {}}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        const blurs = root.findAllByType(BlurView);
+
+        expect(blurs).toHaveLength(1);
+        expect(blurs[0].props.intensity).toBe(50);
+        expect(blurs[0].props.tint).toBe('dark');
+    });
+
+    it('anchors the overlay to the bottom of the screen.', () => {
+        const { root } = render(
+            <Sheet visible onRequestClose={() => {}}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        // The overlay is the first host View under the Modal — it owns the
+        // bottom-anchoring `justifyContent: 'flex-end'` layout.
+        const overlay = root.find(
+            node =>
+                typeof node.type === 'string' &&
+                node.type === 'View' &&
+                (StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+                    | { justifyContent?: string }
+                    | undefined)?.justifyContent === 'flex-end',
+        );
+
+        expect(overlay).toBeTruthy();
+    });
+
+    it('renders a 40×4 grabber inside the sheet container above the children.', () => {
+        const { root } = render(
+            <Sheet visible onRequestClose={() => {}}>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        const grabbers = root.findAll(node => {
+            if (typeof node.type !== 'string') return false;
+            const style = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+                | { width?: number; height?: number; alignSelf?: string }
+                | undefined;
+            return style?.width === 40 && style?.height === 4 && style?.alignSelf === 'center';
+        });
+
+        expect(grabbers).toHaveLength(1);
+    });
+
+    it('exposes the caller-provided accessibility label on the container.', () => {
+        render(
+            <Sheet visible onRequestClose={() => {}} accessibilityLabel='Run zone'>
+                <Text>Sheet body</Text>
+            </Sheet>,
+        );
+
+        expect(screen.getByLabelText('Run zone')).toBeOnTheScreen();
+    });
+});

--- a/app/components/sheet/index.tsx
+++ b/app/components/sheet/index.tsx
@@ -1,0 +1,105 @@
+import {
+    Modal as RNModal,
+    Pressable,
+    StyleSheet,
+    View,
+    type ViewStyle,
+} from 'react-native';
+import { BlurView } from 'expo-blur';
+import type { ReactNode } from 'react';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: {
+        extend: {
+            colors: Record<string, string>;
+            boxShadow: Record<string, string>;
+        };
+    };
+};
+const colors = tailwindConfig.theme.extend.colors;
+const shadows = tailwindConfig.theme.extend.boxShadow;
+
+/**
+ * Props for the Irrigo bottom-sheet primitive.
+ */
+export type SheetProps = {
+    /** Required. Whether the sheet is visible. */
+    visible: boolean;
+    /** Required. Called when the user taps the backdrop or triggers the platform-native dismiss (Android back). */
+    onRequestClose: () => void;
+    /** Optional. Accessibility label for the sheet container, announced when it opens. */
+    accessibilityLabel?: string;
+    /** Required. Sheet contents — rows / actions composed by the caller. */
+    children: ReactNode;
+};
+
+/**
+ * Irrigo bottom-sheet primitive — a bottom-anchored container with a grabber
+ * affordance and a dim+blur backdrop. Wraps React Native's built-in `Modal`
+ * for platform overlay handling. RN port of `.sheet` + `.scrim` from
+ * `components.css`.
+ */
+export function Sheet({ visible, onRequestClose, accessibilityLabel, children }: SheetProps) {
+    return (
+        <RNModal
+            visible={visible}
+            onRequestClose={onRequestClose}
+            transparent
+            animationType='slide'
+            statusBarTranslucent
+        >
+            <View style={styles.overlay}>
+                <Pressable
+                    style={StyleSheet.absoluteFill}
+                    onPress={onRequestClose}
+                    accessibilityRole='button'
+                    accessibilityLabel='Dismiss sheet'
+                >
+                    <BlurView intensity={50} tint='dark' style={StyleSheet.absoluteFill} />
+                    <View style={styles.scrim} />
+                </Pressable>
+
+                <View
+                    style={styles.container}
+                    accessibilityViewIsModal
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    <View style={styles.grabber} />
+                    {children}
+                </View>
+            </View>
+        </RNModal>
+    );
+}
+
+const container: ViewStyle = {
+    backgroundColor: colors['ink-300'],
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    borderTopLeftRadius: 4,
+    borderTopRightRadius: 4,
+    paddingTop: 18,
+    paddingHorizontal: 18,
+    paddingBottom: 22,
+    boxShadow: shadows['3'],
+};
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        justifyContent: 'flex-end',
+    },
+    scrim: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: colors.scrim,
+    },
+    container,
+    grabber: {
+        width: 40,
+        height: 4,
+        backgroundColor: colors['ink-600'],
+        borderRadius: 4,
+        alignSelf: 'center',
+        marginBottom: 14,
+    },
+});

--- a/app/package.json
+++ b/app/package.json
@@ -35,6 +35,7 @@
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.100.13",
     "expo": "~54.0.33",
+    "expo-blur": "^56.0.3",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.21",
     "expo-font": "~14.0.11",

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -79,6 +79,7 @@ module.exports = {
                 'danger-border': 'rgba(255, 107, 123, 0.4)',
                 'danger-tint': 'rgba(255, 107, 123, 0.06)',
                 'on-accent': '#052013',
+                scrim: 'rgba(2, 4, 3, 0.66)',
 
                 // Depletion ramp (saturated → past RAW).
                 'depletion-0': '#6FE39B',

--- a/app/tailwind.config.test.ts
+++ b/app/tailwind.config.test.ts
@@ -75,6 +75,10 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
             expect(colors['on-accent']).toBe('#052013');
         });
 
+        it('exposes the modal / sheet scrim at the design-spec alpha.', () => {
+            expect(colors.scrim).toBe('rgba(2, 4, 3, 0.66)');
+        });
+
         it('exposes tinted border / fill aliases (0.4 / 0.06 alpha) per semantic tone for tag-style chrome.', () => {
             expect(colors['accent-border']).toBe('rgba(111, 227, 155, 0.4)');
             expect(colors['accent-tint']).toBe('rgba(111, 227, 155, 0.06)');


### PR DESCRIPTION
## Ticket

[APP-16](http://192.168.2.100:7123/irrigo/browse/APP-16/) — Card / Sheet / Modal with scrim + blur.

## Summary

- **Card** (`app/components/card`) — surface / elevated variants with an optional `glow` accent-ring shadow. Pure layout container; consumer styles the contents.
- **Modal** (`app/components/modal`) — centred dialog over an `rgba(2,4,3,0.66)` scrim + 8px backdrop blur via `expo-blur`. Wraps RN's built-in `Modal` for platform overlay handling; backdrop press calls `onRequestClose`.
- **Sheet** (`app/components/sheet`) — bottom-anchored variant with a 40×4 grabber, sharing the same backdrop treatment as Modal.
- Added `scrim` colour token to `tailwind.config.js` so the literal lives in one place.
- Added `expo-blur@56.0.3` (Expo SDK 54-compatible) for the backdrop blur.

## Test plan

- [x] `bun --cwd=./app run test` — 161 tests across 31 suites pass (20 new tests across Card / Modal / Sheet / tailwind).
- [x] `bun --cwd=./app run typecheck` — no new errors (the two pre-existing scaffolding errors in `(tabs)/index.tsx` and `modal.tsx` are untouched and unrelated).