### PR TITLE
[APP-25] Master irrigation kill-switch (UI + API wiring)

### DIFF
--- a/app/components/icons.test.tsx
+++ b/app/components/icons.test.tsx
@@ -12,6 +12,7 @@ import {
     type IconProps,
     Menu,
     More,
+    Pause,
     Play,
     Refresh,
     X,
@@ -26,6 +27,7 @@ const icons: ReadonlyArray<readonly [string, ComponentType<IconProps>]> = [
     ['Bell', Bell],
     ['More', More],
     ['Play', Play],
+    ['Pause', Pause],
     ['Zone', Zone],
     ['Cal', Cal],
     ['History', History],
@@ -72,6 +74,13 @@ describe('Irrigo icons', () => {
 
         const svg = screen.getByLabelText('More');
         expect(svg.props.fill).toBe('#FF6B7B');
+    });
+
+    it('applies the color prop to the fill of the Pause icon.', () => {
+        render(<Pause color='#FFBE6B' accessibilityLabel='Pause' />);
+
+        const svg = screen.getByLabelText('Pause');
+        expect(svg.props.fill).toBe('#FFBE6B');
     });
 
     it('honors a custom strokeWidth on a stroke-based icon.', () => {

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -81,6 +81,15 @@ export function Play({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, accessibility
     );
 }
 
+export function Pause({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill={color} accessibilityLabel={accessibilityLabel}>
+            <Rect x={4} y={3} width={2.5} height={10} rx={0.5} />
+            <Rect x={9.5} y={3} width={2.5} height={10} rx={0.5} />
+        </Svg>
+    );
+}
+
 export function Zone({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
     return (
         <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>

--- a/app/components/master-toggle/.test.tsx
+++ b/app/components/master-toggle/.test.tsx
@@ -1,0 +1,137 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+
+import { MasterToggle } from '.';
+
+const mockFetch = jest.fn();
+
+const SAMPLE_TIMESTAMP = '2026-05-22T00:00:00.000Z';
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('MasterToggle', () => {
+    it('renders the loading card while the initial query is pending.', async () => {
+        // Pending forever so we observe the loading branch.
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        expect(screen.getByText('Loading')).toBeOnTheScreen();
+        expect(screen.getByText('Fetching irrigation status…')).toBeOnTheScreen();
+    });
+
+    it('renders the ON card after a successful system query (irrigation enabled).', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('System on')).toBeOnTheScreen());
+        expect(screen.getByText('Irrigation enabled')).toBeOnTheScreen();
+        expect(screen.getByText('Scheduling & manual runs allowed')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Disable irrigation')).toBeOnTheScreen();
+    });
+
+    it('renders the OFF card after a successful system query (irrigation disabled).', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('System off')).toBeOnTheScreen());
+        expect(screen.getByText('Irrigation disabled')).toBeOnTheScreen();
+        expect(screen.getByText('Master kill switch · all runs blocked')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Enable irrigation')).toBeOnTheScreen();
+    });
+
+    it('POSTs /system/disable when the toggle is flipped from on to off.', async () => {
+        // Sequence: GET /system, POST /system/disable, GET /system (re-fetch
+        // after the mutation's onSuccess invalidates the system query).
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Disable irrigation')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Disable irrigation'));
+        });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
+            expect(urls).toContain('http://test.local:9753/system/disable');
+        });
+    });
+
+    it('POSTs /system/enable when the toggle is flipped from off to on.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Enable irrigation')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Enable irrigation'));
+        });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
+            expect(urls).toContain('http://test.local:9753/system/enable');
+        });
+    });
+
+    it('renders the error card when the initial system query fails.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('System unreachable')).toBeOnTheScreen());
+        expect(screen.getByText('Status unknown')).toBeOnTheScreen();
+        expect(screen.getByText('Failed to load system state.')).toBeOnTheScreen();
+    });
+
+    it('surfaces a mutation error in the sub-line while keeping the last-known tone.', async () => {
+        // First call: initial GET returns enabled.
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+        // Second call: the disable mutation fails.
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'HA 502' }, 502));
+        // Any subsequent re-fetch from invalidation: keep returning enabled.
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Disable irrigation')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Disable irrigation'));
+        });
+
+        // Sub line flips to the error prefix; the card still reads "System on"
+        // since the displayed value tracks the query, not the failed mutation.
+        await waitFor(() => expect(screen.getByText(/Last attempt failed:/)).toBeOnTheScreen());
+        expect(screen.getByText('System on')).toBeOnTheScreen();
+    });
+
+    it('renders under the default accessibility label.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Master irrigation kill switch')).toBeOnTheScreen());
+    });
+
+    it('honors a caller-provided accessibility label on the card container.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+
+        render(<MasterToggle accessibilityLabel='Main switch' />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Main switch')).toBeOnTheScreen());
+    });
+});

--- a/app/components/master-toggle/index.tsx
+++ b/app/components/master-toggle/index.tsx
@@ -1,0 +1,182 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { FontFamily } from '@/constants/fonts';
+import { Drop, Pause } from '@/components/icons';
+import { Toggle } from '@/components/toggle';
+import { useSetSystemEnabled, useSystem } from '@/hooks/system';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the master irrigation kill-switch.
+ */
+export type MasterToggleProps = {
+    /** Optional. Accessibility label for the card container. Defaults to `'Master irrigation kill switch'`. */
+    accessibilityLabel?: string;
+};
+
+const DEFAULT_LABEL = 'Master irrigation kill switch';
+const ERROR_QUERY_SUB = 'Failed to load system state.';
+const ERROR_MUTATION_PREFIX = 'Last attempt failed: ';
+
+/**
+ * The master irrigation kill switch — the single control that stops all
+ * scheduling and manual runs site-wide. Owns its own data: `useSystem` for
+ * the current state, `useSetSystemEnabled` for the flip. Drop it into any
+ * screen that needs the switch (Home hero, Settings); no props required.
+ * RN port of `MasterToggle` from the design source's `Mobile.jsx`.
+ */
+export function MasterToggle({ accessibilityLabel = DEFAULT_LABEL }: MasterToggleProps) {
+    const system = useSystem();
+    const setEnabled = useSetSystemEnabled();
+
+    if (system.isPending) return <PendingCard accessibilityLabel={accessibilityLabel} />;
+    if (system.isError || system.data === undefined) {
+        return <ErrorCard accessibilityLabel={accessibilityLabel} />;
+    }
+
+    const on = system.data.irrigationEnabled;
+    const palette = on ? ON_PALETTE : OFF_PALETTE;
+
+    const mutationErrorSub = setEnabled.isError
+        ? `${ERROR_MUTATION_PREFIX}${setEnabled.error.message}.`
+        : undefined;
+
+    return (
+        <View
+            accessibilityLabel={accessibilityLabel}
+            style={[styles.card, { borderColor: palette.border }]}
+        >
+            <View style={[styles.iconBadge, { borderColor: palette.border, backgroundColor: palette.tint }]}>
+                {on
+                    ? <Drop color={colors.accent} />
+                    : <Pause color={colors.warn} />}
+            </View>
+
+            <View style={styles.body}>
+                <Text style={[styles.eyebrow, { color: palette.accent }]}>
+                    {on ? 'System on' : 'System off'}
+                </Text>
+                <Text style={styles.title}>
+                    {on ? 'Irrigation enabled' : 'Irrigation disabled'}
+                </Text>
+                <Text style={styles.sub}>
+                    {mutationErrorSub
+                        ?? (on
+                            ? 'Scheduling & manual runs allowed'
+                            : 'Master kill switch · all runs blocked')}
+                </Text>
+            </View>
+
+            <Toggle
+                value={on}
+                onValueChange={next => setEnabled.mutate(next)}
+                size='lg'
+                disabled={setEnabled.isPending}
+                accessibilityLabel={on ? 'Disable irrigation' : 'Enable irrigation'}
+            />
+        </View>
+    );
+}
+
+type Palette = {
+    accent: string;
+    border: string;
+    tint: string;
+};
+
+const ON_PALETTE: Palette = {
+    accent: colors.accent,
+    border: colors['accent-border'],
+    tint: colors['accent-tint'],
+};
+
+const OFF_PALETTE: Palette = {
+    accent: colors.warn,
+    border: colors['warn-border'],
+    tint: colors['warn-tint'],
+};
+
+function PendingCard({ accessibilityLabel }: { accessibilityLabel: string }) {
+    return (
+        <View
+            accessibilityLabel={accessibilityLabel}
+            style={[styles.card, { borderColor: colors.border }]}
+        >
+            <View style={[styles.iconBadge, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+                <Drop color={colors['fg-muted']} />
+            </View>
+
+            <View style={styles.body}>
+                <Text style={[styles.eyebrow, { color: colors['fg-muted'] }]}>Loading</Text>
+                <Text style={styles.title}>System state</Text>
+                <Text style={styles.sub}>Fetching irrigation status…</Text>
+            </View>
+        </View>
+    );
+}
+
+function ErrorCard({ accessibilityLabel }: { accessibilityLabel: string }) {
+    return (
+        <View
+            accessibilityLabel={accessibilityLabel}
+            style={[styles.card, { borderColor: colors['warn-border'] }]}
+        >
+            <View style={[styles.iconBadge, { borderColor: colors['warn-border'], backgroundColor: colors['warn-tint'] }]}>
+                <Pause color={colors.warn} />
+            </View>
+
+            <View style={styles.body}>
+                <Text style={[styles.eyebrow, { color: colors.warn }]}>System unreachable</Text>
+                <Text style={styles.title}>Status unknown</Text>
+                <Text style={styles.sub}>{ERROR_QUERY_SUB}</Text>
+            </View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    card: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 14,
+        padding: 14,
+        backgroundColor: colors.elevated,
+        borderWidth: 1,
+        borderRadius: 4,
+    },
+    iconBadge: {
+        width: 36,
+        height: 36,
+        flexShrink: 0,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderWidth: 1,
+        borderRadius: 4,
+    },
+    body: {
+        flex: 1,
+        minWidth: 0,
+        gap: 4,
+    },
+    eyebrow: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 10,
+        lineHeight: 12,
+        letterSpacing: 1.6,
+        textTransform: 'uppercase',
+    },
+    title: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 17,
+        lineHeight: 19,
+        color: colors.fg,
+    },
+    sub: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 14,
+        color: colors['fg-muted'],
+    },
+});

--- a/app/components/system-disabled-wrapper/.test.tsx
+++ b/app/components/system-disabled-wrapper/.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet, Text } from 'react-native';
+import type { ReactTestInstance } from 'react-test-renderer';
+
+import { SystemDisabledWrapper } from '.';
+
+type FlatStyle = {
+    opacity?: number;
+    pointerEvents?: 'auto' | 'none' | 'box-only' | 'box-none';
+};
+
+describe('SystemDisabledWrapper', () => {
+    it('renders its children when enabled.', () => {
+        render(
+            <SystemDisabledWrapper disabled={false}>
+                <Text>Home content</Text>
+            </SystemDisabledWrapper>,
+        );
+
+        expect(screen.getByText('Home content')).toBeOnTheScreen();
+    });
+
+    it('applies no opacity / pointer-event styling when enabled.', () => {
+        const { root } = render(
+            <SystemDisabledWrapper disabled={false}>
+                <Text>Home content</Text>
+            </SystemDisabledWrapper>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle | undefined;
+        expect(style?.opacity).toBeUndefined();
+        expect(style?.pointerEvents).toBeUndefined();
+    });
+
+    it('renders children dimmed and not interactive when disabled.', () => {
+        const { root } = render(
+            <SystemDisabledWrapper disabled>
+                <Text>Home content</Text>
+            </SystemDisabledWrapper>,
+        );
+
+        const style = StyleSheet.flatten(root.props.style) as FlatStyle;
+        expect(style.opacity).toBe(0.32);
+        expect(style.pointerEvents).toBe('none');
+        // Children still exist in the tree (just hidden from a11y); reach
+        // through the host tree since `accessibilityElementsHidden` blocks
+        // text-based queries.
+        const textNodes = findText(root, 'Home content');
+        expect(textNodes.length).toBeGreaterThan(0);
+    });
+
+    it('hides children from assistive tech when disabled.', () => {
+        const { root } = render(
+            <SystemDisabledWrapper disabled>
+                <Text>Home content</Text>
+            </SystemDisabledWrapper>,
+        );
+
+        expect(root.props.accessibilityElementsHidden).toBe(true);
+        expect(root.props.importantForAccessibility).toBe('no-hide-descendants');
+    });
+
+    it('renders multiple children correctly in both enabled and disabled modes.', () => {
+        const { rerender, root } = render(
+            <SystemDisabledWrapper disabled={false}>
+                <Text>First</Text>
+                <Text>Second</Text>
+            </SystemDisabledWrapper>,
+        );
+
+        expect(screen.getByText('First')).toBeOnTheScreen();
+        expect(screen.getByText('Second')).toBeOnTheScreen();
+
+        rerender(
+            <SystemDisabledWrapper disabled>
+                <Text>First</Text>
+                <Text>Second</Text>
+            </SystemDisabledWrapper>,
+        );
+
+        // Disabled hides children from a11y; reach via host-tree query.
+        expect(findText(root, 'First').length).toBeGreaterThan(0);
+        expect(findText(root, 'Second').length).toBeGreaterThan(0);
+    });
+});
+
+function findText(root: ReactTestInstance, value: string): ReactTestInstance[] {
+    return root.findAll(node => {
+        if (typeof node.type !== 'string') return false;
+        const children = node.children;
+        return children.some(child => typeof child === 'string' && child === value);
+    });
+}

--- a/app/components/system-disabled-wrapper/index.tsx
+++ b/app/components/system-disabled-wrapper/index.tsx
@@ -1,0 +1,33 @@
+import { View } from 'react-native';
+import type { ReactNode } from 'react';
+
+/**
+ * Props for the system-disabled wrapper.
+ */
+export type SystemDisabledWrapperProps = {
+    /** Required. Whether to dim and disable the wrapped children. */
+    disabled: boolean;
+
+    /** Required. The surfaces to dim/disable when `disabled` is true. */
+    children: ReactNode;
+};
+
+/**
+ * Wraps a slab of UI that should grey out and stop receiving touches when
+ * the master irrigation kill switch is off. Drop the wrapper around any
+ * Home / Schedule / drawer subtree that depends on the system being live;
+ * the MasterToggle itself sits outside the wrapper so it remains
+ * interactive. Mirrors the `irrigationOn ? auto : (opacity 0.32, no
+ * pointer events)` treatment from the design source's `HomeView`.
+ */
+export function SystemDisabledWrapper({ disabled, children }: SystemDisabledWrapperProps) {
+    return (
+        <View
+            style={disabled ? { opacity: 0.32, pointerEvents: 'none' } : undefined}
+            accessibilityElementsHidden={disabled}
+            importantForAccessibility={disabled ? 'no-hide-descendants' : 'auto'}
+        >
+            {children}
+        </View>
+    );
+}


### PR DESCRIPTION
## Ticket

[APP-25](http://192.168.2.100:7123/irrigo/browse/APP-25/) — Master irrigation kill-switch (UI + API wiring).

## Summary

Delivers two reusable primitives the eventual HomeView will compose with:

- **`MasterToggle`** (`app/components/master-toggle/`) — fully API-wired drop-in. Owns its own data via `useSystem` + `useSetSystemEnabled`; no props required. Renders the ON card (`Drop` icon, accent border, "System on" / "Irrigation enabled" / "Scheduling & manual runs allowed") or OFF card (`Pause` icon, warn border, "System off" / "Irrigation disabled" / "Master kill switch · all runs blocked"). Surfaces query and mutation errors in the sub-line; toggle disabled while mutation is pending.
- **`SystemDisabledWrapper`** (`app/components/system-disabled-wrapper/`) — wraps the non-toggle surfaces. When `disabled` is true: `opacity: 0.32`, `pointerEvents: 'none'`, and hidden from a11y tree. Same treatment as the design source's HomeView dim/disable wrapper.
- **`Pause` icon** added to the icon set (mirrors the existing convention in `app/components/icons.tsx`).

## Test plan

- [x] `bun --cwd=./app run test` — 272 tests across 41 suites green.
  - 9 master-toggle tests (loading, ON, OFF, enable/disable POSTs, query error card, mutation error sub-line, default + custom a11y label)
  - 5 system-disabled-wrapper tests
  - 1 added Pause icon coverage
- [x] `bun --cwd=./app run typecheck` — no new errors (pre-existing scaffolding errors in `(tabs)/index.tsx` and `modal.tsx` are unrelated).

## Out of scope

- Building the actual HomeView screen and composing these primitives into it — separate ticket.
- 240ms cross-fade animation on the wrapper (snap-on/off is fine for now).
- Grayscale filter on disabled state (RN doesn't expose CSS filters; opacity alone reads as "off").