### PR TITLE
[APP-44] Replace CycleStrip with per-zone schedule list

### DIFF
--- a/app/components/next-run-hero/.test.tsx
+++ b/app/components/next-run-hero/.test.tsx
@@ -168,7 +168,7 @@ describe('NextRunHero', () => {
         expect(screen.getByText('North · 1 cycle · ends 5:48 am')).toBeOnTheScreen();
     });
 
-    it('renders the embedded compact CycleStrip with the per-zone palette applied.', () => {
+    it('renders one schedule line per zone, in run order, with am/pm windows.', () => {
         render(
             <NextRunHero
                 nextRun={SCHEDULED_NEXT_RUN}
@@ -177,15 +177,42 @@ describe('NextRunHero', () => {
             />,
         );
 
-        // The CycleStrip exposes a stable accessibility label that the
-        // hero embeds verbatim — its presence proves the strip mounted.
-        expect(screen.getByLabelText('Irrigation cycle chart')).toBeOnTheScreen();
-        // Both zones appear in the strip's legend.
-        expect(screen.getByLabelText('North: 1 cycles, 15 minutes')).toBeOnTheScreen();
-        expect(screen.getByLabelText('South: 1 cycles, 12 minutes')).toBeOnTheScreen();
+        // North fires at 22:23 for 15 min → 10:23 pm to 10:38 pm.
+        expect(screen.getByText('North zone: 10:23 pm to 10:38 pm')).toBeOnTheScreen();
+        // South fires at 23:00 for 12 min → 11:00 pm to 11:12 pm.
+        expect(screen.getByText('South zone: 11:00 pm to 11:12 pm')).toBeOnTheScreen();
     });
 
-    it('does not render the cycle strip when zones is empty (active state, no plan yet).', () => {
+    it('joins multiple cycles on the same zone with `, `.', () => {
+        render(
+            <NextRunHero
+                nextRun={{
+                    ...SCHEDULED_NEXT_RUN,
+                    zones: [
+                        {
+                            name: 'North',
+                            slug: 'north',
+                            patch: 'a',
+                            cycles: [
+                                { start: '22:23', durMin: 15 },
+                                { start: '23:40', durMin: 18 },
+                            ],
+                        },
+                    ],
+                    zoneOrder: ['North'],
+                    totalCycles: 2,
+                }}
+                siteTimezone='America/Edmonton'
+                now={NOW_LOCAL_SAME_DAY}
+            />,
+        );
+
+        expect(
+            screen.getByText('North zone: 10:23 pm to 10:38 pm, 11:40 pm to 11:58 pm'),
+        ).toBeOnTheScreen();
+    });
+
+    it('omits the schedule list when zones is empty (active state, no plan yet).', () => {
         render(
             <NextRunHero
                 nextRun={{ ...SCHEDULED_NEXT_RUN, zones: [], zoneOrder: [] }}
@@ -194,7 +221,7 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.queryByLabelText('Irrigation cycle chart')).toBeNull();
+        expect(screen.queryByText(/zone:/)).toBeNull();
         expect(screen.getByText('No zones · 10 cycles · ends 5:48 am')).toBeOnTheScreen();
     });
 });

--- a/app/components/next-run-hero/index.tsx
+++ b/app/components/next-run-hero/index.tsx
@@ -1,13 +1,10 @@
-import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { NextRunDto, NextRunState } from '@/api/types/next-run';
 import { Badge, type BadgeTone } from '@/components/badge';
-import { CycleStrip, type CycleStripNight } from '@/components/cycle-strip';
 import { FontFamily } from '@/constants/fonts';
-import { formatEndsAt, formatNextRunDate, formatTimeOfDay } from '@/lib/relative-time';
+import { formatCycleWindow, formatEndsAt, formatNextRunDate, formatTimeOfDay } from '@/lib/relative-time';
 import { getSiteTimezone } from '@/lib/site-timezone';
-import { paletteForZone } from '@/lib/zone-palette';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
@@ -29,30 +26,13 @@ export type NextRunHeroProps = {
 /**
  * Home-screen hero card showing the next irrigation run. Big mono time in
  * the accent colour, subtitle of zone order + cycle count + ends time,
- * status badge, and an embedded compact `CycleStrip`. Renders a quiet
- * empty-state card when the system has no runs queued.
+ * status badge, and a per-zone schedule list (one line per zone in run
+ * order). Renders a quiet empty-state card when the system has no runs
+ * queued.
  */
 export function NextRunHero({ nextRun, siteTimezone, now }: NextRunHeroProps) {
     const resolvedTimezone = siteTimezone ?? getSiteTimezone();
     const resolvedNow = now ?? new Date();
-    const cycleStripNight = useMemo<CycleStripNight | null>(() => {
-        if (nextRun.zones.length === 0) return null;
-        return {
-            ...(nextRun.axisStart !== null ? { axisStart: nextRun.axisStart } : {}),
-            ...(nextRun.axisEnd !== null ? { axisEnd: nextRun.axisEnd } : {}),
-            sunset: nextRun.sunset ?? '20:00',
-            sunrise: nextRun.sunrise ?? '06:00',
-            zones: nextRun.zones.map((zone, index) => {
-                const palette = paletteForZone(index);
-                return {
-                    name: zone.name,
-                    color: palette.color,
-                    glow: palette.glow,
-                    cycles: zone.cycles,
-                };
-            }),
-        };
-    }, [nextRun.axisStart, nextRun.axisEnd, nextRun.sunset, nextRun.sunrise, nextRun.zones]);
 
     const isIdle = nextRun.state === 'idle';
 
@@ -89,9 +69,13 @@ export function NextRunHero({ nextRun, siteTimezone, now }: NextRunHeroProps) {
                 <Badge tone={badgeToneForState(nextRun.state)}>{badgeLabelForState(nextRun.state)}</Badge>
             </View>
 
-            {cycleStripNight !== null && (
-                <View style={styles.cycleStripWrap}>
-                    <CycleStrip night={cycleStripNight} variant='compact' />
+            {nextRun.zones.length > 0 && (
+                <View style={styles.scheduleListWrap}>
+                    {nextRun.zones.map(zone => (
+                        <Text key={zone.slug} style={styles.scheduleLine}>
+                            {zone.name} zone: {zone.cycles.map(c => formatCycleWindow(c.start, c.durMin)).join(', ')}
+                        </Text>
+                    ))}
                 </View>
             )}
         </View>
@@ -187,7 +171,14 @@ const styles = StyleSheet.create({
         lineHeight: 17,
         color: colors['fg-muted'],
     },
-    cycleStripWrap: {
+    scheduleListWrap: {
         marginTop: 4,
+        gap: 4,
+    },
+    scheduleLine: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 12,
+        lineHeight: 18,
+        color: colors['fg-soft'],
     },
 });

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -1,4 +1,4 @@
-import { formatCountdown, formatEndsAt, formatLastRan, formatNextRunDate, formatRelativeTime, formatTimeOfDay } from '.';
+import { formatCountdown, formatCycleWindow, formatEndsAt, formatLastRan, formatNextRunDate, formatRelativeTime, formatTimeOfDay } from '.';
 
 const TZ = 'America/Edmonton';
 // 2026-05-23T15:00:00Z = 09:00 MDT on 2026-05-23 (Saturday).
@@ -71,6 +71,28 @@ describe('formatTimeOfDay', () => {
 describe('formatEndsAt', () => {
     it('formats the ends-at like formatTimeOfDay.', () => {
         expect(formatEndsAt('2026-05-23T11:48:00.000Z', TZ)).toBe('5:48 am');
+    });
+});
+
+describe('formatCycleWindow', () => {
+    it('renders a basic am window with the midnight hour as 12.', () => {
+        expect(formatCycleWindow('00:13', 34)).toBe('12:13 am to 12:47 am');
+    });
+
+    it('renders a basic pm window with 24h → 12h conversion.', () => {
+        expect(formatCycleWindow('14:30', 25)).toBe('2:30 pm to 2:55 pm');
+    });
+
+    it('flips am → pm across the noon boundary.', () => {
+        expect(formatCycleWindow('11:50', 20)).toBe('11:50 am to 12:10 pm');
+    });
+
+    it('wraps pm → am past midnight via modular minute arithmetic.', () => {
+        expect(formatCycleWindow('23:50', 30)).toBe('11:50 pm to 12:20 am');
+    });
+
+    it('drops the leading zero on single-digit hours.', () => {
+        expect(formatCycleWindow('06:05', 9)).toBe('6:05 am to 6:14 am');
     });
 });
 

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -68,6 +68,29 @@ export function formatEndsAt(iso: string, timezoneName: string): string {
 }
 
 /**
+ * Formats a single per-zone cycle window for the next-run hero's schedule
+ * list — `'h:mm am to h:mm am'`, lowercase, no leading zero on the hour.
+ * The input is already site-local `HH:MM` and a duration in minutes, so
+ * there's no timezone conversion: minutes-of-day arithmetic with a
+ * modular wrap at midnight (a cycle starting at `23:50` for 30 min ends
+ * at `00:20` the next morning, which renders as `'12:20 am'`).
+ */
+export function formatCycleWindow(startHhMm: string, durMin: number): string {
+    const [hourStr, minuteStr] = startHhMm.split(':');
+    const startMinuteOfDay = Number(hourStr) * 60 + Number(minuteStr);
+    const endMinuteOfDay = (startMinuteOfDay + durMin) % (24 * 60);
+    return `${formatLocalClock(startMinuteOfDay)} to ${formatLocalClock(endMinuteOfDay)}`;
+}
+
+function formatLocalClock(minuteOfDay: number): string {
+    const hour24 = Math.floor(minuteOfDay / 60) % 24;
+    const minute = minuteOfDay % 60;
+    const period = hour24 < 12 ? 'am' : 'pm';
+    const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+    return `${hour12}:${minute.toString().padStart(2, '0')} ${period}`;
+}
+
+/**
  * Formats the calendar-day offset between `now` and `iso` into the date
  * prefix used by the Home next-run subtitle. Comparisons are anchored in
  * the supplied IANA timezone so a UTC-late instant that still lands on


### PR DESCRIPTION
## Ticket

[APP-44](http://192.168.2.100:7123/home/browse/APP-44/) — Replace CycleStrip with per-zone schedule text list on next-run tile

## Summary

- Replaced the embedded `<CycleStrip>` SVG timeline inside `NextRunHero` with a per-zone text list — one line per zone in run order, listing every cycle as `start to end` ranges (e.g. `North zone: 10:23 pm to 10:38 pm, 11:40 pm to 11:58 pm`).
- Added `formatCycleWindow(startHhMm, durMin)` to `app/lib/relative-time/` — pure minutes-of-day arithmetic (no dayjs / tz round-trip, since the cycle data is already site-local `HH:MM`). Handles midnight wraps so `'23:50' + 30 → '11:50 pm to 12:20 am'`.
- Dropped the `cycleStripNight` `useMemo` block plus the `CycleStrip` / `CycleStripNight` / `paletteForZone` / `useMemo` imports from `NextRunHero`. The `CycleStrip` primitive and `zone-palette` lib stay in the codebase for potential future use.
- Schedule lines render in `FontFamily.monoMedium` per the ticket.

## Test plan

- [x] `bun --cwd=./app run typecheck` — clean (only pre-existing `app/modal.tsx` scaffold error).
- [x] `bun --cwd=./app run test` — 450 / 450 pass.
- [x] `formatCycleWindow` covered by 5 lib-tests (am, pm, noon flip, midnight wrap, leading-zero).
- [x] NextRunHero schedule-list coverage: in-order rendering, multi-cycle join, empty-zones omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)