### PR TITLE
[API-65] Replace deep relative imports with @/ paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ First-time setup:
 - Dates as ISO-8601 UTC; align DTOs with server contracts. This codebase uses `dayjs` for date handling.
 - Type-check after making changes — run the project's type-check script before declaring work complete.
 - Log liberally via `console.log` / `console.warn` / `console.error` for external calls, state transitions, errors, and significant decisions.
+- **Imports**: use the `@/` path alias for any import that would otherwise cross two or more parent boundaries (i.e. `'../../foo'` or deeper). Both `api/tsconfig.json` and `app/tsconfig.json` map `@/*` to the subproject root. Single-parent (`'../foo'`) and sibling (`'./foo'`, `'.'`) imports stay relative — single-step relatives are still readable. Order imports as: external packages → `@/`-rooted imports → sibling relatives.
 
 ## Shell commands
 

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import dayjs from 'dayjs';
-import { planZoneSchedule } from '.';
-import { createTestZone, GRASS_TYPES, SOIL_TYPES } from '../../mock/zone';
+import { createTestZone, GRASS_TYPES, SOIL_TYPES } from '@/mock/zone';
 import {
     createWeatherDays,
     createDryPeriod,
@@ -9,7 +8,8 @@ import {
     createIntermittentRainfall,
     createVariableET,
     createHeatWave,
-} from '../../mock/weather';
+} from '@/mock/weather';
+import { planZoneSchedule } from '.';
 
 describe('planZoneSchedule', () => {
     // Core Irrigation Scheduling Tests.

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import type { Zone, DailyWeather, IrrigationScheduleEntry, IrrigationCycle } from '../../models';
+import type { Zone, DailyWeather, IrrigationScheduleEntry, IrrigationCycle } from '@/models';
 import {
     isDayAllowed,
     isNightSkipped,


### PR DESCRIPTION
## Ticket

[API-65](http://192.168.2.100:7123/irrigo/browse/API-65/) — Replace deep relative imports with `@/` absolute paths.

## Summary

- Rewrote the three `../../`-rooted import specifiers in `api/schedules/dynamic` (`index.ts`, `.test.ts`) to use the `@/` alias. Single-parent (`../foo`) and sibling (`./foo`, `'.'`) imports are unchanged per ticket scope.
- Reordered the test-file import block so it follows the project convention `external → @/ → ./` after the rewrite.
- Documented the convention as a new bullet in the root `CLAUDE.md` (applies to both `api/` and `app/`, both of which already map `@/*` to the subproject root in `tsconfig.json`).

## Test plan

- [x] `bun --cwd=./api run type-check` — clean.
- [x] `bun --cwd=./api test` — 767 tests across 44 files green.
- [x] Spot grep `git diff main..HEAD` — zero remaining `../../` specifiers anywhere in `api/`.