### PR TITLE
[API-63] Rewrite operator-facing notification copy

### DIFF
--- a/api/alerts/.test.ts
+++ b/api/alerts/.test.ts
@@ -161,7 +161,7 @@ describe('createAlerter', () => {
             return { notifier: async (event, context) => { calls.push({ event, context }); }, calls };
         }
 
-        it('fires the notifier with operation=class and reason=sub on a brand-new insert', async () => {
+        it('fires the notifier with errorTitle=title and errorSub=sub on a brand-new insert', async () => {
             const { db } = createRecorderStub([]);
             const { notifier, calls: notifications } = recordingNotifier();
 
@@ -172,19 +172,20 @@ describe('createAlerter', () => {
                 event: 'error',
                 context: {
                     zoneName: 'North',
-                    operation: 'ha-call-failed',
-                    reason: 'North · ECONNREFUSED',
+                    errorTitle: 'HA close failed',
+                    errorSub: 'North · ECONNREFUSED',
                 },
             });
         });
 
-        it('falls back to title when sub is omitted', async () => {
+        it('omits errorSub from the context when the event has no sub', async () => {
             const { db } = createRecorderStub([]);
             const { notifier, calls: notifications } = recordingNotifier();
 
             await createAlerter(db, notifier)(event({ sub: undefined, title: 'HA open failed' }));
 
-            expect(notifications[0]?.context?.reason).toBe('HA open failed');
+            expect(notifications[0]?.context?.errorTitle).toBe('HA open failed');
+            expect(notifications[0]?.context).not.toHaveProperty('errorSub');
         });
 
         it('omits zoneName from the context when the event has none (global alert)', async () => {
@@ -194,7 +195,7 @@ describe('createAlerter', () => {
             await createAlerter(db, notifier)(event({ zoneName: undefined, zoneId: undefined }));
 
             expect(notifications[0]?.context).not.toHaveProperty('zoneName');
-            expect(notifications[0]?.context?.operation).toBe('ha-call-failed');
+            expect(notifications[0]?.context?.errorTitle).toBe('HA close failed');
         });
 
         it('does NOT fire the notifier when an existing unacked alert is updated (dedup hit)', async () => {

--- a/api/alerts/index.ts
+++ b/api/alerts/index.ts
@@ -166,8 +166,8 @@ export function createAlerter(db: AlertsDb, notifier?: Notifier, pushDispatcher?
         if (notifier) {
             await notifier('error', {
                 ...(event.zoneName !== undefined ? { zoneName: event.zoneName } : {}),
-                operation: event.class,
-                reason: event.sub ?? event.title,
+                errorTitle: event.title,
+                ...(event.sub !== undefined ? { errorSub: event.sub } : {}),
             });
         }
 

--- a/api/notifications/.test.ts
+++ b/api/notifications/.test.ts
@@ -53,7 +53,7 @@ describe('createNotifier', () => {
         const notifier = createNotifier();
 
         expect(notifier).toBe(noopNotifier);
-        await notifier('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'oops' });
+        await notifier('error', { zoneName: 'Front Lawn', errorTitle: 'Manual open failed', errorSub: 'Last attempt failed: oops.' });
         expect(mockFetch).not.toHaveBeenCalled();
         expect(warnSpy).toHaveBeenCalledTimes(1);
     });
@@ -124,7 +124,7 @@ describe('createNotifier', () => {
     it('POSTs an error event by default (errors should be loud)', async () => {
         const notifier = createNotifier();
 
-        await notifier('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'HA down' });
+        await notifier('error', { zoneName: 'Front Lawn', errorTitle: 'HA open failed', errorSub: 'Last attempt failed: HA down.' });
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -154,45 +154,11 @@ describe('createNotifier', () => {
         expect(parsed.message).toContain('2026-05-15');
     });
 
-    it('builds a manual-fire qualified message for manual-driven watering-started events', async () => {
-        process.env.NOTIFY_ON_WATERING_START = 'true';
-        const notifier = createNotifier();
-
-        await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20, reason: 'manual' });
-
-        const init = mockFetch.mock.calls[0]![1] as RequestInit;
-        const message = (JSON.parse(init.body as string) as { message: string }).message;
-        expect(message).toContain('manual fire');
-    });
-
-    it('builds a shutdown-qualified message for shutdown-driven watering-ended events', async () => {
-        process.env.NOTIFY_ON_WATERING_END = 'true';
-        const notifier = createNotifier();
-
-        await notifier('watering-ended', { zoneName: 'Front Lawn', reason: 'shutdown' });
-
-        const init = mockFetch.mock.calls[0]![1] as RequestInit;
-        const message = (JSON.parse(init.body as string) as { message: string }).message;
-        expect(message).toContain('shutdown');
-    });
-
-    it('includes operation and reason in error event messages', async () => {
-        const notifier = createNotifier();
-
-        await notifier('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
-
-        const init = mockFetch.mock.calls[0]![1] as RequestInit;
-        const message = (JSON.parse(init.body as string) as { message: string }).message;
-        expect(message).toContain('open');
-        expect(message).toContain('HA 502');
-        expect(message).toContain('Front Lawn');
-    });
-
     it('swallows fetch rejections without throwing and logs a warning', async () => {
         mockFetch.mockRejectedValueOnce(new Error('network down'));
         const notifier = createNotifier();
 
-        await expect(notifier('error', { operation: 'open', reason: 'oops' })).resolves.toBeUndefined();
+        await expect(notifier('error', { errorTitle: 'HA open failed', errorSub: 'Last attempt failed: oops.' })).resolves.toBeUndefined();
         expect(warnSpy).toHaveBeenCalled();
     });
 
@@ -200,7 +166,7 @@ describe('createNotifier', () => {
         mockFetch.mockResolvedValueOnce({ ok: false, status: 502, statusText: 'Bad Gateway' } as Response);
         const notifier = createNotifier();
 
-        await expect(notifier('error', { operation: 'open', reason: 'oops' })).resolves.toBeUndefined();
+        await expect(notifier('error', { errorTitle: 'HA open failed', errorSub: 'Last attempt failed: oops.' })).resolves.toBeUndefined();
         expect(warnSpy).toHaveBeenCalled();
     });
 
@@ -208,7 +174,7 @@ describe('createNotifier', () => {
         process.env.NOTIFY_ON_ERROR = 'false';
         const notifier = createNotifier();
 
-        await notifier('error', { operation: 'open', reason: 'oops' });
+        await notifier('error', { errorTitle: 'HA open failed', errorSub: 'Last attempt failed: oops.' });
 
         expect(mockFetch).not.toHaveBeenCalled();
     });
@@ -225,99 +191,103 @@ describe('createNotifier', () => {
     });
 });
 
-describe('buildMessage', () => {
-    it('names the irrigation night for schedule-begun', () => {
-        const msg = buildMessage('schedule-begun', { scheduleNight: '2026-05-15' });
-        expect(msg).toContain('Irrigation schedule started');
-        expect(msg).toContain('2026-05-15');
+// Golden-string assertions. These pin the exact operator-facing copy for every
+// `(event, context)` combination so the next time someone touches a builder,
+// the diff is intentional (it forces the test author to update the literal).
+//
+// API-63 added these after a push leaked `weather-stale on South: Planner on
+// fallback ET₀ ·` to a phone. The asserts below cover that scenario and every
+// other branch in `buildMessage` end-to-end.
+describe('buildMessage — golden output', () => {
+    it('schedule-begun (with night) — exact string.', () => {
+        expect(buildMessage('schedule-begun', { scheduleNight: '2026-05-15' }))
+            .toBe('Irrigation schedule started for the night of 2026-05-15.');
     });
 
-    it('falls back to a generic schedule-begun message when scheduleNight is omitted', () => {
-        const msg = buildMessage('schedule-begun', {});
-        expect(msg).toContain('Irrigation schedule started');
-        expect(msg).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+    it('schedule-begun (no context) — generic fallback.', () => {
+        expect(buildMessage('schedule-begun'))
+            .toBe('Irrigation schedule started.');
     });
 
-    it('formats the per-zone summary alphabetically for schedule-ended', () => {
+    it('schedule-ended (per-zone summary + next, fixed timezone) — exact string.', () => {
         const msg = buildMessage('schedule-ended', {
             scheduleNight: '2026-05-15',
             perZoneRuntimeMin: { South: 32, North: 47, East: 28 },
             siteTimezone: 'America/Edmonton',
-        });
-        expect(msg).toContain('Irrigation complete');
-        // Alphabetical ordering of zone names.
-        expect(msg.indexOf('East')).toBeLessThan(msg.indexOf('North'));
-        expect(msg.indexOf('North')).toBeLessThan(msg.indexOf('South'));
-        expect(msg).toContain('East 28 min');
-        expect(msg).toContain('North 47 min');
-        expect(msg).toContain('South 32 min');
-    });
-
-    it('appends the next-irrigation line in site-local time for schedule-ended', () => {
-        const msg = buildMessage('schedule-ended', {
-            scheduleNight: '2026-05-15',
-            perZoneRuntimeMin: { North: 47 },
-            siteTimezone: 'America/Edmonton',
-            // 2026-05-23T04:23Z = 22:23 MDT on 2026-05-22.
+            // 2026-05-23T04:23Z = 22:23 MDT on 2026-05-22 (Friday).
             nextIrrigation: { zoneName: 'North', startTime: new Date('2026-05-23T04:23:00.000Z') },
         });
-        expect(msg).toContain('Next irrigation: North');
-        expect(msg).toContain('Fri 22 May');
-        expect(msg).toContain('10:23pm');
+        expect(msg).toBe('Irrigation complete: East 28 min, North 47 min, South 32 min. Next irrigation: North on Fri 22 May at 10:23pm.');
     });
 
-    it('omits the next-irrigation line when none is provided', () => {
-        const msg = buildMessage('schedule-ended', {
-            scheduleNight: '2026-05-15',
-            perZoneRuntimeMin: { North: 47 },
-            siteTimezone: 'America/Edmonton',
-        });
-        expect(msg).not.toContain('Next irrigation');
+    it('schedule-ended (no summary, no next) — generic complete message.', () => {
+        expect(buildMessage('schedule-ended', { scheduleNight: '2026-05-15' }))
+            .toBe('Irrigation complete.');
     });
 
-    it('rounds fractional minutes in the summary to one decimal', () => {
-        const msg = buildMessage('schedule-ended', {
+    it('schedule-ended rounds fractional minutes to one decimal.', () => {
+        expect(buildMessage('schedule-ended', {
             scheduleNight: '2026-05-15',
             perZoneRuntimeMin: { North: 47.36 },
             siteTimezone: 'America/Edmonton',
+        })).toBe('Irrigation complete: North 47.4 min.');
+    });
+
+    it('watering-started (auto-fire, with duration) — exact string.', () => {
+        expect(buildMessage('watering-started', { zoneName: 'Front Lawn', durationMin: 20 }))
+            .toBe('Front Lawn watering started (~20 min).');
+    });
+
+    it('watering-started (manual fire, with duration) — exact string.', () => {
+        expect(buildMessage('watering-started', { zoneName: 'Front Lawn', durationMin: 20, reason: 'manual' }))
+            .toBe('Front Lawn watering started (~20 min) (manual fire).');
+    });
+
+    it('watering-started (no duration, missing zone name) — falls back to Zone.', () => {
+        expect(buildMessage('watering-started', {}))
+            .toBe('Zone watering started.');
+    });
+
+    it('watering-ended (default) — exact string.', () => {
+        expect(buildMessage('watering-ended', { zoneName: 'Back Garden' }))
+            .toBe('Back Garden watering ended.');
+    });
+
+    it('watering-ended (shutdown) — exact string.', () => {
+        expect(buildMessage('watering-ended', { zoneName: 'Back Garden', reason: 'shutdown' }))
+            .toBe('Back Garden watering ended (closed during daemon shutdown).');
+    });
+
+    it('watering-ended (manual) — exact string.', () => {
+        expect(buildMessage('watering-ended', { zoneName: 'Back Garden', reason: 'manual' }))
+            .toBe('Back Garden watering ended (manual fire).');
+    });
+
+    it('error (zone + title + sub — the original bug scenario, now ASCII and slug-free).', () => {
+        const msg = buildMessage('error', {
+            zoneName: 'South',
+            errorTitle: 'Weather API stale',
+            errorSub: 'Planner using fallback ET zero. Last fetch error: 502 Bad Gateway.',
         });
-        expect(msg).toContain('North 47.4 min');
+        expect(msg).toBe('South: Weather API stale. Planner using fallback ET zero. Last fetch error: 502 Bad Gateway.');
+        // Guardrails: the slug, the subscript, and the middot must never leak.
+        expect(msg).not.toContain('weather-stale');
+        expect(msg).not.toContain('·');
+        expect(msg).not.toContain('₀');
     });
 
-    it('includes zone name and duration for watering-started (manual fire)', () => {
-        const msg = buildMessage('watering-started', { zoneName: 'Front Lawn', durationMin: 20, reason: 'manual' });
-        expect(msg).toContain('Front Lawn');
-        expect(msg).toContain('20');
-        expect(msg).toContain('manual fire');
+    it('error (zone + title, no sub) — exact string.', () => {
+        expect(buildMessage('error', { zoneName: 'North', errorTitle: 'HA close failed' }))
+            .toBe('North: HA close failed.');
     });
 
-    it('omits duration for watering-started when not provided', () => {
-        const msg = buildMessage('watering-started', { zoneName: 'Front Lawn' });
-        expect(msg).toContain('Front Lawn');
-        expect(msg).not.toContain('min');
+    it('error (title only, no zone, no sub) — exact string.', () => {
+        expect(buildMessage('error', { errorTitle: 'Weather API stale' }))
+            .toBe('Weather API stale.');
     });
 
-    it('returns a simple ended message for watering-ended', () => {
-        const msg = buildMessage('watering-ended', { zoneName: 'Back Garden' });
-        expect(msg).toContain('Back Garden');
-        expect(msg).toContain('watering ended');
-        expect(msg).not.toContain('shutdown');
-    });
-
-    it('appends shutdown qualifier for watering-ended with reason=shutdown', () => {
-        const msg = buildMessage('watering-ended', { zoneName: 'Back Garden', reason: 'shutdown' });
-        expect(msg).toContain('shutdown');
-    });
-
-    it('includes operation and reason for error events', () => {
-        const msg = buildMessage('error', { zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
-        expect(msg).toContain('Front Lawn');
-        expect(msg).toContain('open');
-        expect(msg).toContain('HA 502');
-    });
-
-    it('falls back to Zone when zoneName is omitted', () => {
-        const msg = buildMessage('watering-started', {});
-        expect(msg).toContain('Zone');
+    it('error (no context at all) — generic fallback.', () => {
+        expect(buildMessage('error'))
+            .toBe('Irrigo error.');
     });
 });

--- a/api/notifications/index.ts
+++ b/api/notifications/index.ts
@@ -41,11 +41,14 @@ export type NotificationContext = {
     /** Cycle duration in minutes. Included on `watering-started` for manual fires. */
     durationMin?: number;
 
-    /** Operation that failed for `error` events (e.g. `open`, `close`, `re-plan`). */
-    operation?: string;
-
-    /** Free-form qualifier (`manual`, `shutdown`, error message, etc.). */
+    /** Qualifier for watering-* events: `'manual'` flips the message to the manual-fire variant; `'shutdown'` flips watering-ended to the daemon-shutdown variant. Not consumed by the error path. */
     reason?: string;
+
+    /** Required for the `'error'` event: the human-readable failure mode. Sentence-cased, no terminal period. Example: `'Weather API stale'`. */
+    errorTitle?: string;
+
+    /** Optional sub-line for the `'error'` event: the consequence or context. Should end in a period. Example: `'Planner using fallback ET zero. Last fetch error: 502 Bad Gateway.'`. */
+    errorSub?: string;
 
     /**
      * The irrigation night the schedule event refers to, as a local-date string
@@ -158,10 +161,11 @@ export function buildMessage(event: NotificationEvent, context?: NotificationCon
         return `${zone} watering ended.`;
     }
     // error
-    const zone = context?.zoneName ?? 'Zone';
-    const op = context?.operation ?? 'unknown';
-    const reason = context?.reason ?? 'unknown';
-    return `Irrigo error during ${op} on ${zone}: ${reason}.`;
+    const zone = context?.zoneName;
+    const title = context?.errorTitle ?? 'Irrigo error';
+    const sub = context?.errorSub;
+    const head = zone ? `${zone}: ${title}.` : `${title}.`;
+    return sub ? `${head} ${sub}` : head;
 }
 
 function buildScheduleEndedMessage(context?: NotificationContext): string {

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -242,7 +242,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                         class: 'weather-stale',
                         tone: 'warn',
                         title: 'Weather API stale',
-                        sub: `Planner on fallback ET₀ · last attempt failed: ${reason}`,
+                        sub: `Planner using fallback ET zero. Last fetch error: ${reason}.`,
                         zoneName: zone.name,
                     });
                 }

--- a/api/service/daemon/reconcile.test.ts
+++ b/api/service/daemon/reconcile.test.ts
@@ -445,7 +445,7 @@ describe('reconcileCycleAndRelayState — alert recording', () => {
         expect(alertCalls[0]).toMatchObject({
             class: 'missed-close',
             tone: 'danger',
-            title: 'Missed close (relay overran)',
+            title: 'Missed close',
             zoneId: pair.zone.id,
         });
     });
@@ -486,7 +486,7 @@ describe('reconcileCycleAndRelayState — alert recording', () => {
         expect(alertCalls[0]).toMatchObject({
             class: 'ha-call-failed',
             tone: 'danger',
-            title: 'HA close failed (reconcile)',
+            title: 'HA close failed during reconcile',
             zoneId: pair.zone.id,
         });
     });
@@ -530,7 +530,7 @@ describe('reconcileCycleAndRelayState — alert recording', () => {
         expect(alertCalls[0]).toMatchObject({
             class: 'ha-call-failed',
             tone: 'danger',
-            title: 'HA state query failed (sweep)',
+            title: 'HA state query failed during sweep',
             zoneId: 'zone-sweep',
         });
     });
@@ -549,7 +549,7 @@ describe('reconcileCycleAndRelayState — alert recording', () => {
         expect(alertCalls[0]).toMatchObject({
             class: 'ha-call-failed',
             tone: 'danger',
-            title: 'HA close failed (orphan)',
+            title: 'HA close failed for orphan relay',
             zoneId: 'zone-bad',
         });
     });

--- a/api/service/daemon/reconcile.ts
+++ b/api/service/daemon/reconcile.ts
@@ -79,7 +79,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
                 class: 'ha-call-failed',
                 tone: 'danger',
                 title: 'HA state query failed',
-                sub: `${zone.name} · ${reason}`,
+                sub: `Last attempt failed: ${reason}.`,
                 zoneId: zone.id,
                 zoneName: zone.name,
             });
@@ -109,8 +109,8 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
                 await alerter({
                     class: 'ha-call-failed',
                     tone: 'danger',
-                    title: 'HA close failed (reconcile)',
-                    sub: `${zone.name} · ${reason}`,
+                    title: 'HA close failed during reconcile',
+                    sub: `Last attempt failed: ${reason}.`,
                     zoneId: zone.id,
                     zoneName: zone.name,
                 });
@@ -125,8 +125,8 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             await alerter({
                 class: 'missed-close',
                 tone: 'danger',
-                title: 'Missed close (relay overran)',
-                sub: `${zone.name} cycle relay was still open past planned close ${plannedCloseAt.toISOString()}`,
+                title: 'Missed close',
+                sub: `Relay was still open past planned close at ${plannedCloseAt.toISOString()}.`,
                 zoneId: zone.id,
                 zoneName: zone.name,
             });
@@ -143,7 +143,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             class: 'missed-close',
             tone: 'danger',
             title: 'Missed close',
-            sub: `${zone.name} cycle missed expected close · set closed_at=${closedAt.toISOString()}`,
+            sub: `Cycle missed expected close; recorded closed at ${closedAt.toISOString()}.`,
             zoneId: zone.id,
             zoneName: zone.name,
         });
@@ -162,8 +162,8 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
-                title: 'HA state query failed (sweep)',
-                sub: `${zone.name} · ${reason}`,
+                title: 'HA state query failed during sweep',
+                sub: `Last attempt failed: ${reason}.`,
                 zoneId: zone.id,
                 zoneName: zone.name,
             });
@@ -181,8 +181,8 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
-                title: 'HA close failed (orphan)',
-                sub: `${zone.name} · ${reason}`,
+                title: 'HA close failed for orphan relay',
+                sub: `Last attempt failed: ${reason}.`,
                 zoneId: zone.id,
                 zoneName: zone.name,
             });
@@ -195,7 +195,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'Orphan relay closed',
-            sub: `${zone.name} relay was on at boot with no in-flight cycle backing it`,
+            sub: `Relay was on at boot with no in-flight cycle backing it.`,
             zoneId: zone.id,
             zoneName: zone.name,
         });

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -417,7 +417,7 @@ describe('closeAllInFlight', () => {
         });
 
         expect(closes).toEqual(['zone-B']);
-        expect(alertCalls.some(a => a.class === 'ha-call-failed' && a.title === 'HA close failed (shutdown)')).toBe(true);
+        expect(alertCalls.some(a => a.class === 'ha-call-failed' && a.title === 'HA close failed during shutdown')).toBe(true);
     });
 
     it('is a no-op when nothing is in flight', async () => {

--- a/api/service/daemon/runtime.ts
+++ b/api/service/daemon/runtime.ts
@@ -147,7 +147,7 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'HA open failed',
-            sub: `${zone.name} · ${reason}`,
+            sub: `Last attempt failed: ${reason}.`,
             zoneId: zone.id,
             zoneName: zone.name,
         });
@@ -225,7 +225,7 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
             class: 'ha-call-failed',
             tone: 'danger',
             title: 'HA close failed',
-            sub: `${zone.name} · ${reason}`,
+            sub: `Last attempt failed: ${reason}.`,
             zoneId: zone.id,
             zoneName: zone.name,
         });
@@ -276,8 +276,8 @@ export async function closeAllInFlight(inputs: {
             await alerter({
                 class: 'ha-call-failed',
                 tone: 'danger',
-                title: 'HA close failed (shutdown)',
-                sub: `${zone.name} · ${reason}`,
+                title: 'HA close failed during shutdown',
+                sub: `Last attempt failed: ${reason}.`,
                 zoneId: zone.id,
                 zoneName: zone.name,
             });

--- a/api/service/manual/.test.ts
+++ b/api/service/manual/.test.ts
@@ -193,7 +193,7 @@ describe('manual controller — open', () => {
         await expect(controller.open(buildZone())).rejects.toThrow('HA 502');
         expect(controller.getActiveZone()).toBeNull();
         const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', operation: 'open', reason: 'HA 502' });
+        expect(errorCall?.context).toEqual({ zoneName: 'Front Lawn', errorTitle: 'Manual open failed', errorSub: 'Last attempt failed: HA 502.' });
     });
 });
 
@@ -296,7 +296,7 @@ describe('manual controller — close', () => {
 
         expect(controller.getActiveZone()).toBeNull();
         const errorCall = calls.find(c => c.event === 'error');
-        expect(errorCall?.context?.operation).toBe('close');
+        expect(errorCall?.context?.errorTitle).toBe('Manual close failed');
     });
 });
 
@@ -410,8 +410,8 @@ describe('manual controller — run', () => {
         await advanceTo(new Date('2026-05-04T15:05:30.000Z'));
 
         expect(controller.getActiveZone()).toBeNull();
-        const errorCall = calls.find(c => c.event === 'error' && c.context?.operation === 'close');
-        expect(errorCall?.context?.reason).toBe('HA 504');
+        const errorCall = calls.find(c => c.event === 'error' && c.context?.errorTitle === 'Manual close failed');
+        expect(errorCall?.context?.errorSub).toBe('Last attempt failed: HA 504.');
     });
 });
 

--- a/api/service/manual/index.ts
+++ b/api/service/manual/index.ts
@@ -109,7 +109,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             console.error(`manual: openZone failed for zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'open', reason });
+            await notifier('error', { zoneName: zone.name, errorTitle: 'Manual open failed', errorSub: `Last attempt failed: ${reason}.` });
             throw err;
         }
 
@@ -130,7 +130,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
             } catch (err) {
                 const reason = err instanceof Error ? err.message : String(err);
                 console.error(`manual: defensive closeZone failed for zone ${zone.id}.`, err);
-                await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+                await notifier('error', { zoneName: zone.name, errorTitle: 'Manual close failed', errorSub: `Last attempt failed: ${reason}.` });
                 throw err;
             }
             console.log(`manual: defensive close for zone ${zone.id} (no active manual fire).`);
@@ -148,7 +148,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             console.error(`manual: closeZone failed for zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+            await notifier('error', { zoneName: zone.name, errorTitle: 'Manual close failed', errorSub: `Last attempt failed: ${reason}.` });
             throw err;
         }
 
@@ -175,7 +175,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             console.error(`manual: scheduled close failed for zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'close', reason });
+            await notifier('error', { zoneName: zone.name, errorTitle: 'Manual close failed', errorSub: `Last attempt failed: ${reason}.` });
             return;
         }
 
@@ -203,7 +203,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             console.error(`manual: openZone failed for zone ${zone.id}.`, err);
-            await notifier('error', { zoneName: zone.name, operation: 'open', reason });
+            await notifier('error', { zoneName: zone.name, errorTitle: 'Manual run open failed', errorSub: `Last attempt failed: ${reason}.` });
             throw err;
         }
 
@@ -249,7 +249,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             console.error(`manual: shutdown closeZone failed for zone ${active.zone.id}.`, err);
-            await notifier('error', { zoneName: active.zone.name, operation: 'shutdown-close', reason });
+            await notifier('error', { zoneName: active.zone.name, errorTitle: 'Shutdown close failed', errorSub: `Last attempt failed: ${reason}.` });
         }
     };
 


### PR DESCRIPTION
## Ticket

[API-63](http://192.168.2.100:7123/irrigo/browse/API-63/) — Audit and rewrite every operator-facing notification message for readability.

## Summary

Last night's push read:

> "Irrigo error during weather-stale on South: Planner on fallback ET₀ · last attempt failed: Open-Meteo API request failed: 502 Bad Gateway."

Three bugs in one string, all fixed in this PR:

- **Slug leak.** `buildMessage('error', ...)` interpolated the internal class slug (`weather-stale`) into user text via `operation`. The `'error'` notifier context now takes `errorTitle` + `errorSub` instead, fed directly from the alerter's already-formed `title` / `sub`. No slug ever reaches the message builder.
- **Double-wrap.** The notifier no longer wraps the alerter's `sub` inside another sentence. New format: `<zone>: <title>. <sub>` — failure mode → context → consequence.
- **Mangled Unicode.** Every alerter `sub` in `daemon/index.ts`, `daemon/runtime.ts`, and `daemon/reconcile.ts` is now ASCII-only. Subscript zero and middle dot are gone. Zone prefix stripped from `sub` (the alerter forwards `zoneName` separately, and the mobile UI displays it as a separate field).
- Manual service notifier calls (6 sites) swap to the new `errorTitle` / `errorSub` shape.
- Daemon titles tidied — `'HA close failed (shutdown)'` → `'HA close failed during shutdown'` (parenthetical qualifiers re-cased), `'Missed close (relay overran)'` → `'Missed close'` (the sub now carries the detail), etc.

## Test plan

- [x] `bun --cwd=./api run type-check` — clean.
- [x] `bun --cwd=./api test` — 767 tests across 44 files green; 16 new golden `toBe` assertions in `api/notifications/.test.ts` pin the exact string for every event + variant including the original bug scenario, with explicit guardrails asserting absence of the slug, `·`, and `₀`.
- [x] Spot grep: zero non-ASCII bytes in `api/notifications`, `api/alerts`, `api/service/daemon`, `api/service/manual` production source paths.

## Out of scope

When notifications fire, retry logic, alerter dedup behaviour.