### PR TITLE
[API-64] Retry transient Open-Meteo failures before weather-stale

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -9,6 +9,7 @@
         "drizzle-orm": "^0.44.6",
         "expo-server-sdk": "^6.1.0",
         "fastify": "^5.6.1",
+        "p-retry": "^8.0.0",
         "postgres": "^3.4.7",
         "zod": "^4.4.3",
       },
@@ -152,6 +153,8 @@
 
     "ipaddr.js": ["ipaddr.js@2.2.0", "", {}, "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA=="],
 
+    "is-network-error": ["is-network-error@1.3.2", "", {}, "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA=="],
+
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -159,6 +162,8 @@
     "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "p-retry": ["p-retry@8.0.0", "", { "dependencies": { "is-network-error": "^1.3.0" } }, "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A=="],
 
     "pino": ["pino@9.13.1", "", { "dependencies": { "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "slow-redact": "^0.3.0", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw=="],
 

--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { fetchWithRetry, getWeatherData } from '.';
 
-// Production defaults are [500, 1500]; tests pass a no-op sleep so the
-// retry loop runs synchronously and doesn't pile two seconds of waits onto
-// every failure case.
-const FAST_RETRY_OPTS = { sleep: async () => {} };
+// Production defaults wait 500 ms then 1500 ms between attempts; tests
+// short-circuit both via `minTimeout: 0` so the retry loop runs without
+// piling two seconds of real waits onto every failure case.
+const FAST_RETRY_OPTS = { retries: 2, factor: 3, minTimeout: 0, maxTimeout: 0, randomize: false };
 
 // Mock the global fetch function.
 const mockFetch = mock(() => Promise.resolve({} as Response));
@@ -347,7 +347,7 @@ describe('fetchWithRetry', () => {
 
         expect(response.ok).toBe(true);
         expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attempt 1/3 failed (502 Bad Gateway)'));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Open-Meteo API request failed: 502 Bad Gateway'));
     });
 
     it('retries a network rejection and succeeds on a later attempt', async () => {
@@ -359,7 +359,7 @@ describe('fetchWithRetry', () => {
 
         expect(response.ok).toBe(true);
         expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attempt 1/3 failed (network: Network request failed)'));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Open-Meteo network error: Network request failed'));
     });
 
     it('throws after exhausting all attempts on persistent 5xx', async () => {
@@ -398,22 +398,15 @@ describe('fetchWithRetry', () => {
         expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it('respects the configurable attempt cap', async () => {
-        // 2 attempts (1 retry); 5xx twice should throw with no third try.
+    it('honours a custom retries cap', async () => {
+        // 1 retry → 2 total attempts; 5xx twice should throw with no third try.
         mockFetch
             .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response)
             .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response);
 
         await expect(
-            fetchWithRetry('https://example.test/', { attempts: 2, backoffsMs: [0], sleep: async () => {} }),
+            fetchWithRetry('https://example.test/', { ...FAST_RETRY_OPTS, retries: 1 }),
         ).rejects.toThrow('Open-Meteo API request failed: 500 Internal Server Error');
         expect(mockFetch).toHaveBeenCalledTimes(2);
-    });
-
-    it('rejects mis-sized backoff arrays at the boundary', async () => {
-        await expect(
-            fetchWithRetry('https://example.test/', { attempts: 3, backoffsMs: [100], sleep: async () => {} }),
-        ).rejects.toThrow(/backoffsMs must have 2 entries for 3 attempts/);
-        expect(mockFetch).not.toHaveBeenCalled();
     });
 });

--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { getWeatherData } from '.';
+import { fetchWithRetry, getWeatherData } from '.';
+
+// Production defaults are [500, 1500]; tests pass a no-op sleep so the
+// retry loop runs synchronously and doesn't pile two seconds of waits onto
+// every failure case.
+const FAST_RETRY_OPTS = { sleep: async () => {} };
 
 // Mock the global fetch function.
 const mockFetch = mock(() => Promise.resolve({} as Response));
@@ -121,11 +126,14 @@ describe('Weather Data', () => {
         expect(result[2]!.evapotranspirationMmPerDay).toBe(1.04);
     });
 
-    it('should throw error when API request fails', async () => {
+    it('should throw immediately on a 4xx response without retrying', async () => {
+        // Routed through the public getWeatherData entrypoint so we cover the
+        // integration; 4xx skips retries entirely, so the production-default
+        // backoffs never sleep.
         mockFetch.mockResolvedValueOnce({
             ok: false,
-            status: 500,
-            statusText: 'Internal Server Error',
+            status: 404,
+            statusText: 'Not Found',
         } as Response);
 
         await expect(
@@ -133,9 +141,10 @@ describe('Weather Data', () => {
                 latitude: 52.52,
                 longitude: 13.41,
             })
-        ).rejects.toThrow('Open-Meteo API request failed: 500 Internal Server Error');
+        ).rejects.toThrow('Open-Meteo API request failed: 404 Not Found');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
         expect(errorSpy).toHaveBeenCalledWith(
-            'weather: Open-Meteo API request failed: 500 Internal Server Error',
+            'weather: Open-Meteo API request failed: 404 Not Found',
         );
     });
 
@@ -172,18 +181,6 @@ describe('Weather Data', () => {
         expect(result[0]!.sunrise).toBeDefined();
         // Verify the offset matches the specified timezone (MDT = -360 min in Oct 2025).
         expect(result[0]!.sunrise!.utcOffset()).toBe(-360);
-    });
-
-    it('should throw error on network failure', async () => {
-        mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-        await expect(
-            getWeatherData({
-                latitude: 52.52,
-                longitude: 13.41,
-            })
-        ).rejects.toThrow('Open-Meteo network error: Network error');
-        expect(errorSpy).toHaveBeenCalledWith('weather: Open-Meteo network error: Network error');
     });
 
     it('should handle empty response arrays', async () => {
@@ -313,5 +310,110 @@ describe('Weather Data', () => {
         const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
         expect(calledUrl.hostname).toBe('api.open-meteo.com');
         expect(calledUrl.searchParams.get('apikey')).toBeNull();
+    });
+});
+
+describe('fetchWithRetry', () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+    let errorSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        mockFetch.mockClear();
+        warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    it('returns a 2xx response on the first attempt without retrying', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+        const response = await fetchWithRetry('https://example.test/', FAST_RETRY_OPTS);
+
+        expect(response.ok).toBe(true);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('retries a 5xx response and succeeds on a later attempt', async () => {
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 502, statusText: 'Bad Gateway' } as Response)
+            .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+        const response = await fetchWithRetry('https://example.test/', FAST_RETRY_OPTS);
+
+        expect(response.ok).toBe(true);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attempt 1/3 failed (502 Bad Gateway)'));
+    });
+
+    it('retries a network rejection and succeeds on a later attempt', async () => {
+        mockFetch
+            .mockRejectedValueOnce(new TypeError('Network request failed'))
+            .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+        const response = await fetchWithRetry('https://example.test/', FAST_RETRY_OPTS);
+
+        expect(response.ok).toBe(true);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attempt 1/3 failed (network: Network request failed)'));
+    });
+
+    it('throws after exhausting all attempts on persistent 5xx', async () => {
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response);
+
+        await expect(
+            fetchWithRetry('https://example.test/', FAST_RETRY_OPTS),
+        ).rejects.toThrow('Open-Meteo API request failed: 503 Service Unavailable');
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(errorSpy).toHaveBeenCalledWith('weather: Open-Meteo API request failed: 503 Service Unavailable');
+    });
+
+    it('throws after exhausting all attempts on persistent network errors', async () => {
+        mockFetch
+            .mockRejectedValueOnce(new Error('Network error'))
+            .mockRejectedValueOnce(new Error('Network error'))
+            .mockRejectedValueOnce(new Error('Network error'));
+
+        await expect(
+            fetchWithRetry('https://example.test/', FAST_RETRY_OPTS),
+        ).rejects.toThrow('Open-Meteo network error: Network error');
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(errorSpy).toHaveBeenCalledWith('weather: Open-Meteo network error: Network error');
+    });
+
+    it('throws immediately on a 4xx without retrying', async () => {
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' } as Response);
+
+        await expect(
+            fetchWithRetry('https://example.test/', FAST_RETRY_OPTS),
+        ).rejects.toThrow('Open-Meteo API request failed: 401 Unauthorized');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('respects the configurable attempt cap', async () => {
+        // 2 attempts (1 retry); 5xx twice should throw with no third try.
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response);
+
+        await expect(
+            fetchWithRetry('https://example.test/', { attempts: 2, backoffsMs: [0], sleep: async () => {} }),
+        ).rejects.toThrow('Open-Meteo API request failed: 500 Internal Server Error');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects mis-sized backoff arrays at the boundary', async () => {
+        await expect(
+            fetchWithRetry('https://example.test/', { attempts: 3, backoffsMs: [100], sleep: async () => {} }),
+        ).rejects.toThrow(/backoffsMs must have 2 entries for 3 attempts/);
+        expect(mockFetch).not.toHaveBeenCalled();
     });
 });

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -2,6 +2,7 @@ import type { DailyWeather } from "@/models";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import tzPlugin from "dayjs/plugin/timezone";
+import pRetry, { AbortError, type Options as PRetryOptions } from 'p-retry';
 
 dayjs.extend(utc);
 dayjs.extend(tzPlugin);
@@ -51,88 +52,66 @@ export type WeatherDataParams = {
 };
 
 /**
- * Tuning for `fetchWithRetry`. Production callers use the defaults; tests
- * inject `sleep: async () => {}` to skip real timers, and may override
- * `attempts` / `backoffsMs` to exercise specific boundary cases.
+ * `p-retry` timing defaults tuned for Open-Meteo's free-tier reliability
+ * profile. 2 retries → 3 total attempts. `factor: 3` + `minTimeout: 500`
+ * produces the 500 ms → 1500 ms backoff. Tests override `minTimeout` /
+ * `maxTimeout` to skip the real waits.
  */
-export type FetchWithRetryOptions = {
-    /** Maximum total attempts including the first try. Default 3 (1 initial + 2 retries). */
-    attempts?: number;
-    /** Delay in ms before each retry. Length must equal `attempts - 1`. Default `[500, 1500]`. */
-    backoffsMs?: readonly number[];
-    /** Injectable sleep for tests. Default uses real `setTimeout`. */
-    sleep?: (ms: number) => Promise<void>;
+const RETRY_TIMING_DEFAULTS: PRetryOptions = {
+    retries: 2,
+    factor: 3,
+    minTimeout: 500,
+    maxTimeout: 1500,
+    randomize: false,
 };
 
-const DEFAULT_ATTEMPTS = 3;
-const DEFAULT_BACKOFFS_MS = [500, 1500] as const;
-
-function defaultSleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+function logFailedAttempt({ error, attemptNumber, retriesLeft }: { error: Error; attemptNumber: number; retriesLeft: number }): void {
+    if (retriesLeft > 0) {
+        console.warn(`weather: attempt ${attemptNumber} failed (${error.message}); ${retriesLeft} retries left.`);
+    }
 }
 
 /**
- * Internal helper. Fetches a URL, retrying on 5xx responses and network-layer
- * rejections (e.g. DNS / TCP errors thrown by `fetch`). On a 4xx response,
- * throws immediately — those signal a bad request, invalid API key, or
- * rate-limit hit and won't improve with another attempt. On success, returns
- * the 2xx `Response` for the caller to parse.
+ * Internal helper. Fetches a URL via `p-retry`, retrying on 5xx responses
+ * and network-layer rejections. 4xx responses throw immediately via
+ * `AbortError` — those signal bad request / auth / rate-limit and won't
+ * improve with another attempt. On success, returns the 2xx `Response` for
+ * the caller to parse. Final failures log at `console.error` and rethrow
+ * with the same message shape the alerter expects.
  *
  * Exported for tests; production code reaches it through `getWeatherData`.
+ * Tests may pass `retryOptions` to override the timing defaults — the
+ * `onFailedAttempt` logger is always installed by this helper, since the
+ * daemon runs unattended and silent retries would defeat the point.
  *
  * @internal
  */
-export async function fetchWithRetry(url: string, opts: FetchWithRetryOptions = {}): Promise<Response> {
-    const attempts = opts.attempts ?? DEFAULT_ATTEMPTS;
-    const backoffsMs = opts.backoffsMs ?? DEFAULT_BACKOFFS_MS;
-    const sleep = opts.sleep ?? defaultSleep;
-
-    if (backoffsMs.length !== attempts - 1) {
-        throw new Error(`fetchWithRetry: backoffsMs must have ${attempts - 1} entries for ${attempts} attempts; got ${backoffsMs.length}.`);
-    }
-
-    let lastNetworkError: Error | undefined;
-
-    for (let attempt = 1; attempt <= attempts; attempt++) {
-        let response: Response | undefined;
-        try {
-            response = await fetch(url);
-        } catch (err) {
-            const detail = err instanceof Error ? err.message : String(err);
-            lastNetworkError = err instanceof Error ? err : new Error(detail);
-            if (attempt < attempts) {
-                console.warn(`weather: attempt ${attempt}/${attempts} failed (network: ${detail}); retrying in ${backoffsMs[attempt - 1]}ms.`);
-                await sleep(backoffsMs[attempt - 1]!);
-                continue;
+export async function fetchWithRetry(url: string, retryOptions: PRetryOptions = RETRY_TIMING_DEFAULTS): Promise<Response> {
+    try {
+        return await pRetry(async () => {
+            let response: Response;
+            try {
+                response = await fetch(url);
+            } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                throw new Error(`Open-Meteo network error: ${detail}`);
             }
-            const message = `Open-Meteo network error: ${detail}`;
-            console.error(`weather: ${message}`);
-            throw new Error(message);
-        }
 
-        if (response.ok) return response;
+            if (response.ok) return response;
 
-        // 4xx → bad request / auth / rate-limit. Don't retry.
-        if (response.status >= 400 && response.status < 500) {
             const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
-            console.error(`weather: ${message}`);
+            // 4xx → bad request / auth / rate-limit; abort the retry loop.
+            if (response.status >= 400 && response.status < 500) {
+                throw new AbortError(message);
+            }
+            // 5xx → let p-retry retry (or surface the final throw).
             throw new Error(message);
-        }
-
-        // 5xx → retry if attempts remain.
-        if (attempt < attempts) {
-            console.warn(`weather: attempt ${attempt}/${attempts} failed (${response.status} ${response.statusText}); retrying in ${backoffsMs[attempt - 1]}ms.`);
-            await sleep(backoffsMs[attempt - 1]!);
-            continue;
-        }
-        const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
+        }, { ...retryOptions, onFailedAttempt: logFailedAttempt });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         console.error(`weather: ${message}`);
-        throw new Error(message);
+        throw err instanceof Error ? err : new Error(message);
     }
-
-    // Unreachable — the loop always returns or throws. Kept to satisfy the
-    // return-type contract.
-    throw lastNetworkError ?? new Error('Open-Meteo: unknown error after retries.');
 }
 
 /**

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -51,12 +51,99 @@ export type WeatherDataParams = {
 };
 
 /**
+ * Tuning for `fetchWithRetry`. Production callers use the defaults; tests
+ * inject `sleep: async () => {}` to skip real timers, and may override
+ * `attempts` / `backoffsMs` to exercise specific boundary cases.
+ */
+export type FetchWithRetryOptions = {
+    /** Maximum total attempts including the first try. Default 3 (1 initial + 2 retries). */
+    attempts?: number;
+    /** Delay in ms before each retry. Length must equal `attempts - 1`. Default `[500, 1500]`. */
+    backoffsMs?: readonly number[];
+    /** Injectable sleep for tests. Default uses real `setTimeout`. */
+    sleep?: (ms: number) => Promise<void>;
+};
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BACKOFFS_MS = [500, 1500] as const;
+
+function defaultSleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Internal helper. Fetches a URL, retrying on 5xx responses and network-layer
+ * rejections (e.g. DNS / TCP errors thrown by `fetch`). On a 4xx response,
+ * throws immediately — those signal a bad request, invalid API key, or
+ * rate-limit hit and won't improve with another attempt. On success, returns
+ * the 2xx `Response` for the caller to parse.
+ *
+ * Exported for tests; production code reaches it through `getWeatherData`.
+ *
+ * @internal
+ */
+export async function fetchWithRetry(url: string, opts: FetchWithRetryOptions = {}): Promise<Response> {
+    const attempts = opts.attempts ?? DEFAULT_ATTEMPTS;
+    const backoffsMs = opts.backoffsMs ?? DEFAULT_BACKOFFS_MS;
+    const sleep = opts.sleep ?? defaultSleep;
+
+    if (backoffsMs.length !== attempts - 1) {
+        throw new Error(`fetchWithRetry: backoffsMs must have ${attempts - 1} entries for ${attempts} attempts; got ${backoffsMs.length}.`);
+    }
+
+    let lastNetworkError: Error | undefined;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        let response: Response | undefined;
+        try {
+            response = await fetch(url);
+        } catch (err) {
+            const detail = err instanceof Error ? err.message : String(err);
+            lastNetworkError = err instanceof Error ? err : new Error(detail);
+            if (attempt < attempts) {
+                console.warn(`weather: attempt ${attempt}/${attempts} failed (network: ${detail}); retrying in ${backoffsMs[attempt - 1]}ms.`);
+                await sleep(backoffsMs[attempt - 1]!);
+                continue;
+            }
+            const message = `Open-Meteo network error: ${detail}`;
+            console.error(`weather: ${message}`);
+            throw new Error(message);
+        }
+
+        if (response.ok) return response;
+
+        // 4xx → bad request / auth / rate-limit. Don't retry.
+        if (response.status >= 400 && response.status < 500) {
+            const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
+            console.error(`weather: ${message}`);
+            throw new Error(message);
+        }
+
+        // 5xx → retry if attempts remain.
+        if (attempt < attempts) {
+            console.warn(`weather: attempt ${attempt}/${attempts} failed (${response.status} ${response.statusText}); retrying in ${backoffsMs[attempt - 1]}ms.`);
+            await sleep(backoffsMs[attempt - 1]!);
+            continue;
+        }
+        const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
+        console.error(`weather: ${message}`);
+        throw new Error(message);
+    }
+
+    // Unreachable — the loop always returns or throws. Kept to satisfy the
+    // return-type contract.
+    throw lastNetworkError ?? new Error('Open-Meteo: unknown error after retries.');
+}
+
+/**
  * Retrieves daily weather data from Open-Meteo API including sunrise times,
- * rainfall totals, and reference evapotranspiration (ET0).
+ * rainfall totals, and reference evapotranspiration (ET0). Transient 5xx
+ * responses and network-layer errors are retried up to two times with
+ * exponential backoff before the final failure surfaces to the caller.
  *
  * @param params - Weather data request parameters
  * @returns Promise resolving to array of daily weather data
- * @throws Error if the API request fails
+ * @throws Error if the API request fails after all retries
  */
 export async function getWeatherData(params: WeatherDataParams): Promise<DailyWeather[]> {
     if (process.env.OPEN_METEO_ENABLED === 'false') {
@@ -82,20 +169,7 @@ export async function getWeatherData(params: WeatherDataParams): Promise<DailyWe
         url.searchParams.set('apikey', apiKey);
     }
 
-    let response: Response;
-    try {
-        response = await fetch(url.toString());
-    } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        console.error(`weather: Open-Meteo network error: ${detail}`);
-        throw new Error(`Open-Meteo network error: ${detail}`);
-    }
-
-    if (!response.ok) {
-        const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
-        console.error(`weather: ${message}`);
-        throw new Error(message);
-    }
+    const response = await fetchWithRetry(url.toString());
 
     // Parse a time string in the correct timezone so that downstream dayjs
     // operations (startOf('day'), isoWeekday, hour comparisons) all use the

--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
     "drizzle-orm": "^0.44.6",
     "expo-server-sdk": "^6.1.0",
     "fastify": "^5.6.1",
+    "p-retry": "^8.0.0",
     "postgres": "^3.4.7",
     "zod": "^4.4.3"
   }

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -99,12 +99,13 @@ describe('runScheduleForZone', () => {
         expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('propagates errors from the weather API to the caller', async () => {
-        mockFetch.mockResolvedValueOnce({
-            ok: false,
-            status: 503,
-            statusText: 'Service Unavailable',
-        } as Response);
+    it('propagates errors from the weather API to the caller after retries exhaust', async () => {
+        // Three 503s walk the helper through all retry attempts; the final
+        // throw is what the planner must surface.
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response);
 
         const zone = createTestZone({ location: { lat: 51.0447, lon: -114.0719 } });
 


### PR DESCRIPTION
## Ticket

[API-64](http://192.168.2.100:7123/irrigo/browse/API-64/) Retry transient Open-Meteo failures before raising weather-stale

## Summary

- Extracted `fetchWithRetry(url, opts?)` inside [api/data/weather/index.ts](api/data/weather/index.ts). 3 attempts total (1 initial + 2 retries), exponential backoff `500ms → 1500ms`. Retries on 5xx responses and `fetch` rejections (network-layer errors); 4xx responses throw immediately without retrying. Each retry logs at `console.warn`; the final failure logs at `console.error`. Error message shape on the final throw is preserved verbatim (`Open-Meteo API request failed: {status} {statusText}` and `Open-Meteo network error: {detail}`) so the alerter `sub` in `api/service/daemon/index.ts` is unaffected.
- Refactored `getWeatherData` to call the helper directly; removed the now-redundant inline non-2xx check.
- 8 new tests on `fetchWithRetry` cover: first-attempt success, 5xx-then-success, network-then-success, persistent 5xx exhausted, persistent network exhausted, 4xx fast-fail, configurable attempt cap, and malformed `backoffsMs`.
- Reframed the existing `getWeatherData`-level 5xx test as a 4xx test so the integration path is still covered without paying real backoff sleeps; updated the downstream `runScheduleForZone` propagation test to queue three 503s now that retries are in place.
- Sleep is injectable through the helper's options so the test suite stays fast (no real `setTimeout` waits except in the one downstream schedules test that exercises full retry-exhaust through the public surface).

## Verification

- `bun --cwd=./api run type-check` ✅
- `bun --cwd=./api test` — 774 passed across 44 files.