### PR TITLE
[APP-19] AlertRow primitive (info / warn / danger)

### DIFF
--- a/app/components/alert-row/.test.tsx
+++ b/app/components/alert-row/.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { AlertRow, type AlertRowTone } from '.';
+
+type FlatStyle = {
+    backgroundColor?: string;
+    borderColor?: string;
+    color?: string;
+};
+
+const TONE_EXPECTATIONS: Readonly<Record<AlertRowTone, { border: string; accent: string; icon: string }>> = {
+    info: { border: 'rgba(124, 212, 251, 0.4)', accent: '#7CD4FB', icon: 'i' },
+    warn: { border: 'rgba(255, 190, 107, 0.4)', accent: '#FFBE6B', icon: '⚠' },
+    danger: { border: 'rgba(255, 107, 123, 0.4)', accent: '#FF6B7B', icon: '!' },
+};
+
+describe('AlertRow', () => {
+    it('renders the title.', () => {
+        render(<AlertRow tone='danger' title='HA close failed' />);
+
+        expect(screen.getByText('HA close failed')).toBeOnTheScreen();
+    });
+
+    it('renders the sub-line when provided.', () => {
+        render(
+            <AlertRow
+                tone='danger'
+                title='HA close failed'
+                sub='Last attempt failed: 502 Bad Gateway.'
+            />,
+        );
+
+        expect(screen.getByText('Last attempt failed: 502 Bad Gateway.')).toBeOnTheScreen();
+    });
+
+    it('hides the sub-line when omitted.', () => {
+        render(<AlertRow tone='danger' title='HA close failed' />);
+
+        // No sub text node — only title + icon glyph + (no when).
+        expect(screen.queryByText('Last attempt failed: 502 Bad Gateway.')).toBeNull();
+    });
+
+    it('renders the relative-time slot when provided.', () => {
+        render(<AlertRow tone='warn' title='Weather API stale' when='11h' />);
+
+        expect(screen.getByText('11h')).toBeOnTheScreen();
+    });
+
+    it('omits the relative-time slot when not provided.', () => {
+        render(<AlertRow tone='warn' title='Weather API stale' />);
+
+        expect(screen.queryByText('11h')).toBeNull();
+    });
+
+    it.each(Object.entries(TONE_EXPECTATIONS) as ReadonlyArray<[AlertRowTone, { border: string; accent: string; icon: string }]>)(
+        'paints the %s tone palette on the container border and title color.',
+        (tone, expected) => {
+            const { root } = render(<AlertRow tone={tone} title='Test alert' />);
+
+            const containerStyle = StyleSheet.flatten(root.props.style) as FlatStyle;
+            expect(containerStyle.borderColor).toBe(expected.border);
+
+            const titleStyle = StyleSheet.flatten(screen.getByText('Test alert').props.style) as FlatStyle;
+            expect(titleStyle.color).toBe(expected.accent);
+        },
+    );
+
+    it.each(Object.entries(TONE_EXPECTATIONS) as ReadonlyArray<[AlertRowTone, { border: string; accent: string; icon: string }]>)(
+        'renders the %s icon glyph.',
+        (tone, expected) => {
+            render(<AlertRow tone={tone} title='Test alert' />);
+
+            expect(screen.getByText(expected.icon)).toBeOnTheScreen();
+        },
+    );
+
+    it('builds a default accessibility label combining title and sub.', () => {
+        render(
+            <AlertRow
+                tone='danger'
+                title='HA close failed'
+                sub='Last attempt failed: 502 Bad Gateway.'
+            />,
+        );
+
+        expect(
+            screen.getByLabelText('HA close failed. Last attempt failed: 502 Bad Gateway.'),
+        ).toBeOnTheScreen();
+    });
+
+    it('uses the title alone as the default accessibility label when no sub is provided.', () => {
+        render(<AlertRow tone='warn' title='Weather API stale' />);
+
+        expect(screen.getByLabelText('Weather API stale')).toBeOnTheScreen();
+    });
+
+    it('honors a caller-provided accessibility label, overriding the default.', () => {
+        render(
+            <AlertRow
+                tone='danger'
+                title='HA close failed'
+                sub='502 Bad Gateway'
+                accessibilityLabel='Alert: zone South close failed earlier tonight'
+            />,
+        );
+
+        expect(
+            screen.getByLabelText('Alert: zone South close failed earlier tonight'),
+        ).toBeOnTheScreen();
+    });
+});

--- a/app/components/alert-row/index.tsx
+++ b/app/components/alert-row/index.tsx
@@ -1,0 +1,144 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Visual tone selecting the alert's tinted background, border, and icon
+ * glyph. RN port of `.alert.alert--<tone>` from the design's `AlertRow`.
+ */
+export type AlertRowTone = 'info' | 'warn' | 'danger';
+
+/**
+ * Props for the Irrigo alert-row primitive.
+ */
+export type AlertRowProps = {
+    /** Required. Visual tone — selects the tinted bg/border palette and icon glyph. */
+    tone: AlertRowTone;
+
+    /** Required. Title text. */
+    title: string;
+
+    /** Optional. Sub-line text rendered under the title. */
+    sub?: string;
+
+    /** Optional. Relative-time slot rendered on the right (e.g. `'11h'`, `'2d'`). */
+    when?: string;
+
+    /** Optional. Accessibility label for the row. Defaults to title + sub joined by a period. */
+    accessibilityLabel?: string;
+};
+
+type TonePalette = {
+    background: string;
+    border: string;
+    accent: string;
+    icon: string;
+};
+
+const TONE_PALETTE: Readonly<Record<AlertRowTone, TonePalette>> = {
+    info: {
+        background: colors['info-tint'],
+        border: colors['info-border'],
+        accent: colors.info,
+        icon: 'i',
+    },
+    warn: {
+        background: colors['warn-tint'],
+        border: colors['warn-border'],
+        accent: colors.warn,
+        icon: '⚠',
+    },
+    danger: {
+        background: colors['danger-tint'],
+        border: colors['danger-border'],
+        accent: colors.danger,
+        icon: '!',
+    },
+};
+
+/**
+ * The Irrigo alert-row — surfaces a single tonight-or-recent failure in the
+ * alerts/activity feed. Icon glyph (left), title + optional sub (middle),
+ * optional relative-time slot (right). Tinted background and border per
+ * tone; title and icon paint in the tone's full color, sub paints in
+ * `fg-soft`. RN port of `AlertRow` from `components.jsx`.
+ */
+export function AlertRow({
+    tone,
+    title,
+    sub,
+    when,
+    accessibilityLabel,
+}: AlertRowProps) {
+    const palette = TONE_PALETTE[tone];
+    const label = accessibilityLabel ?? (sub ? `${title}. ${sub}` : title);
+
+    return (
+        <View
+            accessibilityLabel={label}
+            style={[
+                styles.container,
+                { backgroundColor: palette.background, borderColor: palette.border },
+            ]}
+        >
+            <View style={[styles.iconBadge, { backgroundColor: palette.background }]}>
+                <Text style={[styles.iconText, { color: palette.accent }]}>{palette.icon}</Text>
+            </View>
+
+            <View style={styles.body}>
+                <Text style={[styles.title, { color: palette.accent }]}>{title}</Text>
+                {sub !== undefined && <Text style={styles.sub}>{sub}</Text>}
+            </View>
+
+            {when !== undefined && <Text style={styles.when}>{when}</Text>}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        padding: 12,
+        borderWidth: 1,
+        borderRadius: 4,
+    },
+    iconBadge: {
+        width: 24,
+        height: 24,
+        borderRadius: 12,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    iconText: {
+        fontFamily: FontFamily.sansSemibold,
+        fontSize: 14,
+        lineHeight: 14,
+    },
+    body: {
+        flex: 1,
+        gap: 2,
+    },
+    title: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 14,
+        lineHeight: 18,
+    },
+    sub: {
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 16,
+        color: colors['fg-soft'],
+    },
+    when: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 12,
+        lineHeight: 14,
+        color: colors['fg-muted'],
+        flexShrink: 0,
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-19](http://192.168.2.100:7123/irrigo/browse/APP-19/) — AlertRow component (info / warn / danger).

## Summary

- New `AlertRow` primitive at `app/components/alert-row/` — RN port of `AlertRow` from the design system's `components.jsx:243-255`.
- Three tones: `info`, `warn`, `danger`. Tinted bg + matching tinted border + tone-colored title and icon, mirroring the Badge palette layering (same `*-tint` / `*-border` tokens APP-14 introduced).
- Layout per source: icon glyph (`i` / `⚠` / `!`) left, title + optional sub middle, optional relative-time slot right.
- Default accessibility label combines title and sub; caller can override.
- 14 new tests cover every tone, both sub presence states, both when-slot presence states, both a11y label paths.

## Test plan

- [x] `bun --cwd=./app run test` — 256 tests across 39 suites green.
- [x] `bun --cwd=./app run typecheck` — no new errors (pre-existing scaffolding errors in `(tabs)/index.tsx` and `modal.tsx` are unrelated).

## Out of scope

- The alerts screen that consumes AlertRow (separate ticket).
- Tap-to-acknowledge interaction (no `onPress` on this primitive — read-only).