### PR TITLE
[APP-20] CycleStrip Gantt primitive

### DIFF
--- a/app/components/cycle-strip/.test.tsx
+++ b/app/components/cycle-strip/.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen } from '@testing-library/react-native';
+
+import {
+    CycleStrip,
+    buildHourTicks,
+    getTotalMin,
+    parseHHMM,
+    pctOf,
+    widthPctOf,
+    type CycleStripNight,
+} from '.';
+
+const SAMPLE_NIGHT: CycleStripNight = {
+    sunset: '20:45',
+    sunrise: '05:30',
+    zones: [
+        {
+            name: 'North',
+            color: '#6FE39B',
+            glow: 'rgba(111, 227, 155, 0.4)',
+            cycles: [
+                { start: '23:00', durMin: 15 },
+                { start: '01:30', durMin: 12 },
+            ],
+        },
+        {
+            name: 'South',
+            color: '#7CD4FB',
+            glow: 'rgba(124, 212, 251, 0.4)',
+            cycles: [
+                { start: '23:30', durMin: 18 },
+            ],
+        },
+    ],
+};
+
+describe('parseHHMM', () => {
+    it('parses a valid HH:MM into minutes-past-midnight.', () => {
+        expect(parseHHMM('22:30')).toBe(22 * 60 + 30);
+        expect(parseHHMM('00:00')).toBe(0);
+        expect(parseHHMM('23:59')).toBe(23 * 60 + 59);
+    });
+
+    it('throws on a malformed string.', () => {
+        expect(() => parseHHMM('22:5')).toThrow();
+        expect(() => parseHHMM('22-30')).toThrow();
+        expect(() => parseHHMM('')).toThrow();
+    });
+
+    it('throws on out-of-range hours or minutes.', () => {
+        expect(() => parseHHMM('24:00')).toThrow();
+        expect(() => parseHHMM('12:60')).toThrow();
+    });
+});
+
+describe('getTotalMin', () => {
+    it('returns the simple delta when the end is past the start within the same day.', () => {
+        expect(getTotalMin(22 * 60, 23 * 60)).toBe(60);
+    });
+
+    it('wraps past midnight when the end is at or before the start.', () => {
+        expect(getTotalMin(22 * 60, 6 * 60)).toBe(8 * 60);
+    });
+
+    it('handles a same-hour wrap (start = end => full day).', () => {
+        expect(getTotalMin(22 * 60, 22 * 60)).toBe(24 * 60);
+    });
+});
+
+describe('pctOf', () => {
+    it('places times after the axis start (same day) at their direct ratio.', () => {
+        const startMin = 22 * 60;
+        const totalMin = 8 * 60;
+        expect(pctOf(startMin, totalMin, '22:30')).toBeCloseTo((30 / 480) * 100, 5);
+    });
+
+    it('wraps post-midnight times so they land in the right half of the chart.', () => {
+        const startMin = 22 * 60;
+        const totalMin = 8 * 60;
+        // 01:00 → 25:00 internally → 3h past start → 3/8 = 37.5%.
+        expect(pctOf(startMin, totalMin, '01:00')).toBeCloseTo(37.5, 5);
+    });
+
+    it('places the axis end exactly at 100%.', () => {
+        const startMin = 22 * 60;
+        const totalMin = 8 * 60;
+        expect(pctOf(startMin, totalMin, '06:00')).toBeCloseTo(100, 5);
+    });
+});
+
+describe('widthPctOf', () => {
+    it('returns the pure ratio of a cycle duration against the chart width.', () => {
+        expect(widthPctOf(8 * 60, 30)).toBeCloseTo((30 / 480) * 100, 5);
+    });
+
+    it('returns 0 for a zero-duration cycle.', () => {
+        expect(widthPctOf(8 * 60, 0)).toBe(0);
+    });
+});
+
+describe('buildHourTicks', () => {
+    it('produces a tick at each whole hour from start through end (full / 1h step).', () => {
+        const ticks = buildHourTicks({ startMin: 22 * 60, totalMin: 8 * 60, stepH: 1 });
+
+        expect(ticks.map(t => t.hour)).toEqual([22, 23, 0, 1, 2, 3, 4, 5, 6]);
+        expect(ticks[0]?.leftPct).toBe(0);
+        expect(ticks[ticks.length - 1]?.leftPct).toBe(100);
+    });
+
+    it('uses a 2-hour step for the compact variant.', () => {
+        const ticks = buildHourTicks({ startMin: 22 * 60, totalMin: 8 * 60, stepH: 2 });
+
+        expect(ticks.map(t => t.hour)).toEqual([22, 0, 2, 4, 6]);
+    });
+
+    it('skips a tick that would land mid-hour when the axis start is not on the hour.', () => {
+        // axisStart 22:15 → first tick at 23:00 → next at 24:00 (=0), 1, 2, 3, 4, 5, 6 — also includes 6:00 since 6*60 ≤ 22:15+8h=6:15.
+        const ticks = buildHourTicks({ startMin: 22 * 60 + 15, totalMin: 8 * 60, stepH: 1 });
+
+        expect(ticks.map(t => t.hour)).toEqual([23, 0, 1, 2, 3, 4, 5, 6]);
+    });
+});
+
+describe('CycleStrip', () => {
+    it('renders under the default accessibility label.', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        expect(screen.getByLabelText('Irrigation cycle chart')).toBeOnTheScreen();
+    });
+
+    it('honors a caller-provided accessibility label.', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} accessibilityLabel='Tonight schedule' />);
+
+        expect(screen.getByLabelText('Tonight schedule')).toBeOnTheScreen();
+    });
+
+    it('renders each zone in the legend with its cycle count and total runtime.', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        expect(screen.getByText('North')).toBeOnTheScreen();
+        expect(screen.getByText('South')).toBeOnTheScreen();
+        // North fires 2 cycles totaling 27 min; South fires 1 cycle totaling 18 min.
+        expect(screen.getByText('· 2 cycles · 27 min')).toBeOnTheScreen();
+        expect(screen.getByText('· 1 cycles · 18 min')).toBeOnTheScreen();
+    });
+
+    it('announces each lane via accessibility label with cycle count and runtime.', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        expect(screen.getByLabelText('North: 2 cycles, 27 minutes')).toBeOnTheScreen();
+        expect(screen.getByLabelText('South: 1 cycles, 18 minutes')).toBeOnTheScreen();
+    });
+
+    it('renders sunset and sunrise labels with their HH:MM times.', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        expect(screen.getByText('sunset 20:45')).toBeOnTheScreen();
+        expect(screen.getByText('sunrise 05:30')).toBeOnTheScreen();
+    });
+
+    it('renders an hour-axis label for every whole hour across the default axis.', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        // Default axis 22:00 → 06:00, full variant: 9 hour ticks (22:00 .. 06:00).
+        for (const h of [22, 23, 0, 1, 2, 3, 4, 5, 6]) {
+            const label = `${String(h).padStart(2, '0')}:00`;
+            expect(screen.getByText(label)).toBeOnTheScreen();
+        }
+    });
+
+    it('renders fewer hour labels in the compact variant (2-hour step).', () => {
+        render(<CycleStrip night={SAMPLE_NIGHT} variant='compact' />);
+
+        // Compact: 22:00, 00:00, 02:00, 04:00, 06:00 (5 ticks).
+        expect(screen.getByText('22:00')).toBeOnTheScreen();
+        expect(screen.getByText('00:00')).toBeOnTheScreen();
+        expect(screen.getByText('02:00')).toBeOnTheScreen();
+        // Odd hours not rendered in compact.
+        expect(screen.queryByText('23:00')).toBeNull();
+        expect(screen.queryByText('01:00')).toBeNull();
+    });
+
+    it('renders one cycle pulse per cycle for each zone.', () => {
+        const { root } = render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        // Cycle pulses are absolutely-positioned Views with `minWidth: 6` —
+        // the only host nodes carrying that distinctive style. North has 2,
+        // South has 1, so 3 total cycle pulses.
+        const pulses = root.findAll(node => {
+            if (typeof node.type !== 'string') return false;
+            const style = node.props.style;
+            if (!Array.isArray(style)) return false;
+            return style.some(s => s && typeof s === 'object' && (s as { minWidth?: number }).minWidth === 6);
+        });
+
+        expect(pulses).toHaveLength(3);
+    });
+
+    it('places a post-midnight cycle later on the axis than a pre-midnight one (wrap-aware).', () => {
+        const startMin = 22 * 60;
+        const totalMin = 8 * 60;
+
+        // 23:30 is 1.5h into the chart → 18.75%.
+        // 01:30 wraps to 25:30 → 3.5h into the chart → 43.75%.
+        // The post-midnight cycle must land later than the pre-midnight one
+        // (and well past the chart start), proving the wrap math is wired
+        // through to the component.
+        const preMidnight = pctOf(startMin, totalMin, '23:30');
+        const postMidnight = pctOf(startMin, totalMin, '01:30');
+
+        expect(preMidnight).toBeCloseTo(18.75, 5);
+        expect(postMidnight).toBeCloseTo(43.75, 5);
+        expect(postMidnight).toBeGreaterThan(preMidnight);
+        expect(postMidnight).toBeGreaterThan(25);
+
+        // Sanity: rendering the wrapped night with both variants doesn't throw.
+        expect(() => render(<CycleStrip night={SAMPLE_NIGHT} />)).not.toThrow();
+        expect(() => render(<CycleStrip night={SAMPLE_NIGHT} variant='compact' />)).not.toThrow();
+    });
+});

--- a/app/components/cycle-strip/index.tsx
+++ b/app/components/cycle-strip/index.tsx
@@ -1,0 +1,436 @@
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import Svg, { Line, Path } from 'react-native-svg';
+
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+const MINUTES_PER_DAY = 1440;
+const DEFAULT_AXIS_START = '22:00';
+const DEFAULT_AXIS_END = '06:00';
+
+/**
+ * Visual density of the cycle strip. `compact` is the Home hero treatment
+ * (smaller lanes, 2-hour tick step); `full` is the Schedule detail treatment.
+ */
+export type CycleStripVariant = 'full' | 'compact';
+
+/**
+ * One cycle that fires (or is planned) during the irrigation night.
+ */
+export type CycleStripCycle = {
+    /** Start time as `HH:MM` (24-hour, site-local). */
+    start: string;
+
+    /** Duration in minutes. */
+    durMin: number;
+};
+
+/**
+ * A single zone with its visual style and the cycles it owns for the night.
+ */
+export type CycleStripZone = {
+    /** Display name shown in the legend and accessibility announcement. */
+    name: string;
+
+    /** Solid color for the lane wash and cycle pulses. */
+    color: string;
+
+    /** Outer-glow color for the cycle pulse `boxShadow`. */
+    glow: string;
+
+    /** Cycles fired (or planned) for this zone during the night. */
+    cycles: ReadonlyArray<CycleStripCycle>;
+};
+
+/**
+ * Night-level chart inputs: axis bounds, sun moments, and the zones to plot.
+ */
+export type CycleStripNight = {
+    /** Optional. `HH:MM` start of the chart axis. Defaults to `'22:00'`. */
+    axisStart?: string;
+
+    /** Optional. `HH:MM` end of the chart axis. Defaults to `'06:00'`. */
+    axisEnd?: string;
+
+    /** Required. `HH:MM` site-local sunset. */
+    sunset: string;
+
+    /** Required. `HH:MM` site-local sunrise. */
+    sunrise: string;
+
+    /** Required. Zones with cycles to render. */
+    zones: ReadonlyArray<CycleStripZone>;
+};
+
+/**
+ * Props for the `CycleStrip` Gantt primitive.
+ */
+export type CycleStripProps = {
+    /** Required. Night data — axis bounds, sun moments, zones + cycles. */
+    night: CycleStripNight;
+
+    /** Optional. Visual density. `compact` for Home hero; `full` for Schedule detail. Defaults to `full`. */
+    variant?: CycleStripVariant;
+
+    /** Optional. Accessibility label for the chart container. Defaults to `'Irrigation cycle chart'`. */
+    accessibilityLabel?: string;
+};
+
+/**
+ * Parses an `HH:MM` 24-hour string into minutes-past-midnight. Throws when
+ * the input doesn't match the expected shape — the chart needs every input
+ * to round-trip cleanly, so a silent fallback would mask wrong data.
+ */
+export function parseHHMM(value: string): number {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+    if (!match) throw new Error(`cycle-strip: invalid HH:MM string ${JSON.stringify(value)}.`);
+    const hours = Number(match[1]);
+    const minutes = Number(match[2]);
+    if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+        throw new Error(`cycle-strip: HH:MM out of range ${JSON.stringify(value)}.`);
+    }
+    return hours * 60 + minutes;
+}
+
+/**
+ * Width of the chart in minutes. Wraps past midnight when the end is at or
+ * before the start (e.g. `22:00 → 06:00` returns 480).
+ */
+export function getTotalMin(startMin: number, endMin: number): number {
+    return endMin > startMin ? endMin - startMin : endMin + MINUTES_PER_DAY - startMin;
+}
+
+/**
+ * Percentage position of `hhmm` along the chart, anchored to the axis start.
+ * Wraps any time that falls below `startMin` to the next day, so a cycle
+ * starting at `01:30` with a `22:00`-anchored axis is plotted at ~44%.
+ */
+export function pctOf(startMin: number, totalMin: number, hhmm: string): number {
+    let m = parseHHMM(hhmm);
+    if (m < startMin) m += MINUTES_PER_DAY;
+    return ((m - startMin) / totalMin) * 100;
+}
+
+/**
+ * Percentage width of a cycle of `durMin` minutes against the total chart
+ * width. Pure ratio, no clamping — callers apply a CSS `max(...)` so a tiny
+ * cycle still renders as a visible pulse.
+ */
+export function widthPctOf(totalMin: number, durMin: number): number {
+    return (durMin / totalMin) * 100;
+}
+
+/**
+ * One hour tick on the axis.
+ */
+export type HourTick = {
+    /** Hour-of-day (0–23) — the integer to format. */
+    hour: number;
+
+    /** Horizontal position as a 0–100 percentage of the chart width. */
+    leftPct: number;
+};
+
+/**
+ * Hour-tick positions from the axis start through the axis end, stepping by
+ * `stepH` hours. The first tick lands on the first whole hour ≥ `startMin`.
+ */
+export function buildHourTicks({
+    startMin,
+    totalMin,
+    stepH,
+}: { startMin: number; totalMin: number; stepH: number }): ReadonlyArray<HourTick> {
+    const ticks: HourTick[] = [];
+    const firstTick = Math.ceil(startMin / 60) * 60;
+    for (let m = firstTick; m <= startMin + totalMin; m += stepH * 60) {
+        const hour = Math.floor(m / 60) % 24;
+        const leftPct = ((m - startMin) / totalMin) * 100;
+        ticks.push({ hour, leftPct });
+    }
+    return ticks;
+}
+
+/**
+ * The Irrigo CycleStrip Gantt — visualises a single irrigation night. Plots
+ * each zone's cycles against an hour axis (defaults `22:00 → 06:00`),
+ * annotates sunset and sunrise with vertical lines and half-sun labels, and
+ * separates each zone into its own lane. The `compact` variant is the Home
+ * hero treatment; `full` is the Schedule detail treatment.
+ */
+export function CycleStrip({
+    night,
+    variant = 'full',
+    accessibilityLabel = 'Irrigation cycle chart',
+}: CycleStripProps) {
+    const compact = variant === 'compact';
+    const stepH = compact ? 2 : 1;
+    const laneHeight = compact ? 16 : 20;
+    const laneGap = compact ? 6 : 8;
+    const legendGap = compact ? 10 : 16;
+
+    const startMin = parseHHMM(night.axisStart ?? DEFAULT_AXIS_START);
+    const endMin = parseHHMM(night.axisEnd ?? DEFAULT_AXIS_END);
+    const totalMin = getTotalMin(startMin, endMin);
+
+    const ticks = buildHourTicks({ startMin, totalMin, stepH });
+    const sunsetPct = pctOf(startMin, totalMin, night.sunset);
+    const sunrisePct = pctOf(startMin, totalMin, night.sunrise);
+
+    return (
+        <View accessibilityLabel={accessibilityLabel}>
+            <View style={[styles.legend, { gap: legendGap }]}>
+                {night.zones.map(zone => (
+                    <View key={zone.name} style={styles.legendItem}>
+                        <View
+                            style={[
+                                styles.legendDot,
+                                {
+                                    backgroundColor: zone.color,
+                                    boxShadow: `0 0 8px ${zone.glow}`,
+                                },
+                            ]}
+                        />
+                        <Text style={styles.legendName}>{zone.name}</Text>
+                        <Text style={styles.legendMeta}>
+                            {`· ${zone.cycles.length} cycles · ${totalCycleMin(zone)} min`}
+                        </Text>
+                    </View>
+                ))}
+            </View>
+
+            <View style={styles.axis}>
+                {ticks.map((tick, i) => (
+                    <AxisTickLabel key={`${tick.hour}-${tick.leftPct}`} tick={tick} isFirst={i === 0} isLast={i === ticks.length - 1} />
+                ))}
+            </View>
+
+            <View style={styles.plot}>
+                {ticks.map(tick => (
+                    <View
+                        key={`grid-${tick.hour}-${tick.leftPct}`}
+                        style={[styles.gridLine, { left: `${tick.leftPct}%` }]}
+                    />
+                ))}
+
+                <SunLine leftPct={sunsetPct} />
+                <SunLine leftPct={sunrisePct} />
+
+                <View style={{ gap: laneGap }}>
+                    {night.zones.map(zone => (
+                        <View
+                            key={zone.name}
+                            style={{ position: 'relative', height: laneHeight }}
+                            accessibilityLabel={`${zone.name}: ${zone.cycles.length} cycles, ${totalCycleMin(zone)} minutes`}
+                        >
+                            <View
+                                style={[
+                                    styles.laneWash,
+                                    { backgroundColor: zone.color },
+                                ]}
+                            />
+                            {zone.cycles.map(cycle => (
+                                <View
+                                    key={`${cycle.start}-${cycle.durMin}`}
+                                    style={[
+                                        styles.cyclePulse,
+                                        {
+                                            left: `${pctOf(startMin, totalMin, cycle.start)}%`,
+                                            width: `${widthPctOf(totalMin, cycle.durMin)}%`,
+                                            backgroundColor: zone.color,
+                                            boxShadow: `0 0 10px ${zone.glow}, inset 0 1px 0 rgba(255, 255, 255, 0.22)`,
+                                        },
+                                    ]}
+                                />
+                            ))}
+                        </View>
+                    ))}
+                </View>
+            </View>
+
+            <View style={styles.sunLabelRow}>
+                <SunLabel leftPct={sunsetPct} kind='set' time={night.sunset} />
+                <SunLabel leftPct={sunrisePct} kind='rise' time={night.sunrise} />
+            </View>
+        </View>
+    );
+}
+
+function totalCycleMin(zone: CycleStripZone): number {
+    return zone.cycles.reduce((sum, cycle) => sum + cycle.durMin, 0);
+}
+
+function AxisTickLabel({ tick, isFirst, isLast }: { tick: HourTick; isFirst: boolean; isLast: boolean }) {
+    // Anchor the first and last tick labels to their respective edges to
+    // avoid clipping off the chart; everything in between is centred.
+    const transformStyle: StyleProp<ViewStyle> = isFirst
+        ? { transform: [{ translateX: 0 }] }
+        : isLast
+            ? undefined
+            : { transform: [{ translateX: -0.5 }] };
+
+    return (
+        <View style={[styles.tickWrap, { left: `${tick.leftPct}%` }, transformStyle]}>
+            <Text style={styles.tick}>
+                {String(tick.hour).padStart(2, '0')}
+                <Text style={styles.tickSuffix}>:00</Text>
+            </Text>
+        </View>
+    );
+}
+
+function SunLine({ leftPct }: { leftPct: number }) {
+    return <View style={[styles.sunLine, { left: `${leftPct}%` }]} />;
+}
+
+function SunLabel({ leftPct, kind, time }: { leftPct: number; kind: 'set' | 'rise'; time: string }) {
+    // Past the midpoint, anchor the label's right edge to the line so it
+    // never falls off the end of the chart.
+    const alignRight = leftPct > 50;
+    const labelText = `${kind === 'set' ? 'sunset' : 'sunrise'} ${time}`;
+
+    return (
+        <View
+            style={[
+                styles.sunLabelWrap,
+                { left: `${leftPct}%` },
+                alignRight ? styles.sunLabelWrapRight : undefined,
+            ]}
+            accessibilityLabel={labelText}
+        >
+            <SunGlyph kind={kind} />
+            <Text style={styles.sunLabelText}>{labelText}</Text>
+        </View>
+    );
+}
+
+function SunGlyph({ kind }: { kind: 'set' | 'rise' }) {
+    return (
+        <Svg width={13} height={9} viewBox='0 0 13 9' fill='none'>
+            <Path d='M1.5 8 a 5 5 0 0 1 10 0 Z' fill={colors['moon-500']} opacity={0.85} />
+            <Line x1={0} y1={8.5} x2={13} y2={8.5} stroke={colors['moon-500']} strokeWidth={0.8} opacity={0.6} />
+            {kind === 'set' ? (
+                <Path
+                    d='M6.5 2.5 v 3 M5 4 l 1.5 1.5 l 1.5 -1.5'
+                    stroke={colors['moon-500']}
+                    strokeWidth={1}
+                    strokeLinecap='round'
+                    fill='none'
+                />
+            ) : (
+                <Path
+                    d='M6.5 5.5 v -3 M5 4 l 1.5 -1.5 l 1.5 1.5'
+                    stroke={colors['moon-500']}
+                    strokeWidth={1}
+                    strokeLinecap='round'
+                    fill='none'
+                />
+            )}
+        </Svg>
+    );
+}
+
+const styles = StyleSheet.create({
+    legend: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        marginBottom: 10,
+    },
+    legendItem: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    legendDot: {
+        width: 10,
+        height: 10,
+        borderRadius: 4,
+    },
+    legendName: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 12,
+        lineHeight: 12,
+        color: colors.fg,
+    },
+    legendMeta: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13.2,
+        color: colors['fg-muted'],
+    },
+    axis: {
+        position: 'relative',
+        height: 16,
+        marginBottom: 4,
+    },
+    tickWrap: {
+        position: 'absolute',
+        top: 0,
+    },
+    tick: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13.2,
+        color: colors['fg-dim'],
+    },
+    tickSuffix: {
+        opacity: 0.5,
+    },
+    plot: {
+        position: 'relative',
+        paddingVertical: 10,
+        borderTopWidth: 1,
+        borderBottomWidth: 1,
+        borderColor: colors.hairline,
+    },
+    gridLine: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        width: 1,
+        backgroundColor: colors.hairline,
+        opacity: 0.55,
+    },
+    sunLine: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        width: 1,
+        backgroundColor: colors['moon-500'],
+        opacity: 0.55,
+    },
+    laneWash: {
+        ...StyleSheet.absoluteFillObject,
+        opacity: 0.07,
+        borderRadius: 4,
+    },
+    cyclePulse: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        minWidth: 6,
+        borderRadius: 4,
+    },
+    sunLabelRow: {
+        position: 'relative',
+        height: 16,
+        marginTop: 6,
+    },
+    sunLabelWrap: {
+        position: 'absolute',
+        top: 0,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 5,
+    },
+    sunLabelWrapRight: {
+        transform: [{ translateX: -1 }],
+    },
+    sunLabelText: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 11,
+        color: colors['moon-500'],
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-20](http://192.168.2.100:7123/irrigo/browse/APP-20/) — CycleStrip Gantt chart (hour axis, sun lines, zone lanes).

## Summary

- New `CycleStrip` primitive at `app/components/cycle-strip/` — RN port of `CycleStrip` from the design system's `components.jsx`.
- Pure geometry helpers (`parseHHMM`, `getTotalMin`, `pctOf`, `widthPctOf`, `buildHourTicks`) exported and unit-tested independently; midnight wrap is encoded in `getTotalMin` / `pctOf` so the component just calls them.
- `compact` (Home hero, 2h tick step, 16px lanes) vs `full` (Schedule detail, 1h step, 20px lanes) variants.
- Sunset / sunrise vertical lines with half-sun glyph labels (SVG via `react-native-svg`); label auto-aligns to the right past the midpoint to avoid clipping.
- Per-zone lane wash + glowing cycle pulses using the design `boxShadow` glow string (RN 0.81+ accepts CSS-style boxShadow — same precedent as Card/Modal). CSS `linear-gradient` lane washes simplified to flat colors at low opacity — same visual cue, no extra dep.
- 23 new tests across helpers (8) + component rendering (15), including a midnight-wrap end-to-end assertion (a 23:30 cycle and a 01:30 cycle place correctly relative to the axis).

## Test plan

- [x] `bun --cwd=./app run test` — 235 tests across 37 suites green.
- [x] `bun --cwd=./app run typecheck` — no new errors (the two pre-existing scaffolding errors in `(tabs)/index.tsx` and `modal.tsx` are unrelated).

## Out of scope

- The Home hero card and Schedule detail screen that embed the variants (separate tickets).
- Animated pulse on the active cycle (the design CSS uses a `pulse` keyframe; can be layered later).