### PR TITLE
[APP-29] Schedule list (active hero + other-profiles switcher)

### DIFF
--- a/app/components/active-schedule-hero/.test.tsx
+++ b/app/components/active-schedule-hero/.test.tsx
@@ -1,0 +1,234 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { ActiveScheduleHero } from '.';
+import type { ScheduleListItem } from '@/api/types/schedules';
+
+const BASE_SCHEDULE: ScheduleListItem = {
+    id: 'sched-001',
+    slug: 'maintenance',
+    name: 'Maintenance',
+    isActive: true,
+    allowedDays: [1, 3, 5],
+    allowedTimeWindows: [{ start: '22:00', end: '06:00' }],
+    rootDepthMOverride: 0.18,
+    allowableDepletionFractionOverride: 0.5,
+    endBySunrise: true,
+    nextRun: { inLabel: '4h 32m', whenLabel: 'tonight at 10:23pm', zonesLabel: 'North + East' },
+    skippedTonight: false,
+};
+
+const NULL_RULES_SCHEDULE: ScheduleListItem = {
+    ...BASE_SCHEDULE,
+    rootDepthMOverride: null,
+    allowableDepletionFractionOverride: null,
+    endBySunrise: false,
+    nextRun: null,
+    allowedDays: null,
+    allowedTimeWindows: null,
+};
+
+const noop = () => {};
+
+describe('ActiveScheduleHero', () => {
+    it('renders the schedule name and the days · window summary.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByText('Maintenance')).toBeOnTheScreen();
+        expect(screen.getByText('Mon · Wed · Fri · 22:00 → 06:00')).toBeOnTheScreen();
+    });
+
+    it('renders the next-run labels when not skipping.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByText('4h 32m')).toBeOnTheScreen();
+        expect(screen.getByText('tonight at 10:23pm · North + East')).toBeOnTheScreen();
+    });
+
+    it('replaces the next-run section with the skip message when skipping.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByText('Skipped tonight. Re-evaluating tomorrow morning.')).toBeOnTheScreen();
+        expect(screen.queryByText('4h 32m')).toBeNull();
+    });
+
+    it('shows the skip-tonight banner only when skipping.', () => {
+        const { rerender } = render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.queryByLabelText('Tonight skipped')).toBeNull();
+
+        rerender(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByLabelText('Tonight skipped')).toBeOnTheScreen();
+    });
+
+    it('renders all four rule rows with the schedule values.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByLabelText('Time window: 22:00 → 06:00')).toBeOnTheScreen();
+        expect(screen.getByLabelText('End by sunrise: On')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Root depth override: 0.18 m')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Depletion fraction: 0.50')).toBeOnTheScreen();
+    });
+
+    it('renders em-dashes and `Off`/`Any time` for the null-rule fallbacks.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={NULL_RULES_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByLabelText('Time window: Any time')).toBeOnTheScreen();
+        expect(screen.getByLabelText('End by sunrise: Off')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Root depth override: —')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Depletion fraction: —')).toBeOnTheScreen();
+    });
+
+    it('flips the footer button label between Skip tonight and Resume tonight.', () => {
+        const { rerender } = render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByText('Skip tonight')).toBeOnTheScreen();
+        expect(screen.queryByText('Resume tonight')).toBeNull();
+
+        rerender(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByText('Resume tonight')).toBeOnTheScreen();
+        expect(screen.queryByText('Skip tonight')).toBeNull();
+    });
+
+    it('fires `onReplan` when the re-plan icon button is pressed.', () => {
+        const onReplan = jest.fn();
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={onReplan}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('Re-plan now'));
+
+        expect(onReplan).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires `onSwitchProfile` when the Switch profile button is pressed.', () => {
+        const onSwitchProfile = jest.fn();
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={onSwitchProfile}
+                onToggleSkip={noop}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Switch profile'));
+
+        expect(onSwitchProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires `onToggleSkip` when the Skip tonight button is pressed.', () => {
+        const onToggleSkip = jest.fn();
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={onToggleSkip}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Skip tonight'));
+
+        expect(onToggleSkip).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the re-plan button while `isReplanning` is true.', () => {
+        const onReplan = jest.fn();
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                isReplanning
+                onReplan={onReplan}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('Re-plan now'));
+
+        expect(onReplan).not.toHaveBeenCalled();
+    });
+});

--- a/app/components/active-schedule-hero/index.tsx
+++ b/app/components/active-schedule-hero/index.tsx
@@ -1,0 +1,321 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Button } from '@/components/button';
+import { DayStrip } from '@/components/day-strip';
+import { Refresh } from '@/components/icons';
+import { FontFamily } from '@/constants/fonts';
+import { daysArrayFromAllowed, formatDaysCsv, formatTimeWindow } from '@/lib/schedule-format';
+import type { ScheduleListItem } from '@/api/types/schedules';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the active schedule hero card.
+ */
+export type ActiveScheduleHeroProps = {
+    /** Required. The active schedule to display. */
+    schedule: ScheduleListItem;
+
+    /** Required. Whether tonight is currently skipped (drives the banner + footer label). */
+    skipping: boolean;
+
+    /** Optional. Re-plan button disabled state. Defaults to `false`. */
+    isReplanning?: boolean;
+
+    /** Required. Fires when the re-plan icon is pressed. */
+    onReplan: () => void;
+
+    /** Required. Fires when the "Switch profile" footer button is pressed. */
+    onSwitchProfile: () => void;
+
+    /** Required. Fires when the skip/resume footer button is pressed. */
+    onToggleSkip: () => void;
+};
+
+/**
+ * Hero card for the active irrigation profile on the Schedules screen.
+ * Shows the running indicator, name + day/window summary, the week-at-a-
+ * glance DayStrip, an optional skip-tonight banner, the next-run section,
+ * a rules block, and the two footer action buttons (switch profile + skip
+ * tonight). RN port of `ActiveScheduleHero` from `Mobile.jsx`.
+ */
+export function ActiveScheduleHero({
+    schedule,
+    skipping,
+    isReplanning = false,
+    onReplan,
+    onSwitchProfile,
+    onToggleSkip,
+}: ActiveScheduleHeroProps) {
+    const daysArray = daysArrayFromAllowed(schedule.allowedDays);
+    const daysCsv = formatDaysCsv(schedule.allowedDays);
+    const window = formatTimeWindow(schedule.allowedTimeWindows);
+    const summary = `${daysCsv} · ${window}`;
+
+    const rootOverride = schedule.rootDepthMOverride;
+    const depletion = schedule.allowableDepletionFractionOverride;
+    const endBySunrise = schedule.endBySunrise === true;
+
+    return (
+        <View style={styles.card}>
+            <View style={styles.headerRow}>
+                <View style={styles.runningPill}>
+                    <View style={styles.runningDot} />
+                    <Text style={styles.runningLabel}>Running</Text>
+                </View>
+
+                <Button
+                    variant='ghost'
+                    size='sm'
+                    iconOnly
+                    onPress={onReplan}
+                    disabled={isReplanning}
+                    accessibilityLabel='Re-plan now'
+                >
+                    <Refresh size={14} color={colors['fg-soft']} />
+                </Button>
+            </View>
+
+            <View>
+                <Text style={styles.name}>{schedule.name}</Text>
+                <Text style={styles.summary}>{summary}</Text>
+            </View>
+
+            <DayStrip days={daysArray} />
+
+            {skipping ? (
+                <View accessibilityLabel='Tonight skipped' style={styles.skipBanner}>
+                    <View style={styles.skipDot} />
+                    <Text style={styles.skipText}>Tonight skipped</Text>
+                </View>
+            ) : null}
+
+            <View style={styles.section}>
+                <Text style={styles.eyebrow}>Next run</Text>
+                {skipping ? (
+                    <Text style={styles.skipBody}>Skipped tonight. Re-evaluating tomorrow morning.</Text>
+                ) : (
+                    <View>
+                        <View style={styles.nextRunRow}>
+                            <Text style={styles.nextRunBig}>{schedule.nextRun?.inLabel ?? '—'}</Text>
+                            <Text style={styles.nextRunFromNow}>from now</Text>
+                        </View>
+                        <Text style={styles.nextRunSub}>
+                            {schedule.nextRun
+                                ? `${schedule.nextRun.whenLabel} · ${schedule.nextRun.zonesLabel}`
+                                : 'No upcoming cycles.'}
+                        </Text>
+                    </View>
+                )}
+            </View>
+
+            <View>
+                <Text style={[styles.eyebrow, { marginBottom: 8 }]}>Rules</Text>
+                <RuleRow label='Time window' value={window} />
+                <RuleRow label='End by sunrise' value={endBySunrise ? 'On' : 'Off'} good={endBySunrise} />
+                <RuleRow
+                    label='Root depth override'
+                    value={rootOverride !== null ? `${rootOverride.toFixed(2)} m` : '—'}
+                    dim={rootOverride === null}
+                />
+                <RuleRow
+                    label='Depletion fraction'
+                    value={depletion !== null ? depletion.toFixed(2) : '—'}
+                    dim={depletion === null}
+                    last
+                />
+            </View>
+
+            <View style={styles.actions}>
+                <View style={styles.actionSlot}>
+                    <Button variant='primary' onPress={onSwitchProfile}>Switch profile</Button>
+                </View>
+                <View style={styles.actionSlot}>
+                    <Button variant='secondary' onPress={onToggleSkip}>
+                        {skipping ? 'Resume tonight' : 'Skip tonight'}
+                    </Button>
+                </View>
+            </View>
+        </View>
+    );
+}
+
+function RuleRow({
+    label,
+    value,
+    good = false,
+    dim = false,
+    last = false,
+}: {
+    label: string;
+    value: string;
+    good?: boolean;
+    dim?: boolean;
+    last?: boolean;
+}) {
+    const valueColor = good ? colors.accent : dim ? colors['fg-dim'] : colors.fg;
+    return (
+        <View style={[styles.ruleRow, last ? null : styles.ruleRowDivider]} accessibilityLabel={`${label}: ${value}`}>
+            <Text style={styles.ruleLabel}>{label}</Text>
+            <Text style={[styles.ruleValue, { color: valueColor }]}>{value}</Text>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    card: {
+        backgroundColor: colors.elevated,
+        borderWidth: 1,
+        borderColor: colors['accent-border'],
+        borderRadius: 4,
+        padding: 18,
+        gap: 16,
+        boxShadow: `0 0 0 1px ${colors['accent-glow']} inset, 0 0 28px -4px ${colors['accent-glow']}`,
+    },
+    headerRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    runningPill: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        paddingVertical: 4,
+        paddingHorizontal: 10,
+        backgroundColor: colors['accent-tint'],
+        borderWidth: 1,
+        borderColor: colors['accent-border'],
+        borderRadius: 4,
+    },
+    runningDot: {
+        width: 7,
+        height: 7,
+        borderRadius: 4,
+        backgroundColor: colors.accent,
+        boxShadow: `0 0 10px ${colors.accent}`,
+    },
+    runningLabel: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 11,
+        lineHeight: 11,
+        letterSpacing: 1.32,
+        color: colors.accent,
+        textTransform: 'uppercase',
+    },
+    name: {
+        fontFamily: FontFamily.displayBold,
+        fontSize: 30,
+        lineHeight: 30,
+        letterSpacing: -0.75,
+        color: colors.fg,
+    },
+    summary: {
+        marginTop: 6,
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 16,
+        color: colors['fg-muted'],
+    },
+    skipBanner: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+        backgroundColor: colors['warn-tint'],
+        borderWidth: 1,
+        borderColor: colors['warn-border'],
+        borderRadius: 4,
+    },
+    skipDot: {
+        width: 8,
+        height: 8,
+        borderRadius: 4,
+        backgroundColor: colors.warn,
+    },
+    skipText: {
+        flex: 1,
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 13,
+        lineHeight: 16,
+        color: colors.fg,
+    },
+    section: {
+        paddingTop: 10,
+        borderTopWidth: 1,
+        borderTopColor: colors.hairline,
+    },
+    eyebrow: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        letterSpacing: 1.54,
+        color: colors['fg-muted'],
+        textTransform: 'uppercase',
+    },
+    nextRunRow: {
+        marginTop: 8,
+        flexDirection: 'row',
+        alignItems: 'baseline',
+        gap: 8,
+        flexWrap: 'wrap',
+    },
+    nextRunBig: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 36,
+        lineHeight: 36,
+        letterSpacing: -1.08,
+        color: colors.accent,
+    },
+    nextRunFromNow: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        color: colors['fg-muted'],
+    },
+    nextRunSub: {
+        marginTop: 6,
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        color: colors['fg-dim'],
+    },
+    skipBody: {
+        marginTop: 8,
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 16,
+        color: colors['fg-muted'],
+    },
+    ruleRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        gap: 16,
+        paddingVertical: 10,
+    },
+    ruleRowDivider: {
+        borderBottomWidth: 1,
+        borderBottomColor: colors.hairline,
+    },
+    ruleLabel: {
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 16,
+        color: colors['fg-muted'],
+    },
+    ruleValue: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 14,
+        lineHeight: 16,
+    },
+    actions: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    actionSlot: {
+        flex: 1,
+    },
+});

--- a/app/components/active-schedule-hero/index.tsx
+++ b/app/components/active-schedule-hero/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { Button } from '@/components/button';
@@ -48,10 +49,10 @@ export function ActiveScheduleHero({
     onSwitchProfile,
     onToggleSkip,
 }: ActiveScheduleHeroProps) {
-    const daysArray = daysArrayFromAllowed(schedule.allowedDays);
-    const daysCsv = formatDaysCsv(schedule.allowedDays);
-    const window = formatTimeWindow(schedule.allowedTimeWindows);
-    const summary = `${daysCsv} · ${window}`;
+    const daysArray = useMemo(() => daysArrayFromAllowed(schedule.allowedDays), [schedule.allowedDays]);
+    const daysCsv = useMemo(() => formatDaysCsv(schedule.allowedDays), [schedule.allowedDays]);
+    const window = useMemo(() => formatTimeWindow(schedule.allowedTimeWindows), [schedule.allowedTimeWindows]);
+    const summary = useMemo(() => `${daysCsv} · ${window}`, [daysCsv, window]);
 
     const rootOverride = schedule.rootDepthMOverride;
     const depletion = schedule.allowableDepletionFractionOverride;

--- a/app/components/day-dots/.test.tsx
+++ b/app/components/day-dots/.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { DayDots } from '.';
+
+type FlatStyle = {
+    width?: number;
+    height?: number;
+    backgroundColor?: string;
+};
+
+const ALL_ON: ReadonlyArray<boolean> = [true, true, true, true, true, true, true];
+const MWF_ONLY: ReadonlyArray<boolean> = [true, false, true, false, true, false, false];
+
+function findDots(root: ReturnType<typeof render>['root']) {
+    return root.findAll(node => {
+        if (typeof node.type !== 'string') return false;
+        if (node.type !== 'View') return false;
+        const flat = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as FlatStyle;
+        return flat.width !== undefined && flat.width === flat.height && flat.width <= 12;
+    });
+}
+
+describe('DayDots', () => {
+    it('renders 7 dots, one per day.', () => {
+        const { root } = render(<DayDots days={ALL_ON} />);
+
+        expect(findDots(root)).toHaveLength(7);
+    });
+
+    it('paints active days with the accent fill and inactive days with the ink-500 fill.', () => {
+        const { root } = render(<DayDots days={MWF_ONLY} />);
+
+        const dots = findDots(root);
+        const fills = dots.map(node => {
+            const flat = StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as FlatStyle;
+            return flat.backgroundColor;
+        });
+
+        // Mon, Wed, Fri → accent; rest → ink-500.
+        expect(fills[0]).toBe('#6FE39B');
+        expect(fills[1]).toBe('#232E29');
+        expect(fills[2]).toBe('#6FE39B');
+        expect(fills[3]).toBe('#232E29');
+        expect(fills[4]).toBe('#6FE39B');
+        expect(fills[5]).toBe('#232E29');
+        expect(fills[6]).toBe('#232E29');
+    });
+
+    it('respects a custom size override.', () => {
+        const { root } = render(<DayDots days={ALL_ON} size={10} />);
+
+        const dots = findDots(root);
+        for (const dot of dots) {
+            const flat = StyleSheet.flatten(dot.props.style as Parameters<typeof StyleSheet.flatten>[0]) as FlatStyle;
+            expect(flat.width).toBe(10);
+            expect(flat.height).toBe(10);
+        }
+    });
+
+    it('respects a custom gap override on the outer row.', () => {
+        const { root } = render(<DayDots days={ALL_ON} gap={8} />);
+
+        // The root View carries the row layout and the `gap` token.
+        const flat = StyleSheet.flatten(root.props.style as Parameters<typeof StyleSheet.flatten>[0]) as { gap?: number };
+        expect(flat.gap).toBe(8);
+    });
+});

--- a/app/components/day-dots/.test.tsx
+++ b/app/components/day-dots/.test.tsx
@@ -10,7 +10,8 @@ type FlatStyle = {
 };
 
 const ALL_ON: ReadonlyArray<boolean> = [true, true, true, true, true, true, true];
-const MWF_ONLY: ReadonlyArray<boolean> = [true, false, true, false, true, false, false];
+// Sun-first encoding: Mon, Wed, Fri = [Sun=F, Mon=T, Tue=F, Wed=T, Thu=F, Fri=T, Sat=F].
+const MWF_ONLY: ReadonlyArray<boolean> = [false, true, false, true, false, true, false];
 
 function findDots(root: ReturnType<typeof render>['root']) {
     return root.findAll(node => {
@@ -37,13 +38,13 @@ describe('DayDots', () => {
             return flat.backgroundColor;
         });
 
-        // Mon, Wed, Fri → accent; rest → ink-500.
-        expect(fills[0]).toBe('#6FE39B');
-        expect(fills[1]).toBe('#232E29');
-        expect(fills[2]).toBe('#6FE39B');
-        expect(fills[3]).toBe('#232E29');
-        expect(fills[4]).toBe('#6FE39B');
-        expect(fills[5]).toBe('#232E29');
+        // Sun-first: Sun=off, Mon=on, Tue=off, Wed=on, Thu=off, Fri=on, Sat=off.
+        expect(fills[0]).toBe('#232E29');
+        expect(fills[1]).toBe('#6FE39B');
+        expect(fills[2]).toBe('#232E29');
+        expect(fills[3]).toBe('#6FE39B');
+        expect(fills[4]).toBe('#232E29');
+        expect(fills[5]).toBe('#6FE39B');
         expect(fills[6]).toBe('#232E29');
     });
 

--- a/app/components/day-dots/index.tsx
+++ b/app/components/day-dots/index.tsx
@@ -1,0 +1,56 @@
+import { StyleSheet, View } from 'react-native';
+
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the compact 7-dot day preview.
+ */
+export type DayDotsProps = {
+    /** Required. Booleans for Mon-Sun (index 0 = Mon). */
+    days: ReadonlyArray<boolean>;
+
+    /** Optional. Side length of each square dot in pixels. Defaults to 6. */
+    size?: number;
+
+    /** Optional. Gap between dots in pixels. Defaults to 3. */
+    gap?: number;
+};
+
+/**
+ * Minimal seven-dot day preview used in the "other profiles" rows. Accent
+ * fill for active days, dimmed `ink-500` for inactive ones. RN port of
+ * `DayDots` from the design source's `Mobile.jsx`.
+ */
+export function DayDots({ days, size = 6, gap = 3 }: DayDotsProps) {
+    return (
+        <View style={{ flexDirection: 'row', gap }}>
+            {days.map((on, index) => (
+                <View
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    style={[
+                        styles.dot,
+                        { width: size, height: size },
+                        on ? styles.dotOn : styles.dotOff,
+                    ]}
+                />
+            ))}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    dot: {
+        // Square corners on purpose — the design uses a 1px square pip, not
+        // a circle.
+    },
+    dotOn: {
+        backgroundColor: colors.accent,
+    },
+    dotOff: {
+        backgroundColor: colors['ink-500'],
+        opacity: 0.6,
+    },
+});

--- a/app/components/day-strip/.test.tsx
+++ b/app/components/day-strip/.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import { DayStrip } from '.';
+
+type FlatStyle = {
+    backgroundColor?: string;
+    borderColor?: string;
+    color?: string;
+    boxShadow?: string;
+};
+
+const ALL_ON: ReadonlyArray<boolean> = [true, true, true, true, true, true, true];
+const ALL_OFF: ReadonlyArray<boolean> = [false, false, false, false, false, false, false];
+const MWF_ONLY: ReadonlyArray<boolean> = [true, false, true, false, true, false, false];
+
+describe('DayStrip', () => {
+    it('renders one cell per day with the Mon-first label sequence.', () => {
+        render(<DayStrip days={ALL_OFF} />);
+
+        // 7 cells, labels in Mon-Sun order: M, T, W, T, F, S, S.
+        expect(screen.getByLabelText('Monday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Tuesday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Wednesday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Thursday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Friday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Saturday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Sunday: inactive')).toBeOnTheScreen();
+    });
+
+    it('marks each active day with an `active` accessibility state.', () => {
+        render(<DayStrip days={MWF_ONLY} />);
+
+        expect(screen.getByLabelText('Monday: active')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Tuesday: inactive')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Wednesday: active')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Friday: active')).toBeOnTheScreen();
+    });
+
+    it('paints active cells with the accent palette and inactive cells with the surface palette.', () => {
+        render(<DayStrip days={MWF_ONLY} />);
+
+        const monStyle = StyleSheet.flatten(screen.getByLabelText('Monday: active').props.style) as FlatStyle;
+        const tueStyle = StyleSheet.flatten(screen.getByLabelText('Tuesday: inactive').props.style) as FlatStyle;
+
+        expect(monStyle.backgroundColor).toBe('rgba(111, 227, 155, 0.06)');
+        expect(monStyle.borderColor).toBe('rgba(111, 227, 155, 0.4)');
+        expect(tueStyle.backgroundColor).toBe('#0E1412');
+        expect(tueStyle.borderColor).toBe('#232E29');
+    });
+
+    it('renders the day letters in the source order M T W T F S S.', () => {
+        render(<DayStrip days={ALL_ON} />);
+
+        // All 7 letters render. The middle T (Thursday) and second S (Sunday)
+        // overlap text-content-wise with their earlier siblings — query by
+        // accessibility label instead and inspect the rendered Text via the
+        // host tree.
+        const labels = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+        for (const name of labels) {
+            expect(screen.getByLabelText(`${name}: active`)).toBeOnTheScreen();
+        }
+    });
+});

--- a/app/components/day-strip/.test.tsx
+++ b/app/components/day-strip/.test.tsx
@@ -12,25 +12,27 @@ type FlatStyle = {
 
 const ALL_ON: ReadonlyArray<boolean> = [true, true, true, true, true, true, true];
 const ALL_OFF: ReadonlyArray<boolean> = [false, false, false, false, false, false, false];
-const MWF_ONLY: ReadonlyArray<boolean> = [true, false, true, false, true, false, false];
+// Sun-first encoding: Mon, Wed, Fri = [Sun=F, Mon=T, Tue=F, Wed=T, Thu=F, Fri=T, Sat=F].
+const MWF_ONLY: ReadonlyArray<boolean> = [false, true, false, true, false, true, false];
 
 describe('DayStrip', () => {
-    it('renders one cell per day with the Mon-first label sequence.', () => {
+    it('renders one cell per day with the Sun-first label sequence.', () => {
         render(<DayStrip days={ALL_OFF} />);
 
-        // 7 cells, labels in Mon-Sun order: M, T, W, T, F, S, S.
+        // 7 cells, labels in Sun-Sat order: S, M, T, W, T, F, S.
+        expect(screen.getByLabelText('Sunday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Monday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Tuesday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Wednesday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Thursday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Friday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Saturday: inactive')).toBeOnTheScreen();
-        expect(screen.getByLabelText('Sunday: inactive')).toBeOnTheScreen();
     });
 
     it('marks each active day with an `active` accessibility state.', () => {
         render(<DayStrip days={MWF_ONLY} />);
 
+        expect(screen.getByLabelText('Sunday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Monday: active')).toBeOnTheScreen();
         expect(screen.getByLabelText('Tuesday: inactive')).toBeOnTheScreen();
         expect(screen.getByLabelText('Wednesday: active')).toBeOnTheScreen();
@@ -49,14 +51,12 @@ describe('DayStrip', () => {
         expect(tueStyle.borderColor).toBe('#232E29');
     });
 
-    it('renders the day letters in the source order M T W T F S S.', () => {
+    it('renders the day letters in the source order S M T W T F S.', () => {
         render(<DayStrip days={ALL_ON} />);
 
-        // All 7 letters render. The middle T (Thursday) and second S (Sunday)
-        // overlap text-content-wise with their earlier siblings — query by
-        // accessibility label instead and inspect the rendered Text via the
-        // host tree.
-        const labels = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+        // All 7 letters render. T (Tue + Thu) and S (Sun + Sat) overlap by
+        // text content — query by accessibility label.
+        const labels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
         for (const name of labels) {
             expect(screen.getByLabelText(`${name}: active`)).toBeOnTheScreen();
         }

--- a/app/components/day-strip/index.tsx
+++ b/app/components/day-strip/index.tsx
@@ -1,0 +1,103 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * 7-letter day label sequence anchored to Monday (`days[0]`). Matches the
+ * Mon-first convention the API's `allowedDays` field uses.
+ */
+const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'] as const;
+
+/**
+ * Props for the full-width 7-day strip.
+ */
+export type DayStripProps = {
+    /** Required. Booleans for Mon-Sun (index 0 = Mon). Length must be 7. */
+    days: ReadonlyArray<boolean>;
+};
+
+/**
+ * Week-at-a-glance strip used in the active-schedule hero. Each cell is a
+ * 40px-tall card with a day-letter, a tiny status dot, and accent chrome
+ * for active days. RN port of `DayStrip` from the design source's
+ * `Mobile.jsx`.
+ */
+export function DayStrip({ days }: DayStripProps) {
+    return (
+        <View style={styles.row}>
+            {DAY_LABELS.map((label, index) => {
+                const on = days[index] === true;
+                return (
+                    <View
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={index}
+                        style={[
+                            styles.cell,
+                            on ? styles.cellOn : styles.cellOff,
+                        ]}
+                        accessibilityLabel={`${dayName(index)}: ${on ? 'active' : 'inactive'}`}
+                    >
+                        <Text style={[styles.label, { color: on ? colors.accent : colors['fg-dim'] }]}>
+                            {label}
+                        </Text>
+                        <View
+                            style={[
+                                styles.dot,
+                                on ? styles.dotOn : styles.dotOff,
+                            ]}
+                        />
+                    </View>
+                );
+            })}
+        </View>
+    );
+}
+
+function dayName(index: number): string {
+    const names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+    return names[index] ?? 'Day';
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        gap: 6,
+    },
+    cell: {
+        flex: 1,
+        height: 40,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 5,
+        borderWidth: 1,
+        borderRadius: 4,
+    },
+    cellOn: {
+        backgroundColor: colors['accent-tint'],
+        borderColor: colors['accent-border'],
+    },
+    cellOff: {
+        backgroundColor: colors.surface,
+        borderColor: colors.border,
+    },
+    label: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 11,
+    },
+    dot: {
+        width: 4,
+        height: 4,
+        borderRadius: 2,
+    },
+    dotOn: {
+        backgroundColor: colors.accent,
+        boxShadow: `0 0 6px ${colors.accent}`,
+    },
+    dotOff: {
+        backgroundColor: colors['ink-500'],
+    },
+});

--- a/app/components/day-strip/index.tsx
+++ b/app/components/day-strip/index.tsx
@@ -6,16 +6,17 @@ import config from '@/tailwind.config';
 const colors = config.theme.extend.colors;
 
 /**
- * 7-letter day label sequence anchored to Monday (`days[0]`). Matches the
- * Mon-first convention the API's `allowedDays` field uses.
+ * 7-letter day label sequence anchored to Sunday (`days[0]`). The app uses
+ * a Sun-first display convention; `daysArrayFromAllowed` in `lib/schedule-
+ * format` is the canonical translator from the API's ISO-weekday encoding.
  */
-const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'] as const;
+const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const;
 
 /**
  * Props for the full-width 7-day strip.
  */
 export type DayStripProps = {
-    /** Required. Booleans for Mon-Sun (index 0 = Mon). Length must be 7. */
+    /** Required. Booleans for Sun-Sat (index 0 = Sun). Length must be 7. */
     days: ReadonlyArray<boolean>;
 };
 
@@ -57,7 +58,7 @@ export function DayStrip({ days }: DayStripProps) {
 }
 
 function dayName(index: number): string {
-    const names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+    const names = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     return names[index] ?? 'Day';
 }
 

--- a/app/components/schedule-list-view/.test.tsx
+++ b/app/components/schedule-list-view/.test.tsx
@@ -1,0 +1,225 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import type { ReactTestInstance } from 'react-test-renderer';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import type { ScheduleListItem } from '@/api/types/schedules';
+
+import { ScheduleListView } from '.';
+
+const mockFetch = jest.fn();
+
+const ACTIVE_SCHEDULE: ScheduleListItem = {
+    id: 'sched-active',
+    slug: 'maintenance',
+    name: 'Maintenance',
+    isActive: true,
+    allowedDays: [1, 3, 5],
+    allowedTimeWindows: [{ start: '22:00', end: '06:00' }],
+    rootDepthMOverride: 0.18,
+    allowableDepletionFractionOverride: 0.5,
+    endBySunrise: true,
+    nextRun: { inLabel: '4h 32m', whenLabel: 'tonight at 10:23pm', zonesLabel: 'North + East' },
+    skippedTonight: false,
+};
+
+const WEEKEND_SCHEDULE: ScheduleListItem = {
+    id: 'sched-weekend',
+    slug: 'weekend',
+    name: 'Weekend',
+    isActive: false,
+    allowedDays: [6, 7],
+    allowedTimeWindows: [{ start: '20:00', end: '04:00' }],
+    rootDepthMOverride: null,
+    allowableDepletionFractionOverride: null,
+    endBySunrise: null,
+};
+
+const OVERSEEDING_SCHEDULE: ScheduleListItem = {
+    id: 'sched-overseed',
+    slug: 'overseeding',
+    name: 'Overseeding',
+    isActive: false,
+    allowedDays: null,
+    allowedTimeWindows: null,
+    rootDepthMOverride: 0.08,
+    allowableDepletionFractionOverride: 0.3,
+    endBySunrise: false,
+};
+
+const ALL_SCHEDULES = [ACTIVE_SCHEDULE, WEEKEND_SCHEDULE, OVERSEEDING_SCHEDULE];
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('ScheduleListView', () => {
+    it('renders the loading state while the schedules query is pending.', () => {
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        expect(screen.getByText('Profile · loading')).toBeOnTheScreen();
+        expect(screen.getByText('Fetching schedules…')).toBeOnTheScreen();
+    });
+
+    it('renders the error state when the schedules query fails.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Failed to load schedules.')).toBeOnTheScreen());
+        expect(screen.getByText('Profile · unavailable')).toBeOnTheScreen();
+    });
+
+    it('renders the active schedule in the hero and the rest as rows.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+        expect(screen.getByText('Profile · 1 active')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Switch to Weekend')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Switch to Overseeding')).toBeOnTheScreen();
+    });
+
+    it('opens the switch modal when a non-active row is pressed.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+
+        fireEvent.press(screen.getByLabelText('Switch to Weekend'));
+
+        await waitFor(() => expect(screen.getByText('Switch to Weekend?')).toBeOnTheScreen());
+    });
+
+    it('closes the modal on cancel without calling the enable endpoint.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+
+        fireEvent.press(screen.getByLabelText('Switch to Weekend'));
+        await waitFor(() => expect(screen.getByText('Switch to Weekend?')).toBeOnTheScreen());
+
+        fireEvent.press(screen.getByText('Cancel'));
+
+        await waitFor(() => expect(screen.queryByText('Switch to Weekend?')).toBeNull());
+
+        // Only the initial GET was called — no POST.
+        const postCalls = mockFetch.mock.calls.filter(call => {
+            const [, init] = call as [string, RequestInit];
+            return init.method === 'POST';
+        });
+        expect(postCalls).toHaveLength(0);
+    });
+
+    it('POSTs /schedule/{slug}/enable when the modal Switch & re-plan button is pressed.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ status: 'enabled', schedule: { slug: 'weekend', name: 'Weekend', siteId: 'site-1' } }));
+        // Refetch after invalidation.
+        mockFetch.mockResolvedValue(jsonResponse(ALL_SCHEDULES));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+
+        fireEvent.press(screen.getByLabelText('Switch to Weekend'));
+        await waitFor(() => expect(screen.getByText('Switch to Weekend?')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByText('Switch & re-plan'));
+        });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
+            expect(urls).toContain('http://test.local:9753/schedule/enable/weekend');
+        });
+    });
+
+    it('POSTs /schedule/skip-tonight when the Skip tonight button is pressed.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ status: 'skipped', schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-1' } }));
+        mockFetch.mockResolvedValue(jsonResponse(ALL_SCHEDULES));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByText('Skip tonight'));
+        });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
+            expect(urls).toContain('http://test.local:9753/schedule/skip-tonight');
+        });
+    });
+
+    it('POSTs /schedule/resume-tonight when Resume tonight is pressed (active schedule already skipping).', async () => {
+        const skippingActive = { ...ACTIVE_SCHEDULE, skippedTonight: true };
+        mockFetch.mockResolvedValueOnce(jsonResponse([skippingActive, WEEKEND_SCHEDULE, OVERSEEDING_SCHEDULE]));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ status: 'resumed', schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-1' } }));
+        mockFetch.mockResolvedValue(jsonResponse([skippingActive, WEEKEND_SCHEDULE, OVERSEEDING_SCHEDULE]));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Resume tonight')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByText('Resume tonight'));
+        });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
+            expect(urls).toContain('http://test.local:9753/schedule/resume-tonight');
+        });
+    });
+
+    it('POSTs /replan when the re-plan icon button is pressed.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+        mockFetch.mockResolvedValue(jsonResponse(ALL_SCHEDULES));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Re-plan now'));
+        });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
+            expect(urls).toContain('http://test.local:9753/replan');
+        });
+    });
+
+    it('handles an empty schedule list without crashing — no hero, no rows, eyebrow flips to none active.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Profile · none active')).toBeOnTheScreen());
+        expect(screen.queryByText('Maintenance')).toBeNull();
+        expect(screen.getByText('Other profiles')).toBeOnTheScreen();
+    });
+
+    it('renders the disabled "+ New" stub button.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
+
+        const { root } = render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Other profiles')).toBeOnTheScreen());
+        const newButton = findByAccessibilityLabel(root, 'Add new profile');
+        expect(newButton?.props.accessibilityState).toEqual({ disabled: true });
+    });
+});
+
+function findByAccessibilityLabel(root: ReactTestInstance, label: string): ReactTestInstance | undefined {
+    return root.find(node => typeof node.type === 'string' && node.props.accessibilityLabel === label);
+}

--- a/app/components/schedule-list-view/index.tsx
+++ b/app/components/schedule-list-view/index.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { ActiveScheduleHero } from '@/components/active-schedule-hero';
+import { Button } from '@/components/button';
+import { ScheduleRow } from '@/components/schedule-row';
+import { SwitchScheduleModal } from '@/components/switch-schedule-modal';
+import { FontFamily } from '@/constants/fonts';
+import {
+    useEnableSchedule,
+    useResumeScheduleTonight,
+    useSchedules,
+    useSkipScheduleTonight,
+} from '@/hooks/schedules';
+import { useReplan } from '@/hooks/replan';
+import type { ScheduleListItem } from '@/api/types/schedules';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Smart container for the Schedules screen. Calls the schedules / replan
+ * hooks, partitions the result into active + others, and composes the
+ * hero, switch rows, and the switch-confirmation modal. Drop-in for any
+ * screen route — caller wraps it in their own scroll container.
+ */
+export function ScheduleListView() {
+    const schedules = useSchedules();
+    const enableSchedule = useEnableSchedule();
+    const skipTonight = useSkipScheduleTonight();
+    const resumeTonight = useResumeScheduleTonight();
+    const replan = useReplan();
+    const [pendingSwitch, setPendingSwitch] = useState<ScheduleListItem | null>(null);
+
+    if (schedules.isPending) {
+        return (
+            <View style={styles.container}>
+                <Text style={styles.eyebrow}>Profile · loading</Text>
+                <Text style={styles.title}>Schedules</Text>
+                <Text style={styles.placeholder}>Fetching schedules…</Text>
+            </View>
+        );
+    }
+
+    if (schedules.isError || schedules.data === undefined) {
+        return (
+            <View style={styles.container}>
+                <Text style={styles.eyebrow}>Profile · unavailable</Text>
+                <Text style={styles.title}>Schedules</Text>
+                <Text style={styles.errorText}>Failed to load schedules.</Text>
+            </View>
+        );
+    }
+
+    const active = schedules.data.find(item => item.isActive) ?? schedules.data[0];
+    const others = active === undefined
+        ? []
+        : schedules.data.filter(item => item.id !== active.id);
+    const skipping = active?.skippedTonight === true;
+
+    const handleConfirmSwitch = (): void => {
+        if (pendingSwitch === null) return;
+        const targetSlug = pendingSwitch.slug;
+        enableSchedule.mutate(targetSlug, {
+            onSuccess: () => setPendingSwitch(null),
+        });
+    };
+
+    const handleToggleSkip = (): void => {
+        if (skipping) resumeTonight.mutate();
+        else skipTonight.mutate();
+    };
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.eyebrow}>Profile · {active ? '1 active' : 'none active'}</Text>
+            <Text style={styles.title}>Schedules</Text>
+
+            {active && (
+                <ActiveScheduleHero
+                    schedule={active}
+                    skipping={skipping}
+                    isReplanning={replan.isPending}
+                    onReplan={() => replan.mutate()}
+                    onSwitchProfile={() => setPendingSwitch(active)}
+                    onToggleSkip={handleToggleSkip}
+                />
+            )}
+
+            <View style={styles.otherHeading}>
+                <Text style={styles.h2}>Other profiles</Text>
+                <Button variant='ghost' size='sm' disabled accessibilityLabel='Add new profile'>
+                    + New
+                </Button>
+            </View>
+
+            <View style={styles.otherList}>
+                {others.map(schedule => (
+                    <ScheduleRow
+                        key={schedule.id}
+                        schedule={schedule}
+                        onSwitch={setPendingSwitch}
+                    />
+                ))}
+            </View>
+
+            <SwitchScheduleModal
+                schedule={pendingSwitch}
+                onCancel={() => setPendingSwitch(null)}
+                onConfirm={handleConfirmSwitch}
+                isSubmitting={enableSchedule.isPending}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 18,
+        paddingHorizontal: 20,
+    },
+    eyebrow: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        letterSpacing: 1.54,
+        color: colors['fg-muted'],
+        textTransform: 'uppercase',
+    },
+    title: {
+        fontFamily: FontFamily.displayBold,
+        fontSize: 28,
+        lineHeight: 28,
+        letterSpacing: -0.7,
+        color: colors.fg,
+    },
+    placeholder: {
+        fontFamily: FontFamily.sans,
+        fontSize: 14,
+        lineHeight: 20,
+        color: colors['fg-muted'],
+    },
+    errorText: {
+        fontFamily: FontFamily.sans,
+        fontSize: 14,
+        lineHeight: 20,
+        color: colors.warn,
+    },
+    otherHeading: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginTop: 6,
+    },
+    h2: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 18,
+        lineHeight: 22,
+        letterSpacing: -0.09,
+        color: colors.fg,
+    },
+    otherList: {
+        gap: 8,
+    },
+});

--- a/app/components/schedule-row/.test.tsx
+++ b/app/components/schedule-row/.test.tsx
@@ -20,7 +20,8 @@ describe('ScheduleRow', () => {
         render(<ScheduleRow schedule={SAMPLE_SCHEDULE} onSwitch={() => {}} />);
 
         expect(screen.getByText('Weekend')).toBeOnTheScreen();
-        expect(screen.getByText('Sat · Sun · 20:00 → 04:00')).toBeOnTheScreen();
+        // `allowedDays: [6, 7]` (Sat, Sun) → Sun-first CSV order is `Sun · Sat`.
+        expect(screen.getByText('Sun · Sat · 20:00 → 04:00')).toBeOnTheScreen();
     });
 
     it('renders the Switch label and is queryable by its accessibility label.', () => {

--- a/app/components/schedule-row/.test.tsx
+++ b/app/components/schedule-row/.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { ScheduleRow } from '.';
+import type { ScheduleListItem } from '@/api/types/schedules';
+
+const SAMPLE_SCHEDULE: ScheduleListItem = {
+    id: 'sched-002',
+    slug: 'weekend',
+    name: 'Weekend',
+    isActive: false,
+    allowedDays: [6, 7],
+    allowedTimeWindows: [{ start: '20:00', end: '04:00' }],
+    rootDepthMOverride: null,
+    allowableDepletionFractionOverride: null,
+    endBySunrise: null,
+};
+
+describe('ScheduleRow', () => {
+    it('renders the schedule name and the days · window summary.', () => {
+        render(<ScheduleRow schedule={SAMPLE_SCHEDULE} onSwitch={() => {}} />);
+
+        expect(screen.getByText('Weekend')).toBeOnTheScreen();
+        expect(screen.getByText('Sat · Sun · 20:00 → 04:00')).toBeOnTheScreen();
+    });
+
+    it('renders the Switch label and is queryable by its accessibility label.', () => {
+        render(<ScheduleRow schedule={SAMPLE_SCHEDULE} onSwitch={() => {}} />);
+
+        expect(screen.getByText('Switch')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Switch to Weekend')).toBeOnTheScreen();
+    });
+
+    it('fires `onSwitch` with the schedule when pressed.', () => {
+        const onSwitch = jest.fn();
+        render(<ScheduleRow schedule={SAMPLE_SCHEDULE} onSwitch={onSwitch} />);
+
+        fireEvent.press(screen.getByLabelText('Switch to Weekend'));
+
+        expect(onSwitch).toHaveBeenCalledTimes(1);
+        expect(onSwitch).toHaveBeenCalledWith(SAMPLE_SCHEDULE);
+    });
+});

--- a/app/components/schedule-row/index.tsx
+++ b/app/components/schedule-row/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { DayDots } from '@/components/day-dots';
@@ -27,12 +28,16 @@ export type ScheduleRowProps = {
  * `ScheduleView` from `Mobile.jsx`.
  */
 export function ScheduleRow({ schedule, onSwitch }: ScheduleRowProps) {
-    const daysArray = daysArrayFromAllowed(schedule.allowedDays);
-    const summary = `${formatDaysCsv(schedule.allowedDays)} · ${formatTimeWindow(schedule.allowedTimeWindows)}`;
+    const daysArray = useMemo(() => daysArrayFromAllowed(schedule.allowedDays), [schedule.allowedDays]);
+    const summary = useMemo(
+        () => `${formatDaysCsv(schedule.allowedDays)} · ${formatTimeWindow(schedule.allowedTimeWindows)}`,
+        [schedule.allowedDays, schedule.allowedTimeWindows],
+    );
+    const handlePress = useCallback(() => onSwitch(schedule), [onSwitch, schedule]);
 
     return (
         <Pressable
-            onPress={() => onSwitch(schedule)}
+            onPress={handlePress}
             accessibilityRole='button'
             accessibilityLabel={`Switch to ${schedule.name}`}
             style={styles.row}

--- a/app/components/schedule-row/index.tsx
+++ b/app/components/schedule-row/index.tsx
@@ -1,0 +1,102 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { DayDots } from '@/components/day-dots';
+import { ChevR } from '@/components/icons';
+import { FontFamily } from '@/constants/fonts';
+import { daysArrayFromAllowed, formatDaysCsv, formatTimeWindow } from '@/lib/schedule-format';
+import type { ScheduleListItem } from '@/api/types/schedules';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the non-active schedule row.
+ */
+export type ScheduleRowProps = {
+    /** Required. The schedule to display. */
+    schedule: ScheduleListItem;
+
+    /** Required. Fires with the schedule when the row is pressed. */
+    onSwitch: (schedule: ScheduleListItem) => void;
+};
+
+/**
+ * One non-active schedule row on the Schedules screen — name + days/window
+ * summary on the left, DayDots preview + "Switch" chevron on the right.
+ * Tap → caller opens the confirmation modal. RN port of the row body in
+ * `ScheduleView` from `Mobile.jsx`.
+ */
+export function ScheduleRow({ schedule, onSwitch }: ScheduleRowProps) {
+    const daysArray = daysArrayFromAllowed(schedule.allowedDays);
+    const summary = `${formatDaysCsv(schedule.allowedDays)} · ${formatTimeWindow(schedule.allowedTimeWindows)}`;
+
+    return (
+        <Pressable
+            onPress={() => onSwitch(schedule)}
+            accessibilityRole='button'
+            accessibilityLabel={`Switch to ${schedule.name}`}
+            style={styles.row}
+        >
+            <View style={styles.body}>
+                <Text style={styles.name}>{schedule.name}</Text>
+                <Text style={styles.summary}>{summary}</Text>
+            </View>
+
+            <View style={styles.right}>
+                <DayDots days={daysArray} />
+                <View style={styles.switchSlot}>
+                    <Text style={styles.switchLabel}>Switch</Text>
+                    <ChevR size={12} color={colors['fg-soft']} />
+                </View>
+            </View>
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        paddingVertical: 14,
+        paddingHorizontal: 14,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 4,
+    },
+    body: {
+        flexShrink: 1,
+        minWidth: 0,
+    },
+    name: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 15,
+        lineHeight: 17,
+        color: colors.fg,
+    },
+    summary: {
+        marginTop: 4,
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        color: colors['fg-muted'],
+    },
+    right: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+    },
+    switchSlot: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 4,
+    },
+    switchLabel: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 12,
+        lineHeight: 12,
+        color: colors['fg-soft'],
+    },
+});

--- a/app/components/switch-schedule-modal/.test.tsx
+++ b/app/components/switch-schedule-modal/.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { SwitchScheduleModal } from '.';
+import type { ScheduleListItem } from '@/api/types/schedules';
+
+const SAMPLE_SCHEDULE: ScheduleListItem = {
+    id: 'sched-002',
+    slug: 'weekend',
+    name: 'Weekend',
+    isActive: false,
+    allowedDays: [6, 7],
+    allowedTimeWindows: null,
+    rootDepthMOverride: null,
+    allowableDepletionFractionOverride: null,
+    endBySunrise: null,
+};
+
+describe('SwitchScheduleModal', () => {
+    it('renders nothing when schedule is null.', () => {
+        render(
+            <SwitchScheduleModal
+                schedule={null}
+                onCancel={() => {}}
+                onConfirm={() => {}}
+            />,
+        );
+
+        expect(screen.queryByText(/Switch to/)).toBeNull();
+    });
+
+    it('renders the title and body when a schedule is supplied.', () => {
+        render(
+            <SwitchScheduleModal
+                schedule={SAMPLE_SCHEDULE}
+                onCancel={() => {}}
+                onConfirm={() => {}}
+            />,
+        );
+
+        expect(screen.getByText('Switch to Weekend?')).toBeOnTheScreen();
+        expect(
+            screen.getByText('Active schedule will be replaced. A re-plan will run immediately.'),
+        ).toBeOnTheScreen();
+    });
+
+    it('fires `onCancel` when the Cancel button is pressed.', () => {
+        const onCancel = jest.fn();
+        render(
+            <SwitchScheduleModal
+                schedule={SAMPLE_SCHEDULE}
+                onCancel={onCancel}
+                onConfirm={() => {}}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Cancel'));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires `onConfirm` when the Switch & re-plan button is pressed.', () => {
+        const onConfirm = jest.fn();
+        render(
+            <SwitchScheduleModal
+                schedule={SAMPLE_SCHEDULE}
+                onCancel={() => {}}
+                onConfirm={onConfirm}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Switch & re-plan'));
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the confirm button while submitting.', () => {
+        const onConfirm = jest.fn();
+        render(
+            <SwitchScheduleModal
+                schedule={SAMPLE_SCHEDULE}
+                onCancel={() => {}}
+                onConfirm={onConfirm}
+                isSubmitting
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Switch & re-plan'));
+
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+});

--- a/app/components/switch-schedule-modal/index.tsx
+++ b/app/components/switch-schedule-modal/index.tsx
@@ -1,0 +1,101 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Button } from '@/components/button';
+import { Modal } from '@/components/modal';
+import { FontFamily } from '@/constants/fonts';
+import type { ScheduleListItem } from '@/api/types/schedules';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the switch-schedule confirmation modal.
+ */
+export type SwitchScheduleModalProps = {
+    /** Required. The schedule to switch to. `null` keeps the modal hidden. */
+    schedule: ScheduleListItem | null;
+
+    /** Required. Fires when the user taps Cancel or the backdrop. */
+    onCancel: () => void;
+
+    /** Required. Fires when the user confirms the switch. */
+    onConfirm: () => void;
+
+    /** Optional. Disables the confirm button while the switch mutation is in flight. */
+    isSubmitting?: boolean;
+};
+
+/**
+ * Confirmation modal for switching the active irrigation profile. Wraps
+ * the generic Modal primitive with the switch-flow copy. The server
+ * always re-plans on schedule enable, so the action label is "Switch &
+ * re-plan" and the body explains the implication. RN port of `SwitchModal`
+ * from `Mobile.jsx`.
+ */
+export function SwitchScheduleModal({
+    schedule,
+    onCancel,
+    onConfirm,
+    isSubmitting = false,
+}: SwitchScheduleModalProps) {
+    const name = schedule?.name ?? '';
+
+    return (
+        <Modal
+            visible={schedule !== null}
+            onRequestClose={onCancel}
+            accessibilityLabel={schedule !== null ? `Switch to ${name}?` : undefined}
+        >
+            <View style={styles.header}>
+                <Text style={styles.title}>Switch to {name}?</Text>
+                <Text style={styles.sub}>Active schedule will be replaced. A re-plan will run immediately.</Text>
+            </View>
+
+            <View style={styles.footer}>
+                <View style={styles.footerSlot}>
+                    <Button variant='ghost' onPress={onCancel}>Cancel</Button>
+                </View>
+                <View style={styles.footerSlot}>
+                    <Button variant='primary' onPress={onConfirm} disabled={isSubmitting}>
+                        Switch & re-plan
+                    </Button>
+                </View>
+            </View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    header: {
+        paddingHorizontal: 22,
+        paddingTop: 20,
+        paddingBottom: 16,
+        gap: 4,
+    },
+    title: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 22,
+        lineHeight: 26,
+        letterSpacing: -0.22,
+        color: colors.fg,
+    },
+    sub: {
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+    footer: {
+        flexDirection: 'row',
+        gap: 8,
+        paddingHorizontal: 18,
+        paddingTop: 14,
+        paddingBottom: 18,
+        borderTopWidth: 1,
+        borderTopColor: colors.hairline,
+        marginTop: 6,
+    },
+    footerSlot: {
+        flex: 1,
+    },
+});

--- a/app/lib/schedule-format/.test.ts
+++ b/app/lib/schedule-format/.test.ts
@@ -1,0 +1,70 @@
+import {
+    daysArrayFromAllowed,
+    formatDaysCsv,
+    formatTimeWindow,
+} from '.';
+
+describe('daysArrayFromAllowed', () => {
+    it('returns 7 trues when allowedDays is null (no restriction).', () => {
+        expect(daysArrayFromAllowed(null)).toEqual([true, true, true, true, true, true, true]);
+    });
+
+    it('returns 7 falses when allowedDays is empty.', () => {
+        expect(daysArrayFromAllowed([])).toEqual([false, false, false, false, false, false, false]);
+    });
+
+    it('maps ISO weekday (1=Mon, 7=Sun) to the Mon-anchored boolean array.', () => {
+        // Mon, Wed, Fri.
+        expect(daysArrayFromAllowed([1, 3, 5])).toEqual([true, false, true, false, true, false, false]);
+        // Sat, Sun (weekend).
+        expect(daysArrayFromAllowed([6, 7])).toEqual([false, false, false, false, false, true, true]);
+    });
+
+    it('ignores out-of-range day numbers gracefully.', () => {
+        expect(daysArrayFromAllowed([0, 8, 99])).toEqual([false, false, false, false, false, false, false]);
+    });
+});
+
+describe('formatDaysCsv', () => {
+    it('returns Every day when allowedDays is null.', () => {
+        expect(formatDaysCsv(null)).toBe('Every day');
+    });
+
+    it('returns No days when allowedDays is empty.', () => {
+        expect(formatDaysCsv([])).toBe('No days');
+    });
+
+    it('joins three-letter day names with a middot.', () => {
+        expect(formatDaysCsv([1, 3, 5])).toBe('Mon · Wed · Fri');
+        expect(formatDaysCsv([6, 7])).toBe('Sat · Sun');
+    });
+
+    it('preserves caller-supplied order rather than sorting.', () => {
+        expect(formatDaysCsv([5, 1, 3])).toBe('Fri · Mon · Wed');
+    });
+
+    it('skips out-of-range day numbers.', () => {
+        expect(formatDaysCsv([0, 1, 8])).toBe('Mon');
+    });
+});
+
+describe('formatTimeWindow', () => {
+    it('returns Any time when allowedTimeWindows is null.', () => {
+        expect(formatTimeWindow(null)).toBe('Any time');
+    });
+
+    it('returns Any time when allowedTimeWindows is empty.', () => {
+        expect(formatTimeWindow([])).toBe('Any time');
+    });
+
+    it('formats a single window as `HH:MM → HH:MM`.', () => {
+        expect(formatTimeWindow([{ start: '22:00', end: '06:00' }])).toBe('22:00 → 06:00');
+    });
+
+    it('comma-joins multiple windows.', () => {
+        expect(formatTimeWindow([
+            { start: '22:00', end: '06:00' },
+            { start: '14:00', end: '15:00' },
+        ])).toBe('22:00 → 06:00, 14:00 → 15:00');
+    });
+});

--- a/app/lib/schedule-format/.test.ts
+++ b/app/lib/schedule-format/.test.ts
@@ -13,11 +13,11 @@ describe('daysArrayFromAllowed', () => {
         expect(daysArrayFromAllowed([])).toEqual([false, false, false, false, false, false, false]);
     });
 
-    it('maps ISO weekday (1=Mon, 7=Sun) to the Mon-anchored boolean array.', () => {
-        // Mon, Wed, Fri.
-        expect(daysArrayFromAllowed([1, 3, 5])).toEqual([true, false, true, false, true, false, false]);
-        // Sat, Sun (weekend).
-        expect(daysArrayFromAllowed([6, 7])).toEqual([false, false, false, false, false, true, true]);
+    it('maps ISO weekday (1=Mon, 7=Sun) to the Sun-first boolean array.', () => {
+        // Mon, Wed, Fri → Sun-first: [Sun=F, Mon=T, Tue=F, Wed=T, Thu=F, Fri=T, Sat=F].
+        expect(daysArrayFromAllowed([1, 3, 5])).toEqual([false, true, false, true, false, true, false]);
+        // Sat, Sun (weekend) → Sun-first: [Sun=T, Mon..Fri=F, Sat=T].
+        expect(daysArrayFromAllowed([6, 7])).toEqual([true, false, false, false, false, false, true]);
     });
 
     it('ignores out-of-range day numbers gracefully.', () => {
@@ -36,11 +36,16 @@ describe('formatDaysCsv', () => {
 
     it('joins three-letter day names with a middot.', () => {
         expect(formatDaysCsv([1, 3, 5])).toBe('Mon · Wed · Fri');
-        expect(formatDaysCsv([6, 7])).toBe('Sat · Sun');
+        expect(formatDaysCsv([6, 7])).toBe('Sun · Sat');
     });
 
-    it('preserves caller-supplied order rather than sorting.', () => {
-        expect(formatDaysCsv([5, 1, 3])).toBe('Fri · Mon · Wed');
+    it('emits Sun-first week order regardless of input ordering.', () => {
+        expect(formatDaysCsv([5, 1, 3])).toBe('Mon · Wed · Fri');
+        expect(formatDaysCsv([7, 1])).toBe('Sun · Mon');
+    });
+
+    it('de-duplicates repeated weekdays.', () => {
+        expect(formatDaysCsv([1, 1, 3, 3])).toBe('Mon · Wed');
     });
 
     it('skips out-of-range day numbers.', () => {

--- a/app/lib/schedule-format/index.ts
+++ b/app/lib/schedule-format/index.ts
@@ -1,0 +1,39 @@
+import type { ScheduleAllowedTimeWindow } from '@/api/types/schedules';
+
+/**
+ * Mon-Sun day labels for the CSV summary. Order matches `isoWeekday`
+ * (1 = Mon, 7 = Sun) shifted to a 0-based array index.
+ */
+const DAY_CSV_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+/**
+ * Converts the API's `allowedDays: number[] | null` (ISO weekday — 1 = Mon,
+ * 7 = Sun) into a Mon-Sun-anchored boolean array consumable by `DayStrip`
+ * and `DayDots`. `null` (no restriction) → every day.
+ */
+export function daysArrayFromAllowed(allowedDays: ReadonlyArray<number> | null): boolean[] {
+    if (allowedDays === null) return [true, true, true, true, true, true, true];
+    return Array.from({ length: 7 }, (_, index) => allowedDays.includes(index + 1));
+}
+
+/**
+ * Formats `allowedDays` as a middot-separated short-day CSV (e.g.
+ * `Mon · Wed · Fri`). `null` (no restriction) renders as `Every day`.
+ */
+export function formatDaysCsv(allowedDays: ReadonlyArray<number> | null): string {
+    if (allowedDays === null) return 'Every day';
+    const labels = allowedDays
+        .filter(day => day >= 1 && day <= 7)
+        .map(day => DAY_CSV_LABELS[day - 1] as string);
+    if (labels.length === 0) return 'No days';
+    return labels.join(' · ');
+}
+
+/**
+ * Formats the time-window list as `HH:MM → HH:MM` (single window) or a
+ * comma-separated list (multiple). `null` / empty → `Any time`.
+ */
+export function formatTimeWindow(allowedTimeWindows: ReadonlyArray<ScheduleAllowedTimeWindow> | null): string {
+    if (allowedTimeWindows === null || allowedTimeWindows.length === 0) return 'Any time';
+    return allowedTimeWindows.map(window => `${window.start} → ${window.end}`).join(', ');
+}

--- a/app/lib/schedule-format/index.ts
+++ b/app/lib/schedule-format/index.ts
@@ -1,31 +1,48 @@
 import type { ScheduleAllowedTimeWindow } from '@/api/types/schedules';
 
 /**
- * Mon-Sun day labels for the CSV summary. Order matches `isoWeekday`
- * (1 = Mon, 7 = Sun) shifted to a 0-based array index.
+ * Short day labels keyed by ISO weekday (1 = Mon, …, 7 = Sun). Used by
+ * `formatDaysCsv` so the lookup matches the API encoding directly.
  */
-const DAY_CSV_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+const DAY_LABEL_BY_WEEKDAY: Readonly<Record<number, string>> = {
+    1: 'Mon',
+    2: 'Tue',
+    3: 'Wed',
+    4: 'Thu',
+    5: 'Fri',
+    6: 'Sat',
+    7: 'Sun',
+};
+
+/**
+ * Sun-first ordering of ISO weekdays — used to sort the CSV and to map
+ * Sun-first display positions back to ISO weekdays.
+ */
+const SUN_FIRST_WEEKDAY_ORDER = [7, 1, 2, 3, 4, 5, 6] as const;
 
 /**
  * Converts the API's `allowedDays: number[] | null` (ISO weekday — 1 = Mon,
- * 7 = Sun) into a Mon-Sun-anchored boolean array consumable by `DayStrip`
- * and `DayDots`. `null` (no restriction) → every day.
+ * 7 = Sun) into a Sun-first boolean array consumable by `DayStrip` and
+ * `DayDots`. Index 0 = Sunday, index 6 = Saturday. `null` (no restriction)
+ * → every day.
  */
 export function daysArrayFromAllowed(allowedDays: ReadonlyArray<number> | null): boolean[] {
     if (allowedDays === null) return [true, true, true, true, true, true, true];
-    return Array.from({ length: 7 }, (_, index) => allowedDays.includes(index + 1));
+    return SUN_FIRST_WEEKDAY_ORDER.map(weekday => allowedDays.includes(weekday));
 }
 
 /**
- * Formats `allowedDays` as a middot-separated short-day CSV (e.g.
- * `Mon · Wed · Fri`). `null` (no restriction) renders as `Every day`.
+ * Formats `allowedDays` as a middot-separated short-day CSV in Sun-first
+ * week order (e.g. `Sun · Tue · Fri`). Duplicate or out-of-range entries
+ * are filtered out. `null` (no restriction) renders as `Every day`.
  */
 export function formatDaysCsv(allowedDays: ReadonlyArray<number> | null): string {
     if (allowedDays === null) return 'Every day';
-    const labels = allowedDays
-        .filter(day => day >= 1 && day <= 7)
-        .map(day => DAY_CSV_LABELS[day - 1] as string);
-    if (labels.length === 0) return 'No days';
+    const validSet = new Set(allowedDays.filter(day => day >= 1 && day <= 7));
+    if (validSet.size === 0) return 'No days';
+    const labels = SUN_FIRST_WEEKDAY_ORDER
+        .filter(weekday => validSet.has(weekday))
+        .map(weekday => DAY_LABEL_BY_WEEKDAY[weekday] as string);
     return labels.join(' · ');
 }
 


### PR DESCRIPTION
## Ticket

[APP-29](http://192.168.2.100:7123/irrigo/browse/APP-29/) — Schedule list (active hero + other-profiles switcher).

## Summary

Delivers the Schedules screen as a drop-in `ScheduleListView` component plus five supporting primitives. The screen is presentational/wired but not yet route-registered — route assembly is a separate ticket.

- **`DayStrip`** — 7-cell Mon-Sun strip used by the active hero. Active cells use accent chrome + glow dot; inactive cells stay surface-toned.
- **`DayDots`** — compact 7-dot preview for the switcher rows. Configurable `size` / `gap`.
- **`ActiveScheduleHero`** — the big card per `Mobile.jsx:657-772`. Running pill + re-plan icon button, name + days/window summary, DayStrip, optional skip banner, next-run section, 4-row Rules block, and Switch profile + Skip / Resume tonight footer buttons.
- **`ScheduleRow`** — non-active row: name + summary on the left, DayDots + "Switch" chevron on the right. Tap fires `onSwitch(schedule)`.
- **`SwitchScheduleModal`** — switch confirmation. Wraps the generic `Modal` primitive. The source's cosmetic checkboxes (re-plan + notify) were dropped — the API always re-plans on enable and there's no notify-on-queue endpoint, so rendering them would be dishonest UX.
- **`ScheduleListView`** — smart root: calls `useSchedules`, `useEnableSchedule`, `useSkipScheduleTonight`, `useResumeScheduleTonight`, `useReplan`. Partitions into active + others, opens the modal on row tap, renders loading / error / empty states gracefully. The "+ New" button stays disabled until a profile-creation flow lands.
- **`lib/schedule-format`** — pure helpers `daysArrayFromAllowed` (maps ISO weekday → Mon-anchored `boolean[7]`), `formatDaysCsv` ("Mon · Wed · Fri"), `formatTimeWindow` ("22:00 → 06:00") shared between hero and row.

## Test plan

- [x] `bun --cwd=./app run test` — 332 tests across 49 suites green.
  - 8 DayStrip + DayDots primitive tests
  - 12 ActiveScheduleHero tests (skip banner, next-run conditional, rule rows, callbacks, isReplanning disabled)
  - 4 ScheduleRow + 5 SwitchScheduleModal tests
  - 11 ScheduleListView tests (loading, error, partition, all 4 mutation endpoints, empty schedule list, "+ New" stub disabled)
  - 14 schedule-format helper tests
- [x] `bun --cwd=./app run typecheck` — no new errors (pre-existing scaffolding errors in `(tabs)/index.tsx` and `modal.tsx` are unrelated).

## Out of scope

- Route registration (separate screen-assembly ticket).
- The "+ New" button — disabled stub per design source; new-profile creation needs an API endpoint first.
- Cosmetic checkboxes from the design's SwitchModal (no backend wire).