### PR TITLE
[APP-37] Replace deep relative imports with @/ absolute paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ First-time setup:
 - Dates as ISO-8601 UTC; align DTOs with server contracts. This codebase uses `dayjs` for date handling.
 - Type-check after making changes — run the project's type-check script before declaring work complete.
 - Log liberally via `console.log` / `console.warn` / `console.error` for external calls, state transitions, errors, and significant decisions.
+- **Imports use the `@/*` path alias for anything that isn't a sibling.** Both `api/tsconfig.json` and `app/tsconfig.json` declare `"paths": { "@/*": ["./*"] }`, so write `import { foo } from '@/util/foo'` instead of `'../../util/foo'`. Sibling (`./bar`) and same-folder (`'.'`) imports stay relative — they're already readable. Single-step parent imports (`'../bar'`) are tolerated but `@/` is preferred. Any specifier containing two or more `../` traversals is a bug to fix.
 
 ## Shell commands
 

--- a/app/components/badge/index.tsx
+++ b/app/components/badge/index.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, Text, View, type ViewStyle, type TextStyle } from 'react-native';
 
-import { FontFamily } from '../../constants/fonts';
-import config from '../../tailwind.config';
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 

--- a/app/components/battery/index.tsx
+++ b/app/components/battery/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { Animated, View } from 'react-native';
 
-import config from '../../tailwind.config';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 

--- a/app/components/card/index.tsx
+++ b/app/components/card/index.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import type { ReactNode } from 'react';
 
-import config from '../../tailwind.config';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 const shadows = config.theme.extend.boxShadow;

--- a/app/components/input/index.tsx
+++ b/app/components/input/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState, type ReactNode } from 'react';
 import { TextInput, View, Text, type TextInputProps } from 'react-native';
 import { tv, type VariantProps } from 'tailwind-variants';
 
-import config from '../../tailwind.config';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 

--- a/app/components/modal/index.tsx
+++ b/app/components/modal/index.tsx
@@ -8,7 +8,7 @@ import {
 import { BlurView } from 'expo-blur';
 import type { ReactNode } from 'react';
 
-import config from '../../tailwind.config';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 const shadows = config.theme.extend.boxShadow;

--- a/app/components/sheet/index.tsx
+++ b/app/components/sheet/index.tsx
@@ -8,7 +8,7 @@ import {
 import { BlurView } from 'expo-blur';
 import type { ReactNode } from 'react';
 
-import config from '../../tailwind.config';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 const shadows = config.theme.extend.boxShadow;

--- a/app/components/toggle/index.tsx
+++ b/app/components/toggle/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Animated, Pressable, View } from 'react-native';
 import { tv, type VariantProps } from 'tailwind-variants';
 
-import config from '../../tailwind.config';
+import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 


### PR DESCRIPTION
## Ticket

[APP-37](http://192.168.2.100:7123/irrigo/browse/APP-37/) Replace deep relative imports with `@/` absolute paths

## Summary

- Rewrote 8 imports across 7 component files in `app/components/` from `'../../foo'` to `'@/foo'`. Files touched: `badge`, `battery`, `card`, `input`, `modal`, `sheet`, `toggle`. All previously reached `tailwind.config` (and `badge` also `constants/fonts`) through a two-step parent traversal; now they use the existing `@/*` path alias from `app/tsconfig.json`.
- Left single-step `../tailwind.config` (in `canvas-background.tsx`) and same-folder `'./<sibling>'` imports alone — both forms are already readable.
- Documented the convention in [CLAUDE.md](CLAUDE.md): `@/*` for non-sibling imports across both `api/` and `app/`; two-or-more `../` traversals are a bug.

## Verification

- `bun --cwd=./app typecheck` ✅ (only the pre-existing typed-routes cache noise remains, unrelated)
- `bun --cwd=./app run test` — 212 passed, 36 suites; no regressions.
- `grep "../../" app/components` — zero TS/TSX hits.