### PR TITLE
[APP-23] Side drawer with nav items and active-schedule footer

### DIFF
--- a/app/components/battery/index.tsx
+++ b/app/components/battery/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { Animated, View } from 'react-native';
 
+import { Duration } from '@/constants/motion';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
@@ -14,8 +15,6 @@ const TONE_COLOR = {
     warn: colors.warn,
     danger: colors.danger,
 } as const;
-
-const TRANSITION_MS = 360;
 
 export type BatteryTone = keyof typeof TONE_COLOR;
 
@@ -93,7 +92,7 @@ export function Battery({
     useEffect(() => {
         Animated.timing(animated, {
             toValue: geometry.pct / 100,
-            duration: TRANSITION_MS,
+            duration: Duration.slow,
             useNativeDriver: false,
         }).start();
     }, [animated, geometry.pct]);
@@ -101,7 +100,7 @@ export function Battery({
     useEffect(() => {
         Animated.timing(toneAnimated, {
             toValue: toneIndex(geometry.tone),
-            duration: TRANSITION_MS,
+            duration: Duration.slow,
             useNativeDriver: false,
         }).start();
     }, [toneAnimated, geometry.tone]);

--- a/app/components/nav-drawer/.test.tsx
+++ b/app/components/nav-drawer/.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import { keys } from '@/api/query-keys';
+import type { ScheduleListItem } from '@/api/types/schedules';
+import { NavDrawer } from '.';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+const SAMPLE_ACTIVE: ScheduleListItem = {
+    id: 'sched-1',
+    slug: 'maintenance',
+    name: 'Maintenance',
+    isActive: true,
+    allowedDays: [3, 5, 7],
+    allowedTimeWindows: [{ start: '00:00', end: '10:00' }],
+    rootDepthMOverride: null,
+    allowableDepletionFractionOverride: null,
+    endBySunrise: null,
+};
+
+const SAMPLE_INACTIVE: ScheduleListItem = {
+    id: 'sched-2',
+    slug: 'overseeding',
+    name: 'Overseeding',
+    isActive: false,
+    allowedDays: null,
+    allowedTimeWindows: null,
+    rootDepthMOverride: 0.05,
+    allowableDepletionFractionOverride: 0.25,
+    endBySunrise: null,
+};
+
+describe('NavDrawer', () => {
+    it('renders the brand row, four nav items, close button, and footer when visible.', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE, SAMPLE_INACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        expect(screen.getByText('Irrigo')).toBeOnTheScreen();
+        expect(screen.getByText('Calgary · 740 m²')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Home')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Zones')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Schedules')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Activity')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Close menu')).toBeOnTheScreen();
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+    });
+
+    it('hides its content when visible is false.', () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible={false} onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        // Modal is not visible — RN test renderer hides its children entirely.
+        expect(screen.queryByLabelText('Home')).toBeNull();
+        expect(screen.queryByText('Irrigo')).toBeNull();
+    });
+
+    it('calls onSelect with the tapped nav item id.', () => {
+        const onSelect = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={onSelect} />,
+            { wrapper },
+        );
+        fireEvent.press(screen.getByLabelText('Zones'));
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toHaveBeenCalledWith('zones');
+    });
+
+    it('also calls onClose after a nav item is selected so the drawer dismisses.', () => {
+        const onSelect = jest.fn();
+        const onClose = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={onClose} activeId='home' onSelect={onSelect} />,
+            { wrapper },
+        );
+        fireEvent.press(screen.getByLabelText('Schedules'));
+
+        expect(onSelect).toHaveBeenCalledWith('schedules');
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the close button is tapped.', () => {
+        const onClose = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={onClose} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+        fireEvent.press(screen.getByLabelText('Close menu'));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the active item with `accessibilityState.selected: true` and leaves others false.', () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={jest.fn()} activeId='zones' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        expect(screen.getByLabelText('Zones').props.accessibilityState).toMatchObject({ selected: true });
+        expect(screen.getByLabelText('Home').props.accessibilityState).toMatchObject({ selected: false });
+        expect(screen.getByLabelText('Schedules').props.accessibilityState).toMatchObject({ selected: false });
+        expect(screen.getByLabelText('Activity').props.accessibilityState).toMatchObject({ selected: false });
+    });
+
+    it('shows the active schedule name and formatted cadence in the footer.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse([SAMPLE_ACTIVE, SAMPLE_INACTIVE]));
+
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+        expect(screen.getByText('Wed · Fri · Sun · 00:00–10:00')).toBeOnTheScreen();
+    });
+
+    it('unmounts the modal content after the close animation completes when visible flips to false.', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        const { rerender } = render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+        expect(screen.getByLabelText('Home')).toBeOnTheScreen();
+
+        rerender(
+            <NavDrawer visible={false} onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+        );
+
+        // Slide-out is 280ms; waitFor polls until the modal unmounts.
+        await waitFor(() => expect(screen.queryByLabelText('Home')).toBeNull(), { timeout: 1500 });
+    });
+
+    it('"Switch profile" button calls onSelect("schedules") and onClose.', () => {
+        const onSelect = jest.fn();
+        const onClose = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={onClose} activeId='home' onSelect={onSelect} />,
+            { wrapper },
+        );
+        fireEvent.press(screen.getByText('Switch profile'));
+
+        expect(onSelect).toHaveBeenCalledWith('schedules');
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/components/nav-drawer/index.tsx
+++ b/app/components/nav-drawer/index.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+    Animated,
+    Easing,
+    Modal as RNModal,
+    Pressable,
+    StyleSheet,
+    Text,
+    View,
+    type ViewStyle,
+} from 'react-native';
+import { BlurView } from 'expo-blur';
+
+import { BrandGlyph } from '@/components/brand-glyph';
+import { Button } from '@/components/button';
+import { Cal, History, Home as HomeIcon, X, Zone, type IconProps } from '@/components/icons';
+import { FontFamily } from '@/constants/fonts';
+import { useSchedules } from '@/hooks/schedules';
+import config from '@/tailwind.config';
+import type { ScheduleAllowedTimeWindow, ScheduleListItem } from '@/api/types/schedules';
+
+const colors = config.theme.extend.colors;
+const shadows = config.theme.extend.boxShadow;
+
+const DRAWER_WIDTH = 280;
+const ANIM_DURATION_MS = 280;
+const EASING = Easing.bezier(0.2, 0.7, 0.2, 1);
+
+/**
+ * The four nav destinations the drawer offers. Consumers map these to their
+ * own routes; the drawer itself stays route-agnostic.
+ */
+export type NavItemId = 'home' | 'zones' | 'schedules' | 'activity';
+
+type NavItem = {
+    id: NavItemId;
+    label: string;
+    icon: (props: IconProps) => React.JSX.Element;
+};
+
+const NAV_ITEMS: readonly NavItem[] = [
+    { id: 'home', label: 'Home', icon: HomeIcon },
+    { id: 'zones', label: 'Zones', icon: Zone },
+    { id: 'schedules', label: 'Schedules', icon: Cal },
+    { id: 'activity', label: 'Activity', icon: History },
+];
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+/**
+ * Renders a schedule's `allowedDays` + `allowedTimeWindows` into the
+ * `Wed · Fri · Sun · 00:00–10:00` form the drawer footer card displays.
+ *
+ * - `days === null` → "Every day" (no day restriction).
+ * - `windows` null / empty → "any time" (no window restriction).
+ * - Multiple windows → comma-joined (`08:00–10:00, 18:00–20:00`).
+ */
+function formatCadence(days: number[] | null, windows: ScheduleAllowedTimeWindow[] | null): string {
+    const dayLabel = days === null
+        ? 'Every day'
+        : days.map(d => DAY_LABELS[d - 1] ?? '?').join(' · ');
+    const windowLabel = !windows || windows.length === 0
+        ? 'any time'
+        : windows.map(w => `${w.start}–${w.end}`).join(', ');
+    return `${dayLabel} · ${windowLabel}`;
+}
+
+/**
+ * Props for the Irrigo side drawer.
+ */
+export type NavDrawerProps = {
+    /** Required. Whether the drawer is open. Controls slide-in/out + mount. */
+    visible: boolean;
+
+    /** Required. Called when the user requests dismissal (scrim tap, close button, Android back, or after selecting a nav item). */
+    onClose: () => void;
+
+    /** Required. The id of the currently-active nav destination. The matching row paints with the active treatment + dot indicator. */
+    activeId: NavItemId;
+
+    /** Required. Called with the tapped item's id when the user picks a nav destination or hits "Switch profile" (which passes `'schedules'`). */
+    onSelect: (id: NavItemId) => void;
+};
+
+/**
+ * Irrigo's left-anchored nav drawer. Composes a brand row, four nav items
+ * (Home / Zones / Schedules / Activity), and a glow-bordered footer card
+ * surfacing the currently-active schedule with a "Switch profile" shortcut.
+ *
+ * Controlled component — `visible`, `activeId`, `onClose`, and `onSelect`
+ * are all owned by the parent shell. Selecting a nav item fires
+ * `onSelect(id)` followed by `onClose()` so the drawer dismisses after a
+ * navigation, matching the Mobile.jsx tap-then-close UX.
+ *
+ * Slide animation: 280ms `translateX` from `-DRAWER_WIDTH → 0` (open) and
+ * back (close). RN Modal handles the platform overlay + Android back; the
+ * internal `modalVisible` state lags the `visible` prop so the slide-OUT
+ * runs to completion before the Modal unmounts. `useSchedules` powers the
+ * footer card; when no schedule is active (or the query is still in flight)
+ * the footer renders a `—` placeholder rather than a blank card.
+ */
+export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerProps) {
+    const translateX = useRef(new Animated.Value(-DRAWER_WIDTH)).current;
+    const [modalVisible, setModalVisible] = useState(visible);
+
+    useEffect(() => {
+        if (visible) {
+            setModalVisible(true);
+            Animated.timing(translateX, {
+                toValue: 0,
+                duration: ANIM_DURATION_MS,
+                easing: EASING,
+                useNativeDriver: true,
+            }).start();
+        } else if (modalVisible) {
+            Animated.timing(translateX, {
+                toValue: -DRAWER_WIDTH,
+                duration: ANIM_DURATION_MS,
+                easing: EASING,
+                useNativeDriver: true,
+            }).start(({ finished }) => {
+                if (finished) setModalVisible(false);
+            });
+        }
+    }, [visible, modalVisible, translateX]);
+
+    const handleSelect = (id: NavItemId) => {
+        onSelect(id);
+        onClose();
+    };
+
+    const { data: schedules } = useSchedules();
+    const activeSchedule = schedules?.find(row => row.isActive) ?? null;
+
+    return (
+        <RNModal
+            visible={modalVisible}
+            onRequestClose={onClose}
+            transparent
+            animationType='none'
+            statusBarTranslucent
+        >
+            <View style={styles.overlay}>
+                <Pressable
+                    style={StyleSheet.absoluteFill}
+                    onPress={onClose}
+                    accessibilityRole='button'
+                    accessibilityLabel='Dismiss drawer'
+                >
+                    <BlurView intensity={50} tint='dark' style={StyleSheet.absoluteFill} />
+                    <View style={styles.scrim} />
+                </Pressable>
+
+                <Animated.View
+                    style={[styles.panel, { transform: [{ translateX }] }]}
+                    accessibilityViewIsModal
+                    accessibilityLabel='Navigation'
+                >
+                    <View style={styles.brandRow}>
+                        <View style={styles.brandIdentity}>
+                            <BrandGlyph size={28} />
+                            <View>
+                                <Text style={styles.wordmark}>Irrigo</Text>
+                                <Text style={styles.subtitle}>Calgary · 740 m²</Text>
+                            </View>
+                        </View>
+                        <Button
+                            iconOnly
+                            size='sm'
+                            variant='ghost'
+                            accessibilityLabel='Close menu'
+                            onPress={onClose}
+                        >
+                            <X size={14} />
+                        </Button>
+                    </View>
+
+                    <View style={styles.nav}>
+                        {NAV_ITEMS.map(item => (
+                            <NavRow
+                                key={item.id}
+                                item={item}
+                                active={item.id === activeId}
+                                onPress={() => handleSelect(item.id)}
+                            />
+                        ))}
+                    </View>
+
+                    <View style={styles.footerSlot}>
+                        <ActiveScheduleCard
+                            schedule={activeSchedule}
+                            onSwitchProfile={() => handleSelect('schedules')}
+                        />
+                    </View>
+                </Animated.View>
+            </View>
+        </RNModal>
+    );
+}
+
+function NavRow({ item, active, onPress }: { item: NavItem; active: boolean; onPress: () => void }) {
+    const rowStyle: ViewStyle = {
+        ...styles.navRow,
+        backgroundColor: active ? colors['surface-2'] : 'transparent',
+        borderColor: active ? colors.border : 'transparent',
+    };
+    return (
+        <Pressable
+            onPress={onPress}
+            accessibilityRole='button'
+            accessibilityLabel={item.label}
+            accessibilityState={{ selected: active }}
+            style={rowStyle}
+        >
+            <item.icon size={18} color={active ? colors.accent : colors['fg-muted']} />
+            <Text style={[styles.navLabel, { color: active ? colors.fg : colors['fg-soft'] }]}>
+                {item.label}
+            </Text>
+            {active && <View style={styles.activeDot} />}
+        </Pressable>
+    );
+}
+
+function ActiveScheduleCard({
+    schedule,
+    onSwitchProfile,
+}: {
+    schedule: ScheduleListItem | null;
+    onSwitchProfile: () => void;
+}) {
+    const name = schedule?.name ?? '—';
+    const cadence = schedule
+        ? formatCadence(schedule.allowedDays, schedule.allowedTimeWindows)
+        : '';
+    return (
+        <View style={styles.activeCard}>
+            <Text style={styles.activeEyebrow}>ACTIVE</Text>
+            <Text style={styles.activeName}>{name}</Text>
+            {cadence !== '' && <Text style={styles.activeCadence}>{cadence}</Text>}
+            <View style={styles.switchButtonRow}>
+                <Button variant='secondary' size='sm' onPress={onSwitchProfile}>
+                    Switch profile
+                </Button>
+            </View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+    },
+    scrim: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: 'rgba(2, 4, 3, 0.55)',
+    },
+    panel: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        left: 0,
+        width: DRAWER_WIDTH,
+        backgroundColor: colors['ink-300'],
+        borderRightWidth: 1,
+        borderRightColor: colors.border,
+        boxShadow: shadows['3'],
+        paddingTop: 60,
+        flexDirection: 'column',
+    },
+    brandRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingHorizontal: 16,
+        paddingTop: 6,
+        paddingBottom: 18,
+    },
+    brandIdentity: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+    },
+    wordmark: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 18,
+        lineHeight: 18,
+        letterSpacing: -0.36,
+        color: colors.fg,
+    },
+    subtitle: {
+        marginTop: 2,
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 14,
+        color: colors['fg-muted'],
+    },
+    nav: {
+        paddingHorizontal: 12,
+        paddingTop: 8,
+        flexDirection: 'column',
+        gap: 2,
+    },
+    navRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 14,
+        paddingHorizontal: 14,
+        paddingVertical: 12,
+        borderRadius: 4,
+        borderWidth: 1,
+    },
+    navLabel: {
+        flex: 1,
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 15,
+        lineHeight: 15,
+    },
+    activeDot: {
+        width: 6,
+        height: 6,
+        borderRadius: 4,
+        backgroundColor: colors.accent,
+        boxShadow: `0 0 8px ${colors.accent}`,
+    },
+    footerSlot: {
+        marginTop: 'auto',
+        padding: 16,
+    },
+    activeCard: {
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors['accent-border'],
+        borderRadius: 8,
+        paddingHorizontal: 14,
+        paddingTop: 14,
+        paddingBottom: 12,
+    },
+    activeEyebrow: {
+        fontFamily: FontFamily.sansSemibold,
+        fontSize: 11,
+        lineHeight: 11,
+        letterSpacing: 1.54,
+        color: colors.accent,
+    },
+    activeName: {
+        marginTop: 4,
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 18,
+        lineHeight: 22,
+        color: colors.fg,
+    },
+    activeCadence: {
+        marginTop: 2,
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 16,
+        color: colors['fg-muted'],
+    },
+    switchButtonRow: {
+        marginTop: 12,
+    },
+});

--- a/app/components/nav-drawer/index.tsx
+++ b/app/components/nav-drawer/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
     Animated,
-    Easing,
     Modal as RNModal,
     Pressable,
     StyleSheet,
@@ -15,6 +14,7 @@ import { BrandGlyph } from '@/components/brand-glyph';
 import { Button } from '@/components/button';
 import { Cal, History, Home as HomeIcon, X, Zone, type IconProps } from '@/components/icons';
 import { FontFamily } from '@/constants/fonts';
+import { Duration, MotionEasing } from '@/constants/motion';
 import { useSchedules } from '@/hooks/schedules';
 import config from '@/tailwind.config';
 import type { ScheduleAllowedTimeWindow, ScheduleListItem } from '@/api/types/schedules';
@@ -23,8 +23,6 @@ const colors = config.theme.extend.colors;
 const shadows = config.theme.extend.boxShadow;
 
 const DRAWER_WIDTH = 280;
-const ANIM_DURATION_MS = 280;
-const EASING = Easing.bezier(0.2, 0.7, 0.2, 1);
 
 /**
  * The four nav destinations the drawer offers. Consumers map these to their
@@ -108,15 +106,15 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
             setModalVisible(true);
             Animated.timing(translateX, {
                 toValue: 0,
-                duration: ANIM_DURATION_MS,
-                easing: EASING,
+                duration: Duration.default,
+                easing: MotionEasing.standard,
                 useNativeDriver: true,
             }).start();
         } else if (modalVisible) {
             Animated.timing(translateX, {
                 toValue: -DRAWER_WIDTH,
-                duration: ANIM_DURATION_MS,
-                easing: EASING,
+                duration: Duration.default,
+                easing: MotionEasing.standard,
                 useNativeDriver: true,
             }).start(({ finished }) => {
                 if (finished) setModalVisible(false);

--- a/app/components/toggle/index.tsx
+++ b/app/components/toggle/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Animated, Pressable, View } from 'react-native';
 import { tv, type VariantProps } from 'tailwind-variants';
 
+import { Duration } from '@/constants/motion';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
@@ -15,8 +16,6 @@ const SIZE_SPEC = {
     default: { width: 44, height: 26, padding: 3 },
     lg: { width: 54, height: 30, padding: 3 },
 } as const;
-
-const TRANSITION_MS = 220;
 
 const toggle = tv({
     slots: {
@@ -80,7 +79,7 @@ export function Toggle({
     useEffect(() => {
         Animated.timing(animated, {
             toValue: value ? 1 : 0,
-            duration: TRANSITION_MS,
+            duration: Duration.default,
             useNativeDriver: false,
         }).start();
     }, [animated, value]);

--- a/app/constants/motion.ts
+++ b/app/constants/motion.ts
@@ -1,0 +1,26 @@
+import { Easing } from 'react-native';
+
+/**
+ * Canonical animation durations, mirroring the `--d-1` / `--d-2` / `--d-3`
+ * tokens defined in [`app/design/irrigo/project/colors_and_type.css`](app/design/irrigo/project/colors_and_type.css).
+ * Use these for every `Animated.timing` `duration` value so the app's motion
+ * feels consistent across primitives.
+ */
+export const Duration = {
+    /** 120 ms — quick state flips (button press feedback, hover-tier color changes). */
+    fast: 120,
+    /** 220 ms — default for control transitions (toggle thumb, drawer slide). */
+    default: 220,
+    /** 360 ms — slower hero animations (battery fill, depletion tone). */
+    slow: 360,
+} as const;
+
+/**
+ * Canonical easing curves, mirroring `--ease-out` in the design tokens.
+ * Named `MotionEasing` rather than `Easing` to avoid shadowing React Native's
+ * own `Easing` export at import sites.
+ */
+export const MotionEasing = {
+    /** `cubic-bezier(0.2, 0.7, 0.2, 1)` — the brand-canonical ease-out used by every transition in the design source. */
+    standard: Easing.bezier(0.2, 0.7, 0.2, 1),
+} as const;


### PR DESCRIPTION
## Ticket

[APP-23](http://192.168.2.100:7123/irrigo/browse/APP-23/) — Side drawer with nav items + active-schedule footer card.

## Summary

- Adds `app/components/nav-drawer/index.tsx`: 280px-wide left-anchored drawer with a brand row (`BrandGlyph` + Irrigo wordmark + "Calgary · 740 m²" subtitle + close button), four nav items (Home / Zones / Schedules / Activity), and a glow-bordered active-schedule footer card with a "Switch profile" button.
- Controlled primitive — `visible`, `activeId`, `onSelect`, `onClose` are owned by the parent shell. Selecting a nav item fires `onSelect(id)` then `onClose()` so the drawer dismisses after the navigation, matching the Mobile.jsx tap-then-close UX.
- Slide animation: 280ms `translateX` from `-DRAWER_WIDTH → 0` via `Easing.bezier(0.2, 0.7, 0.2, 1)`. Internal `modalVisible` state lags the `visible` prop so the slide-OUT runs to completion before RN's `Modal` unmounts.
- Footer reads `useSchedules()` internally and renders the active row's name + a `Wed · Fri · Sun · 00:00–10:00`-style cadence formatted from `allowedDays` + `allowedTimeWindows`. Falls back to a `—` placeholder when no schedule is active.
- "Disabled when irrigation is off" is enforced upstream — APP-22's `Header` already disables the menu button in that state, so the drawer never opens; no extra guard needed here.
- Site subtitle ("Calgary · 740 m²") is hardcoded — no site/location endpoint exists yet. A future ticket can wire a real value.
- Nine behaviour tests cover: open render, hidden render, nav-item select callback, post-select dismiss, close-button dismiss, active-item accessibility state, footer schedule data + cadence formatting, "Switch profile" → schedules nav, and slide-out unmount after `visible` flips false.

## Test plan

- [x] `bun --cwd=./app run test components/nav-drawer` — 9 passed.
- [x] `bun --cwd=./app run test` — 265 passed (40 suites).
- [x] `bun --cwd=./app run typecheck` — no new errors. Two pre-existing `expo-router` typed-routes errors remain on main (`app/(tabs)/index.tsx`, `app/modal.tsx`); they regenerate on `expo start`.
- [ ] Visual smoke deferred to the shell-wiring ticket where the drawer is mounted and pathname-driven `activeId` lights up.