### PR TITLE
[APP-36] Convert tailwind.config.js to TypeScript

### DIFF
--- a/app/.vscode/settings.json
+++ b/app/.vscode/settings.json
@@ -3,5 +3,6 @@
     "source.fixAll": "explicit",
     "source.organizeImports": "explicit",
     "source.sortMembers": "explicit"
-  }
+  },
+  "tailwindCSS.experimental.configFile": "tailwind.config.ts"
 }

--- a/app/components/badge/index.tsx
+++ b/app/components/badge/index.tsx
@@ -1,11 +1,9 @@
 import { StyleSheet, Text, View, type ViewStyle, type TextStyle } from 'react-native';
 
 import { FontFamily } from '../../constants/fonts';
+import config from '../../tailwind.config';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: { extend: { colors: Record<string, string> } };
-};
-const colors = tailwindConfig.theme.extend.colors;
+const colors = config.theme.extend.colors;
 
 /**
  * Visual tone selecting the badge's color, border tint, background tint, and

--- a/app/components/battery/index.tsx
+++ b/app/components/battery/index.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { Animated, View } from 'react-native';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: { extend: { colors: Record<string, string> } };
-};
-const colors = tailwindConfig.theme.extend.colors;
+import config from '../../tailwind.config';
+
+const colors = config.theme.extend.colors;
 
 const TRACK_BG = colors['ink-400'];
 const TRACK_BORDER = colors.border;

--- a/app/components/canvas-background.tsx
+++ b/app/components/canvas-background.tsx
@@ -2,10 +2,9 @@ import type { PropsWithChildren } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Svg, { Defs, RadialGradient, Rect, Stop } from 'react-native-svg';
 
-const tailwindConfig = require('../tailwind.config.js') as {
-    theme: { extend: { colors: Record<string, string> } };
-};
-const colors = tailwindConfig.theme.extend.colors;
+import config from '../tailwind.config';
+
+const colors = config.theme.extend.colors;
 
 /**
  * Props for the Irrigo canvas background.
@@ -17,7 +16,7 @@ export type CanvasBackgroundProps = PropsWithChildren<{
 
 const BACKGROUND_COLOR = colors.bg;
 // Soft canvas-backdrop tints shared with the modal scrim (grass-glow-3) and
-// info-tinted surfaces (water-glow). See `tailwind.config.js`.
+// info-tinted surfaces (water-glow). See `tailwind.config.ts`.
 const GREEN_GLOW = colors['grass-glow-3'];
 const BLUE_GLOW = colors['water-glow'];
 

--- a/app/components/card/index.tsx
+++ b/app/components/card/index.tsx
@@ -1,16 +1,10 @@
 import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import type { ReactNode } from 'react';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: {
-        extend: {
-            colors: Record<string, string>;
-            boxShadow: Record<string, string>;
-        };
-    };
-};
-const colors = tailwindConfig.theme.extend.colors;
-const shadows = tailwindConfig.theme.extend.boxShadow;
+import config from '../../tailwind.config';
+
+const colors = config.theme.extend.colors;
+const shadows = config.theme.extend.boxShadow;
 
 /**
  * Visual variant selecting the card's background, padding, radius, and base

--- a/app/components/input/index.tsx
+++ b/app/components/input/index.tsx
@@ -2,10 +2,9 @@ import { useCallback, useState, type ReactNode } from 'react';
 import { TextInput, View, Text, type TextInputProps } from 'react-native';
 import { tv, type VariantProps } from 'tailwind-variants';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: { extend: { colors: Record<string, string> } };
-};
-const colors = tailwindConfig.theme.extend.colors;
+import config from '../../tailwind.config';
+
+const colors = config.theme.extend.colors;
 
 const input = tv({
     slots: {

--- a/app/components/modal/index.tsx
+++ b/app/components/modal/index.tsx
@@ -8,16 +8,10 @@ import {
 import { BlurView } from 'expo-blur';
 import type { ReactNode } from 'react';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: {
-        extend: {
-            colors: Record<string, string>;
-            boxShadow: Record<string, string>;
-        };
-    };
-};
-const colors = tailwindConfig.theme.extend.colors;
-const shadows = tailwindConfig.theme.extend.boxShadow;
+import config from '../../tailwind.config';
+
+const colors = config.theme.extend.colors;
+const shadows = config.theme.extend.boxShadow;
 
 /**
  * Props for the Irrigo modal primitive.

--- a/app/components/sheet/index.tsx
+++ b/app/components/sheet/index.tsx
@@ -8,16 +8,10 @@ import {
 import { BlurView } from 'expo-blur';
 import type { ReactNode } from 'react';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: {
-        extend: {
-            colors: Record<string, string>;
-            boxShadow: Record<string, string>;
-        };
-    };
-};
-const colors = tailwindConfig.theme.extend.colors;
-const shadows = tailwindConfig.theme.extend.boxShadow;
+import config from '../../tailwind.config';
+
+const colors = config.theme.extend.colors;
+const shadows = config.theme.extend.boxShadow;
 
 /**
  * Props for the Irrigo bottom-sheet primitive.

--- a/app/components/toggle/index.tsx
+++ b/app/components/toggle/index.tsx
@@ -2,10 +2,9 @@ import { useEffect, useRef } from 'react';
 import { Animated, Pressable, View } from 'react-native';
 import { tv, type VariantProps } from 'tailwind-variants';
 
-const tailwindConfig = require('../../tailwind.config.js') as {
-    theme: { extend: { colors: Record<string, string> } };
-};
-const colors = tailwindConfig.theme.extend.colors;
+import config from '../../tailwind.config';
+
+const colors = config.theme.extend.colors;
 
 const TRACK_OFF_COLOR = colors['ink-400'];
 const TRACK_ON_COLOR = colors.accent;

--- a/app/tailwind.config.test.ts
+++ b/app/tailwind.config.test.ts
@@ -1,6 +1,6 @@
-import type { Config, PluginAPI } from 'tailwindcss/types/config';
+import type { PluginAPI } from 'tailwindcss/types/config';
 
-const config = require('./tailwind.config.js') as Config;
+import config from './tailwind.config';
 
 const theme = (config.theme?.extend ?? {}) as Record<string, Record<string, unknown>>;
 

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -1,12 +1,14 @@
-const plugin = require('tailwindcss/plugin');
+import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
+// @ts-expect-error — `nativewind/preset` ships an empty `.d.ts`; the CJS module exports a Tailwind preset object at runtime.
+import nativewindPreset from 'nativewind/preset';
 
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
     content: [
         './app/**/*.{js,jsx,ts,tsx}',
         './components/**/*.{js,jsx,ts,tsx}',
     ],
-    presets: [require('nativewind/preset')],
+    presets: [nativewindPreset],
     theme: {
         extend: {
             colors: {
@@ -264,4 +266,4 @@ module.exports = {
             });
         }),
     ],
-};
+} satisfies Config;


### PR DESCRIPTION
## Ticket

[APP-36](http://192.168.2.100:7123/irrigo/browse/APP-36/) — Convert tailwind.config.js to TypeScript and replace require calls with import.

## Summary

- Renamed `app/tailwind.config.js` → `app/tailwind.config.ts` with `import plugin from 'tailwindcss/plugin'`, `import nativewindPreset from 'nativewind/preset'`, and `export default { ... } satisfies Config`.
- Replaced every `require('.../tailwind.config.js') as { ... }` cast in 9 call sites (Badge, Battery, CanvasBackground, Card, Input, Modal, Sheet, Toggle, and the tailwind test) with a typed `import config from '../../tailwind.config'`. The hand-maintained shape casts are gone — call sites infer the type from the config file.
- Suppressed a single type-only error on the `nativewind/preset` import (`@ts-expect-error` with a comment) because that package ships an empty `.d.ts`.

## Test plan

- [x] `bun --cwd=./app run test` — 212 tests across 36 suites pass.
- [x] `bun --cwd=./app run typecheck` — no new errors (the two pre-existing scaffolding errors in `(tabs)/index.tsx` and `modal.tsx` are unrelated).