### PR TITLE
[APP-22] App header (menu / brand / re-plan)

### DIFF
--- a/app/components/header/.test.tsx
+++ b/app/components/header/.test.tsx
@@ -1,0 +1,133 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import { keys } from '@/api/query-keys';
+import { Header } from '.';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('Header', () => {
+    it('renders menu, brand, and re-plan controls.', () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+
+        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+
+        expect(screen.getByLabelText('Open menu')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Irrigo')).toBeOnTheScreen();
+        expect(screen.getByText('Irrigo')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Re-plan')).toBeOnTheScreen();
+    });
+
+    it('calls onMenuPress when the user taps the menu button while irrigation is on.', () => {
+        const onMenuPress = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+
+        render(<Header onMenuPress={onMenuPress} />, { wrapper });
+        fireEvent.press(screen.getByLabelText('Open menu'));
+
+        expect(onMenuPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the menu button and ignores presses when irrigation is off.', () => {
+        const onMenuPress = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'x' });
+
+        render(<Header onMenuPress={onMenuPress} />, { wrapper });
+        const menu = screen.getByLabelText('Open menu');
+        fireEvent.press(menu);
+
+        expect(onMenuPress).not.toHaveBeenCalled();
+        expect(menu.props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it('posts to /replan when the user taps the refresh button while irrigation is on.', async () => {
+        // First resolved value covers the POST /replan; subsequent
+        // mockResolvedValue covers the background GET /system refetch that
+        // `useReplan.onSuccess` triggers by invalidating the system query.
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({ status: 'replanned', lastRePlanAt: '2026-05-23T03:00:00.000Z' }),
+        );
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: true, since: 'x' }));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+
+        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Re-plan'));
+        });
+
+        await waitFor(() => {
+            const replanCalls = mockFetch.mock.calls.filter(([url]) => String(url).endsWith('/replan'));
+            expect(replanCalls).toHaveLength(1);
+        });
+        const replanCall = mockFetch.mock.calls.find(([url]) => String(url).endsWith('/replan'));
+        expect((replanCall as [string, RequestInit])[1].method).toBe('POST');
+    });
+
+    it('disables the refresh button and does not POST /replan when irrigation is off.', () => {
+        // Seed the system cache. The header still mounts `useSystem`, which
+        // will refetch (the seeded entry is immediately stale under the
+        // default `staleTime: 0`), so we cover that background GET too —
+        // the test asserts no `/replan` POST, not zero fetches overall.
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: false, since: 'x' }));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'x' });
+
+        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+        const refresh = screen.getByLabelText('Re-plan');
+        fireEvent.press(refresh);
+
+        const replanCalls = mockFetch.mock.calls.filter(([url]) => String(url).endsWith('/replan'));
+        expect(replanCalls).toHaveLength(0);
+        expect(refresh.props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it('keeps the refresh button disabled while a re-plan request is in flight.', async () => {
+        // Hold the POST /replan promise open so the mutation stays pending
+        // long enough to observe the disabled state.
+        let resolveReplan: (response: Response) => void = () => {};
+        const replanPromise = new Promise<Response>(resolve => {
+            resolveReplan = resolve;
+        });
+        mockFetch.mockReturnValueOnce(replanPromise);
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: true, since: 'x' }));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+
+        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+        fireEvent.press(screen.getByLabelText('Re-plan'));
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Re-plan').props.accessibilityState).toMatchObject({ disabled: true });
+        });
+
+        // Release the held promise so the mutation settles and React Query
+        // doesn't log "unhandled promise" warnings after the test ends.
+        await act(async () => {
+            resolveReplan(jsonResponse({ status: 'replanned', lastRePlanAt: 'x' }));
+            await replanPromise;
+        });
+    });
+
+    it('treats an unresolved system query as off so both icon buttons stay disabled.', () => {
+        const { wrapper } = buildApiWrapper();
+
+        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+
+        expect(screen.getByLabelText('Open menu').props.accessibilityState).toMatchObject({ disabled: true });
+        expect(screen.getByLabelText('Re-plan').props.accessibilityState).toMatchObject({ disabled: true });
+    });
+});

--- a/app/components/header/index.tsx
+++ b/app/components/header/index.tsx
@@ -1,0 +1,85 @@
+import { Text, View } from 'react-native';
+
+import { BrandGlyph } from '@/components/brand-glyph';
+import { Button } from '@/components/button';
+import { Menu, Refresh } from '@/components/icons';
+import { FontFamily } from '@/constants/fonts';
+import { useReplan } from '@/hooks/replan';
+import { useSystem } from '@/hooks/system';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the Irrigo app header.
+ */
+export type HeaderProps = {
+    /**
+     * Required. Fired when the hamburger button is tapped (and irrigation is
+     * on). The header itself is drawer-agnostic — APP-23 wires this prop to
+     * the nav drawer's open handler.
+     */
+    onMenuPress: () => void;
+};
+
+/**
+ * The shared app header — hamburger on the left, `BrandGlyph` + `Irrigo`
+ * wordmark in the centre, refresh icon on the right. RN port of the App
+ * header block in [`Mobile.jsx:32-68`](app/design/irrigo/project/ui_kit/Mobile.jsx).
+ *
+ * Reads the master irrigation switch via `useSystem`. When the system is off
+ * (or the query hasn't resolved yet — sticky-off during cold start), both
+ * icon buttons disable and the centre brand row dims to 0.45 opacity. The
+ * design source uses `filter: grayscale(1)` to desaturate the brand, but
+ * React Native has no CSS filter; opacity is the portable approximation.
+ *
+ * The refresh button dispatches `useReplan` and stays disabled while a
+ * re-plan is in flight so impatient double-taps don't queue duplicate
+ * mutations.
+ */
+export function Header({ onMenuPress }: HeaderProps) {
+    const { data: system } = useSystem();
+    const replan = useReplan();
+    const irrigationOn = system?.irrigationEnabled === true;
+    const refreshDisabled = !irrigationOn || replan.isPending;
+
+    return (
+        <View className='flex-row items-center justify-between gap-3 px-4 pt-1 pb-[14px]'>
+            <Button
+                iconOnly
+                variant='ghost'
+                accessibilityLabel='Open menu'
+                disabled={!irrigationOn}
+                onPress={onMenuPress}
+            >
+                <Menu size={18} />
+            </Button>
+            <View
+                className='flex-row items-center gap-2'
+                style={{ opacity: irrigationOn ? 1 : 0.45 }}
+            >
+                <BrandGlyph size={24} />
+                <Text
+                    style={{
+                        fontFamily: FontFamily.displaySemibold,
+                        fontSize: 16,
+                        lineHeight: 16,
+                        letterSpacing: -0.32,
+                        color: colors.fg,
+                    }}
+                >
+                    Irrigo
+                </Text>
+            </View>
+            <Button
+                iconOnly
+                variant='ghost'
+                accessibilityLabel='Re-plan'
+                disabled={refreshDisabled}
+                onPress={() => replan.mutate()}
+            >
+                <Refresh size={16} />
+            </Button>
+        </View>
+    );
+}


### PR DESCRIPTION
## Ticket

[APP-22](http://192.168.2.100:7123/irrigo/browse/APP-22/) — App header (menu / brand / re-plan).

## Summary

- Adds `app/components/header/index.tsx`: hamburger / `BrandGlyph` + Irrigo wordmark / re-plan icon, mirroring the App header block in `app/design/irrigo/project/ui_kit/Mobile.jsx:32-68`.
- Reads master-switch state via `useSystem`; while irrigation is off (or the query hasn't resolved yet) both icon buttons disable and the brand row dims to 0.45 opacity. RN has no CSS `filter`, so the design source's `grayscale(1)` is approximated with the opacity drop.
- Refresh dispatches `useReplan` and stays disabled while a re-plan is in flight.
- `onMenuPress` is a required prop; the header stays drawer-agnostic so APP-23 can wire it without touching this file.
- Seven behaviour tests cover: control rendering, menu callback, menu disabled when off, refresh POST when on, refresh suppressed when off, refresh suppressed while pending, undefined system state treated as off.

## Test plan

- [x] `bun --cwd=./app run test components/header` — 7 passed.
- [x] `bun --cwd=./app run test` — 219 passed (37 suites).
- [x] `bun --cwd=./app run typecheck` — no new errors. Two pre-existing `expo-router` typed-routes errors remain in `app/(tabs)/index.tsx` and `app/modal.tsx` from cached `.expo/types/router.d.ts`; they regenerate on `expo start`.
- [ ] Visual smoke deferred to APP-23 when the header is mounted in the shell.