### PR TITLE
[API-66] Multi-zone interleaving + sunrise boundary for the planner

### DIFF
--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -127,15 +127,22 @@ describe('runScheduleForZone', () => {
         const baselineCycle = baseline.entries[0]!.cycles[0]!;
         const baselineDay = baseline.entries[0]!.date.format('YYYY-MM-DD');
 
-        // Apply a busy window that straddles the cycle's natural start, pushing it past
-        // sunrise — the planner drops that day's entry entirely.
+        // Apply a busy window that straddles the cycle's natural start. Per API-66
+        // the planner now slides the cycle earlier (ending at busyStart) instead of
+        // shoving it forward past sunrise.
         const busyStart = baselineCycle.startTime.subtract(15, 'minute').toDate();
         const busyEnd = baselineCycle.startTime.add(20, 'minute').toDate();
 
         const { entries } = await runScheduleForZone(zone, { busyWindows: [{ start: busyStart, end: busyEnd }] });
 
-        // Day 0 entry is absent — the busy window displaced its cycle past sunrise.
-        expect(entries.find(e => e.date.format('YYYY-MM-DD') === baselineDay)).toBeUndefined();
+        const dayEntry = entries.find(e => e.date.format('YYYY-MM-DD') === baselineDay);
+        expect(dayEntry).toBeDefined();
+        for (const cycle of dayEntry!.cycles) {
+            const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute').toDate();
+            // No cycle overlaps the busy window.
+            const overlap = cycle.startTime.toDate() < busyEnd && cycleEnd > busyStart;
+            expect(overlap).toBe(false);
+        }
     });
 
     it('forwards schedule restrictions to the planner so disallowed days drop their cycles', async () => {

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1031,9 +1031,10 @@ describe('planZoneSchedule', () => {
             expect(emptyCycle.durationMin).toBe(baselineCycle.durationMin);
         });
 
-        it('drops the day when a busy window pushes the cycle past sunrise', () => {
-            // The baseline cycle ends exactly at sunrise. Any forward shift cascades
-            // the end time past sunrise, so the cycle is dropped and no entry is produced.
+        it('slides the cycle earlier so it ends at busyStart when its planned slot overlaps a busy window', () => {
+            // API-66: previously the cycle was shoved forward past sunrise and dropped.
+            // New behavior: the cycle slides earlier to end at busyStart, interleaving
+            // with the busy zone instead of being lost.
             const zone = singleCycleZone();
             const weather = singleCycleWeather();
             const baseline = planZoneSchedule(zone, weather);
@@ -1043,10 +1044,14 @@ describe('planZoneSchedule', () => {
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            expect(entries).toHaveLength(0);
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+            expect(cycleEnd.isSame(busyStart)).toBe(true);
         });
 
-        it('drops the day when a busy window whose tail straddles the cycle pushes it past sunrise', () => {
+        it('slides the cycle earlier when a busy window straddles its tail', () => {
+            // API-66: cycle now slides to end at busyStart rather than being shoved forward.
             const zone = singleCycleZone();
             const weather = singleCycleWeather();
             const baseline = planZoneSchedule(zone, weather);
@@ -1056,24 +1061,34 @@ describe('planZoneSchedule', () => {
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            expect(entries).toHaveLength(0);
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+            expect(cycleEnd.isSame(busyStart)).toBe(true);
         });
 
-        it('drops the day when consecutive busy windows push the cycle past sunrise', () => {
+        it('slides the cycle earlier past consecutive busy windows until it fits', () => {
+            // API-66: with two overlapping busy spans, the cycle keeps sliding earlier
+            // until both are cleared. The earlier window starts before the cycle's
+            // planned position, so we expect the cycle to land just before THAT span.
             const zone = singleCycleZone();
             const weather = singleCycleWeather();
             const baseline = planZoneSchedule(zone, weather);
             const baselineCycle = baseline.entries[0]!.cycles[0]!;
+            const firstBusyStart = baselineCycle.startTime.subtract(30, 'minute');
             const firstBusyEnd = baselineCycle.startTime.add(10, 'minute');
             const secondBusyStart = firstBusyEnd.add(2, 'minute');
             const secondBusyEnd = secondBusyStart.add(20, 'minute');
 
             const { entries } = planZoneSchedule(zone, weather, [
-                { start: baselineCycle.startTime.subtract(30, 'minute'), end: firstBusyEnd },
+                { start: firstBusyStart, end: firstBusyEnd },
                 { start: secondBusyStart, end: secondBusyEnd },
             ]);
 
-            expect(entries).toHaveLength(0);
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+            expect(cycleEnd.isSame(firstBusyStart)).toBe(true);
         });
 
         it('leaves a cycle untouched when no busy window overlaps', () => {
@@ -1092,9 +1107,11 @@ describe('planZoneSchedule', () => {
             expect(cycle.durationMin).toBe(baselineCycle.durationMin);
         });
 
-        it('keeps cycles that fit and drops cycles displaced past sunrise by a busy window', () => {
-            // Default zone: ~190 min total over 2 cycles; a busy window shifts cycle 1
-            // to busyEnd (still before sunrise) but the cascade pushes cycle 2 past sunrise.
+        it('slides both cycles of a multi-cycle plan earlier past a busy window', () => {
+            // API-66: previously only cycle 1 survived (slid forward to busyEnd) while
+            // cycle 2 was lost to the cascading delay. New behavior: both cycles slide
+            // earlier, the last cycle ending at busyStart and the first cycle one soak
+            // earlier.
             const zone = createTestZone({ currentDepletionMm: 22 });
             const weather = createWeatherDays([
                 {
@@ -1111,22 +1128,31 @@ describe('planZoneSchedule', () => {
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
-            // Cycle 1 shifted to busyEnd (still fits before sunrise).
-            // Cycle 2's intra-zone cascade lands past sunrise — dropped.
             expect(entries).toHaveLength(1);
-            expect(entries[0]!.cycles).toHaveLength(1);
-            expect(entries[0]!.cycles[0]!.startTime.isSame(busyEnd)).toBe(true);
+            expect(entries[0]!.cycles).toHaveLength(2);
+            const [cycle1, cycle2] = entries[0]!.cycles;
+            // No cycle overlaps the busy window.
+            for (const cycle of entries[0]!.cycles) {
+                const end = cycle.startTime.add(cycle.durationMin, 'minute');
+                const overlap = cycle.startTime.isBefore(busyEnd) && end.isAfter(busyStart);
+                expect(overlap).toBe(false);
+            }
+            // Cycles remain in chronological order.
+            expect(cycle1!.startTime.isBefore(cycle2!.startTime)).toBe(true);
         });
 
-        it('drops the day when a busy window blocks the entire slot before sunrise', () => {
+        it('drops the day when a busy window blocks every backward placement before earliestStart', () => {
+            // Day 0 (no prevDaySunset → earliestStart = midnight) with a busy window
+            // covering the entire midnight-to-sunrise span leaves no slot the cycle
+            // can backward-slide into. The placer truncates to zero cycles and the
+            // day is skipped.
             const zone = singleCycleZone();
             const sunrise = dayjs('2025-10-20').hour(6).minute(0).second(0).millisecond(0);
             const weather = createWeatherDays([
                 { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunrise },
             ]);
-            // Busy window brackets the entire pre-sunrise region — cycle has nowhere to go.
-            const busyStart = sunrise.subtract(2, 'hour');
-            const busyEnd = sunrise.add(2, 'hour');
+            const busyStart = sunrise.startOf('day');
+            const busyEnd = sunrise;
 
             const { entries } = planZoneSchedule(zone, weather, [{ start: busyStart, end: busyEnd }]);
 
@@ -1161,6 +1187,42 @@ describe('planZoneSchedule', () => {
                     const aEnd = a.startTime.add(a.durationMin, 'minute');
                     const bEnd = b.startTime.add(b.durationMin, 'minute');
                     const overlap = a.startTime.isBefore(bEnd) && aEnd.isAfter(b.startTime);
+                    expect(overlap).toBe(false);
+                }
+            }
+        });
+
+        it('interleaves a second zone\'s cycles into the soak gaps of the first zone (API-66)', () => {
+            // Two identical zones planned sequentially. Zone B receives A's run windows
+            // as busyWindows. Old behaviour: B got pushed past sunrise and lost all
+            // cycles. New behaviour: B's cycles slide earlier, ending at each A
+            // cycle's start — landing inside A's soak gaps.
+            const zone = createTestZone({ currentDepletionMm: 22 });
+            const weather = createWeatherDays([
+                {
+                    evapotranspirationMmPerDay: 1.0,
+                    rainfallMm: 0,
+                    sunrise: dayjs('2025-10-20').hour(6).minute(0).second(0).millisecond(0),
+                },
+            ]);
+
+            const planA = planZoneSchedule(zone, weather);
+            expect(planA.entries[0]!.cycles.length).toBeGreaterThan(0);
+
+            const aBusyWindows = planA.entries[0]!.cycles.map(c => ({
+                start: c.startTime,
+                end: c.startTime.add(c.durationMin, 'minute'),
+            }));
+
+            const planB = planZoneSchedule(zone, weather, aBusyWindows);
+
+            // Zone B should still produce cycles (the core bug fix).
+            expect(planB.entries[0]!.cycles.length).toBeGreaterThan(0);
+            // None of B's cycles overlap any of A's run windows.
+            for (const bCycle of planB.entries[0]!.cycles) {
+                const bEnd = bCycle.startTime.add(bCycle.durationMin, 'minute');
+                for (const aWindow of aBusyWindows) {
+                    const overlap = bCycle.startTime.isBefore(aWindow.end) && bEnd.isAfter(aWindow.start);
                     expect(overlap).toBe(false);
                 }
             }

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1740,6 +1740,97 @@ describe('planZoneSchedule', () => {
             const cycle = entries[0]!.cycles[0]!;
             expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(NOW_09.valueOf());
         });
+
+        it('drops past-due cycles entirely when restrictions.endBySunrise is true (API-66)', () => {
+            // Re-plan at 14:00 UTC (well past sunrise); the planned cycle would land
+            // before sunrise. With endBySunrise=true the forward push is forbidden
+            // (no daytime irrigation), so the cycle is dropped and depletion carries
+            // forward to the next plan.
+            const zone = pastWindowZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(
+                zone,
+                weather,
+                [PAST_WINDOW],
+                { allowedDays: null, allowedTimeWindows: null, endBySunrise: true },
+            );
+
+            expect(entries).toHaveLength(0);
+        });
+
+        it('carries depletion forward to day 1 when day 0 is dropped under endBySunrise', () => {
+            // Day 0 fires before re-plan (cycles dropped → no irrigation); depletion
+            // accumulates and day 1 fires. The planner's `projectedNextDepletionMm`
+            // reflects the carried-forward deficit.
+            const zone = pastWindowZone();
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+                ],
+                dayjs('2026-05-04'),
+            ).map((day, i) => ({
+                ...day,
+                sunrise: dayjs(`2026-05-0${4 + i}`).hour(6).minute(0).second(0).millisecond(0),
+            }));
+
+            const withSunriseGate = planZoneSchedule(
+                zone,
+                weather,
+                [PAST_WINDOW],
+                { allowedDays: null, allowedTimeWindows: null, endBySunrise: true },
+            );
+
+            // Day 0's cycles are all past-due → dropped. Day 1 still gets planned with
+            // accumulated depletion (visible via day-1 entry's depletionBeforeMm > the
+            // baseline single-day RAW).
+            expect(withSunriseGate.entries.length).toBeGreaterThan(0);
+            for (const entry of withSunriseGate.entries) {
+                expect(entry.date.format('YYYY-MM-DD')).not.toBe('2026-05-04');
+            }
+        });
+
+        it('keeps the existing forward-shift behaviour when endBySunrise is false (default)', () => {
+            // Regression guard: without endBySunrise the planner still pushes past-due
+            // cycles to fire at NOW.
+            const zone = pastWindowZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(
+                zone,
+                weather,
+                [PAST_WINDOW],
+                { allowedDays: null, allowedTimeWindows: null, endBySunrise: false },
+            );
+
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(NOW.valueOf());
+        });
+
+        it('keeps future cycles on day 0 when re-plan kicks off before sunrise under endBySunrise', () => {
+            // Re-plan at 03:00 UTC — sunrise 06:00. Day-0 cycle planned around 05:50
+            // (single-cycle zone): still in the future, so it survives the
+            // endBySunrise gate.
+            const NOW_03 = dayjs('2026-05-04T03:00:00.000Z');
+            const zone = pastWindowZone();
+            const weather = weatherDay();
+
+            const { entries } = planZoneSchedule(
+                zone,
+                weather,
+                [{ start: dayjs(new Date(0)), end: NOW_03 }],
+                { allowedDays: null, allowedTimeWindows: null, endBySunrise: true },
+            );
+
+            expect(entries).toHaveLength(1);
+            const cycle = entries[0]!.cycles[0]!;
+            const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+            expect(cycle.startTime.valueOf()).toBeGreaterThan(NOW_03.valueOf());
+            // And the cycle still ends at-or-before sunrise (06:00).
+            expect(cycleEnd.valueOf()).toBeLessThanOrEqual(weather[0]!.sunrise!.valueOf() + 1000);
+        });
     });
 
     describe('skip-tonight marker', () => {

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -279,11 +279,29 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         return null;
     }
 
-    // Past-window shift runs after backward placement: past-dated cycles get
-    // pushed forward to fire after `now`, even if that lands past sunrise.
-    const finalCycles = pastWindow
-        ? deconflictCycles(placedCycles, [pastWindow], soakTimeMinutes)
-        : placedCycles;
+    // Past-window handling differs by schedule shape (API-66):
+    //  - default: shift past-due cycles forward to fire at-or-after `now`,
+    //    even if that lands past sunrise. The daemon would rather fire a
+    //    late cycle than skip the day.
+    //  - `endBySunrise=true`: daytime irrigation is explicitly forbidden, so
+    //    push-forward is wrong. Drop the past-due cycles instead and let
+    //    depletion carry forward to the next allowed day.
+    const finalCycles = (() => {
+        if (pastWindow === undefined) return placedCycles;
+        if (restrictions.endBySunrise === true) {
+            const nowMs = pastWindow.end.valueOf();
+            return placedCycles.filter(c => {
+                const endMs = c.startTime.valueOf() + c.durationMin * 60_000;
+                return endMs > nowMs;
+            });
+        }
+        return deconflictCycles(placedCycles, [pastWindow], soakTimeMinutes);
+    })();
+
+    if (finalCycles.length === 0) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles remain after past-window handling on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
+        return null;
+    }
 
     const entry: IrrigationScheduleEntry = {
         date,

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -248,57 +248,42 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
     const hasPrevSunset = prevDaySunset !== undefined;
     const earliestStart = hasPrevSunset ? prevDaySunset : sunrise.startOf('day');
 
-    const plannedCycles = buildCyclePlan(
+    // The daemon plumbs a "past window" — { start: epoch, end: now } — as a
+    // busy interval that pushes past-dated cycles forward. It's handled
+    // separately from real cross-zone busy windows: cross-zone windows feed
+    // the backward placer (so cycles slide *earlier* into soak gaps), while
+    // the past window applies as a forward shift *after* placement so a
+    // past-due cycle is fired now-ish instead of dropped.
+    const pastWindow = busyWindowsSoFar.find(w => w.start.valueOf() === 0);
+    const crossZoneBusyWindows = pastWindow
+        ? busyWindowsSoFar.filter(w => w !== pastWindow)
+        : busyWindowsSoFar;
+
+    const placedCycles = placeCyclesBackwardAvoidingBusy(
         totalRunTimeMinutes,
         maximumCycleMinutes,
         sunrise,
         soakTimeMinutes,
         earliestStart,
         hasPrevSunset,
+        crossZoneBusyWindows,
     );
 
-    if (plannedCycles === null) {
+    if (placedCycles === null) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): overnight window too short to fit the planned cycles on ${date.format('YYYY-MM-DD')} — deferring irrigation.`);
         return null;
     }
 
-    if (plannedCycles.length === 0) {
+    if (placedCycles.length === 0) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles fit the overnight window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
         return null;
     }
 
-    // The daemon plumbs a "past window" — { start: epoch, end: now } — as a
-    // busy interval to push past-dated cycles forward. Distinguish it from
-    // real cross-zone busy windows so it can be applied after the sunrise
-    // validation: a cycle shifted by the past window is intentionally past
-    // sunrise and shouldn't be dropped, whereas a cycle pushed past sunrise
-    // by a cross-zone conflict has no useful slot and should drop.
-    const pastWindow = busyWindowsSoFar.find(w => w.start.valueOf() === 0);
-    const crossZoneBusyWindows = pastWindow
-        ? busyWindowsSoFar.filter(w => w !== pastWindow)
-        : busyWindowsSoFar;
-
-    const deconflictedCycles = deconflictCycles(plannedCycles, crossZoneBusyWindows, soakTimeMinutes);
-
-    // Drop any cycle displaced past sunrise by cross-zone busy windows. A
-    // 1-second tolerance absorbs floating-point drift from non-integer
-    // cycle durations.
-    const toleranceMs = 1000;
-    const validCycles = deconflictedCycles.filter(c => {
-        const endMs = c.startTime.valueOf() + c.durationMin * 60_000;
-        return endMs <= sunrise.valueOf() + toleranceMs;
-    });
-
-    if (validCycles.length === 0) {
-        console.warn(`planner: zone ${zone.id} (${zone.name}): all cycles displaced past sunrise by busy windows on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
-        return null;
-    }
-
-    // Past-window shift runs after sunrise validation: past-dated cycles get
+    // Past-window shift runs after backward placement: past-dated cycles get
     // pushed forward to fire after `now`, even if that lands past sunrise.
     const finalCycles = pastWindow
-        ? deconflictCycles(validCycles, [pastWindow], soakTimeMinutes)
-        : validCycles;
+        ? deconflictCycles(placedCycles, [pastWindow], soakTimeMinutes)
+        : placedCycles;
 
     const entry: IrrigationScheduleEntry = {
         date,
@@ -315,9 +300,16 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
 
 
 /**
- * Builds an irrigation cycle plan anchored so the last cycle ends at sunrise,
- * filling backward into the night. Behavior when a cycle would start before
- * `earliestStart`:
+ * Builds and places an irrigation cycle plan anchored so the last cycle ends
+ * at sunrise, walking backward into the night. While walking, each cycle is
+ * slid *earlier* past any overlapping `busyWindows` until it fits — that's
+ * what lets a follow-on zone's cycles interleave into the soak gaps of an
+ * earlier-planned zone instead of being shoved past sunrise (the old
+ * forward-only deconflict cascaded delays and dropped most days for the
+ * second zone, see API-66).
+ *
+ * Behavior when a cycle still doesn't fit (i.e., sliding earlier would land
+ * before `earliestStart`):
  *  - `deferIfWindowTooShort=true` (previous-day sunset available): the entire
  *    day is treated as un-irrigatable; the function returns `null` so the
  *    caller defers and carries depletion into the next allowed day.
@@ -326,40 +318,58 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
  *
  * @param totalRunTimeMinutes - Total irrigation runtime needed.
  * @param maximumCycleMinutes - Maximum duration per cycle (infiltration limit).
- * @param sunrise - End anchor: last cycle ends here.
- * @param soakTimeMinutes - Soak gap between consecutive cycles.
+ * @param sunrise - End anchor: last cycle ends here (or earlier if busy windows displace it).
+ * @param soakTimeMinutes - Soak gap between consecutive cycles of this zone.
  * @param earliestStart - Hard floor: no cycle may start before this time.
  * @param deferIfWindowTooShort - When true, returning `null` signals deferral
  *   rather than truncation.
+ * @param busyWindows - Intervals occupied by other zones (or the past window
+ *   if handled here). Cycles slide earlier to avoid overlap.
  * @returns Cycles in chronological order (earliest first), `null` when the
  *   day must be deferred, or `[]` when nothing needs to run.
  */
-function buildCyclePlan(
+function placeCyclesBackwardAvoidingBusy(
     totalRunTimeMinutes: number,
     maximumCycleMinutes: number,
     sunrise: dayjs.Dayjs,
     soakTimeMinutes: number,
     earliestStart: dayjs.Dayjs,
     deferIfWindowTooShort: boolean,
+    busyWindows: ReadonlyArray<BusyWindow>,
 ): IrrigationCycle[] | null {
     if (totalRunTimeMinutes <= 0) return [];
 
+    let numberOfCycles: number;
+    let perCycleMinutes: number;
     if (maximumCycleMinutes <= 0 || totalRunTimeMinutes <= maximumCycleMinutes) {
-        const durationMin = roundTo1Decimal(totalRunTimeMinutes);
-        const startTime = sunrise.subtract(durationMin, 'minute');
-        if (startTime.isBefore(earliestStart)) return deferIfWindowTooShort ? null : [];
-        return [{ startTime, durationMin }];
+        numberOfCycles = 1;
+        perCycleMinutes = roundTo1Decimal(totalRunTimeMinutes);
+    } else {
+        numberOfCycles = Math.ceil(totalRunTimeMinutes / maximumCycleMinutes);
+        perCycleMinutes = roundTo1Decimal(totalRunTimeMinutes / numberOfCycles);
     }
 
-    const numberOfCycles = Math.ceil(totalRunTimeMinutes / maximumCycleMinutes),
-        perCycleMinutes = roundTo1Decimal(totalRunTimeMinutes / numberOfCycles);
-
     const cyclesInReverse: IrrigationCycle[] = [];
-    let totalMinutesBeforeSunrise = 0;
+    let cursor: dayjs.Dayjs = sunrise; // latest-allowed end for the next placed cycle (walking backward)
 
     for (let i = 0; i < numberOfCycles; i++) {
-        const offsetMinutes = totalMinutesBeforeSunrise + perCycleMinutes;
-        const cycleStart = sunrise.subtract(offsetMinutes, 'minute');
+        let cycleEnd: dayjs.Dayjs = cursor;
+        let cycleStart: dayjs.Dayjs = cycleEnd.subtract(perCycleMinutes, 'minute');
+
+        // Slide earlier past any busy window we overlap. Re-iterate after each
+        // shift since the new (earlier) slot may overlap a different window.
+        let stable = false;
+        while (!stable) {
+            stable = true;
+            for (const w of busyWindows) {
+                if (cycleStart.isBefore(w.end) && cycleEnd.isAfter(w.start)) {
+                    cycleEnd = w.start;
+                    cycleStart = cycleEnd.subtract(perCycleMinutes, 'minute');
+                    stable = false;
+                    break;
+                }
+            }
+        }
 
         if (cycleStart.isBefore(earliestStart)) {
             if (deferIfWindowTooShort) return null;
@@ -367,7 +377,7 @@ function buildCyclePlan(
         }
 
         cyclesInReverse.push({ startTime: cycleStart, durationMin: perCycleMinutes });
-        totalMinutesBeforeSunrise = offsetMinutes + soakTimeMinutes;
+        cursor = cycleStart.subtract(soakTimeMinutes, 'minute');
     }
 
     return cyclesInReverse.reverse();


### PR DESCRIPTION
## Ticket

[API-66](http://192.168.2.100:7123/irrigo/browse/API-66/) — Schedule generator only plans South zone; soak windows not used for concurrent zone irrigation; sunrise boundary skipped on day 0.

## Summary

Three related planner bugs, all rooted in the planner's per-zone independent placement + forward-only deconflict. Fixed together:

1. **Only South zone gets schedule entries.** Was: each follow-on zone's cycles, planned backward from sunrise, overlapped the first zone's runs; the forward-only `deconflictCycles` shoved them past sunrise where they were dropped. Cascading intra-zone soak chained the delay across every cycle, so the follow-on zone got zero entries. Now: cycles slide *earlier* past busy windows, naturally interleaving into the soak gaps of earlier-planned zones.

2. **Soak windows didn't host concurrent zones.** Same root cause; the new backward-walking placer puts cycle N of zone B into the soak window between cycle N and cycle N+1 of zone A whenever the geometry allows.

3. **Sunrise boundary violated on day 0.** The past-window "fire now-ish" forward shift was running unconditionally; under `endBySunrise=true` it pushed past-due overnight cycles into daytime. Now: when `endBySunrise` is set, past-due cycles are *dropped* rather than shifted forward — depletion carries forward to the next allowed day.

## Implementation

- **`placeCyclesBackwardAvoidingBusy`** ([api/schedules/dynamic/index.ts](api/schedules/dynamic/index.ts)) replaces `buildCyclePlan` + the cross-zone `deconflictCycles` call. Walks backward from sunrise, sliding each cycle's end earlier to the start of any busy window it overlaps until stable, then chains the next (earlier) cycle off the placed cycle's start − soak. Defers/truncates if a cycle's slide would land before `earliestStart`. Single-zone behaviour is unchanged (no busy windows ⇒ no sliding).
- **Past-window handling** ([api/schedules/dynamic/index.ts](api/schedules/dynamic/index.ts)) branches on `restrictions.endBySunrise`: when true, drop cycles whose end has already passed; when false, keep the existing forward-shift to fire past-due cycles at `now`.
- Five existing busy-window tests updated to assert the new backward-slide behavior (they previously documented the broken forward-only shift).
- Added: multi-zone interleaving test, defer-when-backward-blocked test, and four `endBySunrise` + past-window tests.

## Test plan

- [x] `bun --cwd=./api test schedules` — 175 passed (122 in `schedules/dynamic`, including 5 new tests).
- [x] `bun --cwd=./api test` — 793 passed across 45 suites.
- [x] `bun --cwd=./api run type-check` — clean.
- [ ] Manual smoke: after deploy, observe the next 04:00 re-plan. Expect East/West/North zones to have entries (not just South) and no daytime cycles on the day of the re-plan when `endBySunrise=true`.