### PR TITLE
[APP-17] Depletion Battery primitive (tone ramp, RAW notch, tall/compact)

### DIFF
--- a/app/components/battery/.test.tsx
+++ b/app/components/battery/.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { Battery, computeBatteryGeometry } from '.';
+
+describe('computeBatteryGeometry', () => {
+    it('returns ok tone with the correct fill and notch percentages when depletion is well below RAW.', () => {
+        // raw 25, depletion 10 → scaleMax = max(31.25, 14) = 31.25
+        // pct = 10 / 31.25 = 32%, rawPct = 25 / 31.25 = 80%
+        const result = computeBatteryGeometry(10, 25);
+
+        expect(result.tone).toBe('ok');
+        expect(result.scaleMax).toBeCloseTo(31.25);
+        expect(result.pct).toBeCloseTo(32);
+        expect(result.rawPct).toBeCloseTo(80);
+    });
+
+    it('flips to warn tone once depletion crosses 80% of RAW.', () => {
+        // depletion / raw = 21 / 25 = 0.84 → warn
+        const result = computeBatteryGeometry(21, 25);
+
+        expect(result.tone).toBe('warn');
+    });
+
+    it('stays in ok tone at exactly 80% of RAW (strictly greater triggers warn).', () => {
+        // depletion / raw = 20 / 25 = 0.80 → ok
+        const result = computeBatteryGeometry(20, 25);
+
+        expect(result.tone).toBe('ok');
+    });
+
+    it('flips to danger tone when depletion meets or exceeds RAW.', () => {
+        expect(computeBatteryGeometry(25, 25).tone).toBe('danger');
+        expect(computeBatteryGeometry(30, 25).tone).toBe('danger');
+    });
+
+    it('keeps fill width capped at 100% even when depletion would exceed the scale.', () => {
+        // depletion 30, raw 25 → scaleMax = max(31.25, 34) = 34; pct = 30/34 ≈ 88.2%
+        const result = computeBatteryGeometry(30, 25);
+
+        expect(result.pct).toBeLessThanOrEqual(100);
+    });
+
+    it('handles RAW = 0 without dividing by zero; tone falls back to ok.', () => {
+        const result = computeBatteryGeometry(5, 0);
+
+        expect(result.tone).toBe('ok');
+        expect(Number.isFinite(result.pct)).toBe(true);
+        expect(result.rawPct).toBe(0);
+    });
+
+    it('clamps negative depletion to 0 (surplus-moisture state still pegs at the lowest tick).', () => {
+        const result = computeBatteryGeometry(-3, 25);
+
+        expect(result.pct).toBe(0);
+        expect(result.tone).toBe('ok');
+    });
+});
+
+describe('Battery', () => {
+    it('renders a progressbar with the derived accessibility label.', () => {
+        render(<Battery depletion={10} raw={25} />);
+
+        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        expect(bar).toBeOnTheScreen();
+        expect(bar.props.accessibilityRole).toBe('progressbar');
+    });
+
+    it('reflects the warn tone in the derived label as depletion crosses 80% of RAW.', () => {
+        render(<Battery depletion={21} raw={25} />);
+
+        expect(screen.getByLabelText('warn — 21 of 25 mm')).toBeOnTheScreen();
+    });
+
+    it('reflects the danger tone in the derived label once depletion meets RAW.', () => {
+        render(<Battery depletion={26} raw={25} />);
+
+        expect(screen.getByLabelText('danger — 26 of 25 mm')).toBeOnTheScreen();
+    });
+
+    it('honours an explicit accessibility label override.', () => {
+        render(<Battery depletion={10} raw={25} accessibilityLabel='north-soil-battery' />);
+
+        expect(screen.getByLabelText('north-soil-battery')).toBeOnTheScreen();
+    });
+
+    it('exposes the depletion as the progressbar `now` value with `max` matching the computed scale.', () => {
+        render(<Battery depletion={10} raw={25} />);
+
+        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        expect(bar.props.accessibilityValue).toEqual({ min: 0, max: 31.25, now: 10 });
+    });
+
+    it('renders the 10px-tall compact variant by default.', () => {
+        render(<Battery depletion={10} raw={25} />);
+
+        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        const style = StyleSheet.flatten(bar.props.style) as { height?: number };
+        expect(style.height).toBe(10);
+    });
+
+    it('renders the 16px-tall variant when `tall` is true.', () => {
+        render(<Battery depletion={10} raw={25} tall />);
+
+        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        const style = StyleSheet.flatten(bar.props.style) as { height?: number };
+        expect(style.height).toBe(16);
+    });
+
+    it('positions the notch at raw / scaleMax (80% for raw 25 / depletion 10).', () => {
+        render(<Battery depletion={10} raw={25} />);
+
+        const notch = screen.getByLabelText('raw-notch');
+        const style = StyleSheet.flatten(notch.props.style) as { left?: string };
+        expect(style.left).toBe('80%');
+    });
+});

--- a/app/components/battery/index.tsx
+++ b/app/components/battery/index.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef } from 'react';
+import { Animated, View } from 'react-native';
+
+const tailwindConfig = require('../../tailwind.config.js') as {
+    theme: { extend: { colors: Record<string, string> } };
+};
+const colors = tailwindConfig.theme.extend.colors;
+
+const TRACK_BG = colors['ink-400'];
+const TRACK_BORDER = colors.border;
+const NOTCH_COLOR = colors['chalk-200'];
+
+const TONE_COLOR = {
+    ok: colors.accent,
+    warn: colors.warn,
+    danger: colors.danger,
+} as const;
+
+const TRANSITION_MS = 360;
+
+export type BatteryTone = keyof typeof TONE_COLOR;
+
+/**
+ * Pure geometry helper. Mirrors the math in the source `Battery` component:
+ *
+ *     scaleMax = max(raw * 1.25, depletion + 4)
+ *     pct      = min(100, (depletion / scaleMax) * 100)
+ *     rawPct   = (raw / scaleMax) * 100
+ *     tone     = depletion >= raw          ? 'danger'
+ *              : depletion / raw > 0.8     ? 'warn'
+ *              : 'ok'
+ *
+ * Guards:
+ *   - `depletion` is clamped to 0 (negative depletion = surplus moisture; the
+ *     visual still pegs at the lowest tick).
+ *   - When `raw <= 0` the ratio test is undefined, so `tone` defaults to `ok`
+ *     and the scale is driven entirely by `depletion + 4`.
+ */
+export function computeBatteryGeometry(
+    depletion: number,
+    raw: number,
+): { pct: number; rawPct: number; scaleMax: number; tone: BatteryTone } {
+    const safeDepletion = Math.max(0, depletion);
+    const scaleMax = Math.max(raw * 1.25, safeDepletion + 4);
+    const pct = scaleMax > 0 ? Math.min(100, (safeDepletion / scaleMax) * 100) : 0;
+    const rawPct = scaleMax > 0 && raw > 0 ? (raw / scaleMax) * 100 : 0;
+
+    let tone: BatteryTone = 'ok';
+    if (raw > 0) {
+        if (safeDepletion >= raw) tone = 'danger';
+        else if (safeDepletion / raw > 0.8) tone = 'warn';
+    }
+
+    return { pct, rawPct, scaleMax, tone };
+}
+
+/**
+ * Props for the Irrigo depletion battery primitive.
+ */
+export type BatteryProps = {
+    /** Required. Current depletion in mm. Clamped to 0 if negative. */
+    depletion: number;
+
+    /** Required. RAW threshold in mm (the maximum allowable depletion for the zone). */
+    raw: number;
+
+    /** Optional. Renders the 16px-tall variant used by the Zone detail hero. Defaults to false (compact 10px). */
+    tall?: boolean;
+
+    /** Optional. Accessibility label spoken by screen readers. Defaults to a derived `"{tone} — {depletion} of {raw} mm"` string. */
+    accessibilityLabel?: string;
+};
+
+/**
+ * The Irrigo depletion battery — visually compares the current soil-moisture
+ * depletion against the zone's RAW (readily-available water) threshold.
+ * Track recolors from accent (ok) to warn (≥80% of RAW) to danger (≥ RAW) as
+ * depletion approaches the limit. The notch holds steady at the RAW mark
+ * while the fill grows; both width and tone tween over 360ms.
+ */
+export function Battery({
+    depletion,
+    raw,
+    tall = false,
+    accessibilityLabel,
+}: BatteryProps) {
+    const geometry = computeBatteryGeometry(depletion, raw);
+    const trackHeight = tall ? 16 : 10;
+    const notchOverflow = tall ? 4 : 3;
+
+    const animated = useRef(new Animated.Value(geometry.pct / 100)).current;
+    const toneAnimated = useRef(new Animated.Value(toneIndex(geometry.tone))).current;
+
+    useEffect(() => {
+        Animated.timing(animated, {
+            toValue: geometry.pct / 100,
+            duration: TRANSITION_MS,
+            useNativeDriver: false,
+        }).start();
+    }, [animated, geometry.pct]);
+
+    useEffect(() => {
+        Animated.timing(toneAnimated, {
+            toValue: toneIndex(geometry.tone),
+            duration: TRANSITION_MS,
+            useNativeDriver: false,
+        }).start();
+    }, [toneAnimated, geometry.tone]);
+
+    const fillWidth = animated.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['0%', '100%'],
+    });
+    const fillBackgroundColor = toneAnimated.interpolate({
+        inputRange: [0, 1, 2],
+        outputRange: [TONE_COLOR.ok, TONE_COLOR.warn, TONE_COLOR.danger],
+    });
+
+    const derivedLabel = accessibilityLabel
+        ?? `${geometry.tone} — ${formatMm(depletion)} of ${formatMm(raw)} mm`;
+
+    return (
+        <View
+            accessibilityRole='progressbar'
+            accessibilityLabel={derivedLabel}
+            accessibilityValue={{ min: 0, max: Math.round(geometry.scaleMax * 100) / 100, now: Math.max(0, depletion) }}
+            style={{
+                position: 'relative',
+                width: '100%',
+                height: trackHeight,
+                backgroundColor: TRACK_BG,
+                borderWidth: 1,
+                borderColor: TRACK_BORDER,
+                borderRadius: 4,
+                overflow: 'hidden',
+            }}
+        >
+            <Animated.View
+                style={{
+                    position: 'absolute',
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    width: fillWidth,
+                    backgroundColor: fillBackgroundColor,
+                }}
+            />
+            <View
+                accessibilityLabel='raw-notch'
+                style={{
+                    position: 'absolute',
+                    top: -notchOverflow,
+                    bottom: -notchOverflow,
+                    left: `${geometry.rawPct}%`,
+                    width: 2,
+                    backgroundColor: NOTCH_COLOR,
+                    opacity: 0.8,
+                    borderRadius: 4,
+                }}
+            />
+        </View>
+    );
+}
+
+function toneIndex(tone: BatteryTone): number {
+    if (tone === 'ok') return 0;
+    if (tone === 'warn') return 1;
+    return 2;
+}
+
+function formatMm(value: number): string {
+    return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+}


### PR DESCRIPTION
## Ticket

[APP-17](http://192.168.2.100:7123/irrigo/browse/APP-17/) Depletion Battery primitive (green→amber→red, RAW notch, tall/compact)

## Summary

- RN port of `Battery` from [app/design/irrigo/project/ui_kit/components.jsx:18-37](app/design/irrigo/project/ui_kit/components.jsx) backed by the `.batt` rules in [app/design/irrigo/project/components.css:360-394](app/design/irrigo/project/components.css).
- New [app/components/battery/index.tsx](app/components/battery/index.tsx) + paired `.test.tsx`. Exports `<Battery depletion raw tall? accessibilityLabel? />` and a pure `computeBatteryGeometry(depletion, raw)` helper so the math is unit-testable in isolation.
- Geometry math mirrors the source verbatim: `scaleMax = max(raw × 1.25, depletion + 4)`, fill `pct = min(100, depletion / scaleMax × 100)`, notch `rawPct = raw / scaleMax × 100`. Tone ramp: `depletion >= raw` → danger, `depletion / raw > 0.8` → warn, else ok.
- Animated `Animated.Value` tweens on both fill width and tone color (interpolating across the ok→warn→danger palette), 360ms ease-out to match the design's `--d-3`. Notch is positioned absolutely at the RAW mark and never animates.
- Defensive guards: `raw === 0` short-circuits the ratio test (tone defaults to ok, no NaN); negative `depletion` clamps to 0 so the "surplus moisture" state still pegs at the lowest tick.
- 15 behaviour tests across the pure helper (7) and the component (8) — every tone branch, both heights, the RAW guard, the negative-depletion clamp, the label-override path, and the notch positioning. Full app suite green at 204/204.