### PR TITLE
[APP-48] Tighten the home next-run tile

### DIFF
--- a/app/components/cycle-strip/.test.tsx
+++ b/app/components/cycle-strip/.test.tsx
@@ -144,11 +144,93 @@ describe('CycleStrip', () => {
         expect(screen.getByText('· 1 cycles · 18 min')).toBeOnTheScreen();
     });
 
+    it('rounds the per-zone total runtime to whole minutes in the legend.', () => {
+        // Without rounding, JS sums of `durMin` like 12.3 + 17.6 + 0.4 produce
+        // floating-point noise like 30.300000000000004 — `Math.round` kills it
+        // before interpolation so the legend reads cleanly as "· 3 cycles · 30 min".
+        const NIGHT_WITH_FLOAT_DUR: CycleStripNight = {
+            sunset: '20:45',
+            sunrise: '05:30',
+            zones: [
+                {
+                    name: 'Mixed',
+                    color: '#6FE39B',
+                    glow: 'rgba(111, 227, 155, 0.4)',
+                    cycles: [
+                        { start: '23:00', durMin: 12.3 },
+                        { start: '00:30', durMin: 17.6 },
+                        { start: '02:00', durMin: 0.4 },
+                    ],
+                },
+            ],
+        };
+
+        render(<CycleStrip night={NIGHT_WITH_FLOAT_DUR} />);
+
+        expect(screen.getByText('· 3 cycles · 30 min')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Mixed: 3 cycles, 30 minutes')).toBeOnTheScreen();
+    });
+
     it('announces each lane via accessibility label with cycle count and runtime.', () => {
         render(<CycleStrip night={SAMPLE_NIGHT} />);
 
         expect(screen.getByLabelText('North: 2 cycles, 27 minutes')).toBeOnTheScreen();
         expect(screen.getByLabelText('South: 1 cycles, 18 minutes')).toBeOnTheScreen();
+    });
+
+    it('renders each sun label with just its text — no glyph child beside it.', () => {
+        const { root } = render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        // The label wrap previously held a `<SunGlyph />` (Svg dome + arrow)
+        // next to the Text. After the cleanup, only the Text child remains.
+        for (const labelText of ['sunset 20:45', 'sunrise 05:30']) {
+            const wraps = root.findAll(node =>
+                typeof node.type === 'string'
+                && node.props.accessibilityLabel === labelText,
+            );
+            expect(wraps).toHaveLength(1);
+            const hostChildren = (wraps[0]?.children ?? []).filter(child => typeof child !== 'string');
+            expect(hostChildren).toHaveLength(1);
+        }
+    });
+
+    it('anchors the sunrise label by its right edge so it never overflows the chart.', () => {
+        const { root } = render(<CycleStrip night={SAMPLE_NIGHT} />);
+
+        // Default axisEnd is '06:00' and sunrise is '05:30' — both land in the
+        // right half of the chart, so the SunLabel wrap should be positioned
+        // with `right`, not `left`.
+        const sunriseWraps = root.findAll(node =>
+            typeof node.type === 'string'
+            && node.props.accessibilityLabel === 'sunrise 05:30',
+        );
+        expect(sunriseWraps).toHaveLength(1);
+        const styles = sunriseWraps[0]?.props.style as ReadonlyArray<Record<string, unknown>>;
+        const hasRight = styles.some(s => typeof s === 'object' && s !== null && 'right' in s);
+        const hasLeft = styles.some(s => typeof s === 'object' && s !== null && 'left' in s);
+        expect(hasRight).toBe(true);
+        expect(hasLeft).toBe(false);
+    });
+
+    it('anchors a sun label by its left edge when it lands in the left half of the chart.', () => {
+        // Sunset at 22:30 sits just inside the default axis start of 22:00 —
+        // well within the left half — so positioning falls back to `left`.
+        const NIGHT_LEFT_HALF_SUNSET: CycleStripNight = {
+            ...SAMPLE_NIGHT,
+            sunset: '22:30',
+        };
+        const { root } = render(<CycleStrip night={NIGHT_LEFT_HALF_SUNSET} />);
+
+        const sunsetWraps = root.findAll(node =>
+            typeof node.type === 'string'
+            && node.props.accessibilityLabel === 'sunset 22:30',
+        );
+        expect(sunsetWraps).toHaveLength(1);
+        const styles = sunsetWraps[0]?.props.style as ReadonlyArray<Record<string, unknown>>;
+        const hasLeft = styles.some(s => typeof s === 'object' && s !== null && 'left' in s);
+        const hasRight = styles.some(s => typeof s === 'object' && s !== null && 'right' in s);
+        expect(hasLeft).toBe(true);
+        expect(hasRight).toBe(false);
     });
 
     it('renders sunset and sunrise labels with their HH:MM times.', () => {

--- a/app/components/cycle-strip/index.tsx
+++ b/app/components/cycle-strip/index.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
-import Svg, { Line, Path } from 'react-native-svg';
 
 import { MINUTES_PER_DAY } from '@/constants/duration';
 import { FontFamily } from '@/constants/fonts';
@@ -194,7 +193,7 @@ export function CycleStrip({
                         />
                         <Text style={styles.legendName}>{zone.name}</Text>
                         <Text style={styles.legendMeta}>
-                            {`· ${zone.cycles.length} cycles · ${totalCycleMin(zone)} min`}
+                            {`· ${zone.cycles.length} cycles · ${Math.round(totalCycleMin(zone))} min`}
                         </Text>
                     </View>
                 ))}
@@ -222,7 +221,7 @@ export function CycleStrip({
                         <View
                             key={zone.name}
                             style={{ position: 'relative', height: laneHeight }}
-                            accessibilityLabel={`${zone.name}: ${zone.cycles.length} cycles, ${totalCycleMin(zone)} minutes`}
+                            accessibilityLabel={`${zone.name}: ${zone.cycles.length} cycles, ${Math.round(totalCycleMin(zone))} minutes`}
                         >
                             <View
                                 style={[
@@ -289,45 +288,14 @@ function SunLabel({ leftPct, kind, time }: { leftPct: number; kind: 'set' | 'ris
     // never falls off the end of the chart.
     const alignRight = leftPct > 50;
     const labelText = `${kind === 'set' ? 'sunset' : 'sunrise'} ${time}`;
+    const positionStyle: ViewStyle = alignRight
+        ? { right: `${100 - leftPct}%` }
+        : { left: `${leftPct}%` };
 
     return (
-        <View
-            style={[
-                styles.sunLabelWrap,
-                { left: `${leftPct}%` },
-                alignRight ? styles.sunLabelWrapRight : undefined,
-            ]}
-            accessibilityLabel={labelText}
-        >
-            <SunGlyph kind={kind} />
+        <View style={[styles.sunLabelWrap, positionStyle]} accessibilityLabel={labelText}>
             <Text style={styles.sunLabelText}>{labelText}</Text>
         </View>
-    );
-}
-
-function SunGlyph({ kind }: { kind: 'set' | 'rise' }) {
-    return (
-        <Svg width={13} height={9} viewBox='0 0 13 9' fill='none'>
-            <Path d='M1.5 8 a 5 5 0 0 1 10 0 Z' fill={colors['moon-500']} opacity={0.85} />
-            <Line x1={0} y1={8.5} x2={13} y2={8.5} stroke={colors['moon-500']} strokeWidth={0.8} opacity={0.6} />
-            {kind === 'set' ? (
-                <Path
-                    d='M6.5 2.5 v 3 M5 4 l 1.5 1.5 l 1.5 -1.5'
-                    stroke={colors['moon-500']}
-                    strokeWidth={1}
-                    strokeLinecap='round'
-                    fill='none'
-                />
-            ) : (
-                <Path
-                    d='M6.5 5.5 v -3 M5 4 l 1.5 -1.5 l 1.5 1.5'
-                    stroke={colors['moon-500']}
-                    strokeWidth={1}
-                    strokeLinecap='round'
-                    fill='none'
-                />
-            )}
-        </Svg>
     );
 }
 
@@ -420,12 +388,6 @@ const styles = StyleSheet.create({
     sunLabelWrap: {
         position: 'absolute',
         top: 0,
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 5,
-    },
-    sunLabelWrapRight: {
-        transform: [{ translateX: -1 }],
     },
     sunLabelText: {
         fontFamily: FontFamily.monoMedium,

--- a/app/components/home-view/.test.tsx
+++ b/app/components/home-view/.test.tsx
@@ -110,18 +110,21 @@ beforeEach(() => {
 });
 
 describe('HomeView', () => {
-    it('renders the eyebrow with the site timezone label.', async () => {
-        setupSuccessfulFetch();
-        render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
-
-        await waitFor(() => expect(screen.getByText('Next run · America/Edmonton')).toBeOnTheScreen());
-    });
-
     it('renders the next-run hero with the scheduled time.', async () => {
         setupSuccessfulFetch();
         render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
 
         await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
+    });
+
+    it('does not render the outer "Next run · <timezone>" eyebrow above the hero card.', async () => {
+        setupSuccessfulFetch();
+        render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
+
+        // Wait for the page to stabilise, then assert the timezone-bearing
+        // eyebrow is absent. The inner card's own "Next run" eyebrow stays.
+        await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
+        expect(screen.queryByText(/Next run · America\/Edmonton/)).toBeNull();
     });
 
     it('renders a zone tile for every zone returned by /zones.', async () => {

--- a/app/components/home-view/index.tsx
+++ b/app/components/home-view/index.tsx
@@ -54,8 +54,6 @@ export function HomeView() {
 
             <SystemDisabledWrapper disabled={!irrigationEnabled}>
                 <View style={styles.body}>
-                    <Text style={styles.eyebrow}>Next run · {siteTimezone.replace('_', ' ')}</Text>
-
                     {nextRun.isPending ? (
                         <PlaceholderCard label='Loading next run…' />
                     ) : nextRun.isError || nextRun.data == null ? (
@@ -123,14 +121,6 @@ const styles = StyleSheet.create({
     },
     body: {
         gap: 18,
-    },
-    eyebrow: {
-        fontFamily: FontFamily.sansMedium,
-        fontSize: 11,
-        lineHeight: 13,
-        letterSpacing: 1.54,
-        color: colors['fg-muted'],
-        textTransform: 'uppercase',
     },
     zonesHeading: {
         flexDirection: 'row',

--- a/app/components/next-run-hero/.test.tsx
+++ b/app/components/next-run-hero/.test.tsx
@@ -65,7 +65,7 @@ describe('NextRunHero', () => {
         expect(screen.getByText('10:23 pm')).toBeOnTheScreen();
     });
 
-    it('renders the subtitle without a date prefix when the run is today.', () => {
+    it(`renders the date label as 'Today, D MMM' when the run is today.`, () => {
         render(
             <NextRunHero
                 nextRun={SCHEDULED_NEXT_RUN}
@@ -74,10 +74,10 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.getByText('North, then South · 10 cycles · ends 5:48 am')).toBeOnTheScreen();
+        expect(screen.getByText('Today, 23 May')).toBeOnTheScreen();
     });
 
-    it('prepends "Tomorrow" to the subtitle when the run is the next local calendar day.', () => {
+    it(`renders the date label as 'Tomorrow, D MMM' when the run is the next local calendar day.`, () => {
         // NOW is one full local day before SCHEDULED_NEXT_RUN.startTime (2026-05-23 MDT).
         const nowDayBefore = new Date('2026-05-22T20:00:00.000Z');
         render(
@@ -88,10 +88,10 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.getByText('Tomorrow · North, then South · 10 cycles · ends 5:48 am')).toBeOnTheScreen();
+        expect(screen.getByText('Tomorrow, 23 May')).toBeOnTheScreen();
     });
 
-    it('prepends the short weekday for runs 2–6 local days out.', () => {
+    it(`renders the date label as 'Ddd, D MMM' for runs 2+ local days out.`, () => {
         // NOW is three local days before SCHEDULED_NEXT_RUN.startTime (2026-05-23 MDT = Saturday).
         const nowThreeDaysBefore = new Date('2026-05-20T20:00:00.000Z');
         render(
@@ -102,10 +102,10 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.getByText('Sat · North, then South · 10 cycles · ends 5:48 am')).toBeOnTheScreen();
+        expect(screen.getByText('Sat, 23 May')).toBeOnTheScreen();
     });
 
-    it('prepends the long "Ddd D MMM" form for runs 7+ local days out.', () => {
+    it(`renders the same 'Ddd, D MMM' format for far-future runs (7+ local days out).`, () => {
         // NOW is ten local days before SCHEDULED_NEXT_RUN.startTime (2026-05-23 MDT = Saturday 23 May).
         const nowTenDaysBefore = new Date('2026-05-13T20:00:00.000Z');
         render(
@@ -116,7 +116,7 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.getByText('Sat 23 May · North, then South · 10 cycles · ends 5:48 am')).toBeOnTheScreen();
+        expect(screen.getByText('Sat, 23 May')).toBeOnTheScreen();
     });
 
     it('renders the Scheduled badge for the scheduled state.', () => {
@@ -141,31 +141,6 @@ describe('NextRunHero', () => {
         );
 
         expect(screen.getByText('Firing')).toBeOnTheScreen();
-    });
-
-    it('omits the ends-at suffix from the subtitle when endsAt is null.', () => {
-        render(
-            <NextRunHero
-                nextRun={{ ...SCHEDULED_NEXT_RUN, endsAt: null }}
-                siteTimezone='America/Edmonton'
-                now={NOW_LOCAL_SAME_DAY}
-            />,
-        );
-
-        expect(screen.getByText('North, then South · 10 cycles')).toBeOnTheScreen();
-        expect(screen.queryByText(/ends/)).toBeNull();
-    });
-
-    it('switches to the singular `cycle` label when totalCycles is 1.', () => {
-        render(
-            <NextRunHero
-                nextRun={{ ...SCHEDULED_NEXT_RUN, totalCycles: 1, zoneOrder: ['North'] }}
-                siteTimezone='America/Edmonton'
-                now={NOW_LOCAL_SAME_DAY}
-            />,
-        );
-
-        expect(screen.getByText('North · 1 cycle · ends 5:48 am')).toBeOnTheScreen();
     });
 
     it('renders the embedded compact CycleStrip with the per-zone palette applied.', () => {
@@ -195,6 +170,7 @@ describe('NextRunHero', () => {
         );
 
         expect(screen.queryByLabelText('Irrigation cycle chart')).toBeNull();
-        expect(screen.getByText('No zones · 10 cycles · ends 5:48 am')).toBeOnTheScreen();
+        // The date label still renders — it doesn't depend on zones.
+        expect(screen.getByText('Today, 23 May')).toBeOnTheScreen();
     });
 });

--- a/app/components/next-run-hero/index.tsx
+++ b/app/components/next-run-hero/index.tsx
@@ -5,7 +5,7 @@ import type { NextRunDto, NextRunState } from '@/api/types/next-run';
 import { Badge, type BadgeTone } from '@/components/badge';
 import { CycleStrip, type CycleStripNight } from '@/components/cycle-strip';
 import { FontFamily } from '@/constants/fonts';
-import { formatEndsAt, formatNextRunDate, formatTimeOfDay } from '@/lib/relative-time';
+import { formatNextRunDate, formatTimeOfDay } from '@/lib/relative-time';
 import { getSiteTimezone } from '@/lib/site-timezone';
 import { paletteForZone } from '@/lib/zone-palette';
 import config from '@/tailwind.config';
@@ -68,14 +68,6 @@ export function NextRunHero({ nextRun, siteTimezone, now }: NextRunHeroProps) {
 
     const timeOfDay = formatTimeOfDay(nextRun.startTime, resolvedTimezone);
     const dateLabel = formatNextRunDate(nextRun.startTime, resolvedTimezone, resolvedNow);
-    const endsLabel = nextRun.endsAt !== null ? `ends ${formatEndsAt(nextRun.endsAt, resolvedTimezone)}` : null;
-    const zoneOrder = nextRun.zoneOrder.length > 0 ? nextRun.zoneOrder.join(', then ') : 'No zones';
-    const cyclesLabel = `${nextRun.totalCycles} ${nextRun.totalCycles === 1 ? 'cycle' : 'cycles'}`;
-    const subtitleParts: string[] = [];
-    if (dateLabel !== '') subtitleParts.push(dateLabel);
-    subtitleParts.push(zoneOrder, cyclesLabel);
-    if (endsLabel !== null) subtitleParts.push(endsLabel);
-    const subtitle = subtitleParts.join(' · ');
 
     return (
         <View style={[styles.card, styles.cardActive]} accessibilityLabel={`Next run at ${timeOfDay}`}>
@@ -83,7 +75,7 @@ export function NextRunHero({ nextRun, siteTimezone, now }: NextRunHeroProps) {
                 <View style={styles.headerText}>
                     <Text style={[styles.eyebrow, { color: colors.accent }]}>Next run</Text>
                     <Text style={styles.time}>{timeOfDay}</Text>
-                    <Text style={styles.subtitle}>{subtitle}</Text>
+                    <Text style={styles.subtitle}>{dateLabel}</Text>
                 </View>
 
                 <Badge tone={badgeToneForState(nextRun.state)}>{badgeLabelForState(nextRun.state)}</Badge>

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -78,34 +78,35 @@ describe('formatNextRunDate', () => {
     // 2026-05-23T15:00:00Z = 09:00 MDT on 2026-05-23 (Saturday).
     const NOW_LOCAL_SATURDAY = new Date('2026-05-23T15:00:00.000Z');
 
-    it(`returns '' when the run lands on the same local calendar day.`, () => {
+    it(`returns 'Today, D MMM' when the run lands on the same local calendar day.`, () => {
         // 2026-05-24T04:23Z = 22:23 MDT on 2026-05-23 — still Saturday local.
-        expect(formatNextRunDate('2026-05-24T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('');
+        expect(formatNextRunDate('2026-05-24T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Today, 23 May');
     });
 
-    it(`returns '' when the run is already in the past.`, () => {
-        expect(formatNextRunDate('2026-05-22T12:00:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('');
+    it(`returns 'Today, D MMM' when the run is already in the past.`, () => {
+        // 2026-05-22T12:00Z = 06:00 MDT on 2026-05-22 (Friday) — one day before NOW.
+        expect(formatNextRunDate('2026-05-22T12:00:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Today, 22 May');
     });
 
-    it(`returns 'Tomorrow' for the next local calendar day.`, () => {
+    it(`returns 'Tomorrow, D MMM' for the next local calendar day.`, () => {
         // 2026-05-25T04:23Z = 22:23 MDT on 2026-05-24 (Sunday) — one day on from Saturday.
-        expect(formatNextRunDate('2026-05-25T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Tomorrow');
+        expect(formatNextRunDate('2026-05-25T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Tomorrow, 24 May');
     });
 
-    it('returns the short weekday for runs 2–6 days out.', () => {
+    it(`returns 'Ddd, D MMM' for runs 2+ days out.`, () => {
         // 2026-05-27T04:23Z = 22:23 MDT on 2026-05-26 (Tuesday) — three days on.
-        expect(formatNextRunDate('2026-05-27T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Tue');
+        expect(formatNextRunDate('2026-05-27T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Tue, 26 May');
     });
 
-    it(`returns the long form 'Ddd D MMM' for runs 7+ days out.`, () => {
+    it(`returns the same 'Ddd, D MMM' format for runs 7+ days out (no separate far-future bucket).`, () => {
         // 2026-06-03T04:23Z = 22:23 MDT on 2026-06-02 (Tuesday) — ten days on.
-        expect(formatNextRunDate('2026-06-03T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Tue 2 Jun');
+        expect(formatNextRunDate('2026-06-03T04:23:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Tue, 2 Jun');
     });
 
     it('uses the site timezone for the calendar-day comparison, not UTC.', () => {
         // 2026-05-24T05:30Z is "Sunday" in UTC but 23:30 MDT on Saturday locally —
         // still the same calendar day as NOW_LOCAL_SATURDAY (09:00 MDT Sat).
-        expect(formatNextRunDate('2026-05-24T05:30:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('');
+        expect(formatNextRunDate('2026-05-24T05:30:00.000Z', TZ, NOW_LOCAL_SATURDAY)).toBe('Today, 23 May');
     });
 });
 

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -69,27 +69,27 @@ export function formatEndsAt(iso: string, timezoneName: string): string {
 
 /**
  * Formats the calendar-day offset between `now` and `iso` into the date
- * prefix used by the Home next-run subtitle. Comparisons are anchored in
- * the supplied IANA timezone so a UTC-late instant that still lands on
+ * label rendered beneath the Home next-run time. Comparisons are anchored
+ * in the supplied IANA timezone so a UTC-late instant that still lands on
  * "today" locally doesn't slip into the "Tomorrow" bucket.
  *
  * Buckets:
  *
- * | Offset (calendar days, site-local) | Output         |
- * |------------------------------------|----------------|
- * | `<= 0` (today or already past)     | `''`           |
- * | `1`                                | `'Tomorrow'`   |
- * | `2`–`6`                            | `'Wed'`        |
- * | `>= 7`                             | `'Mon 28 May'` |
+ * | Offset (calendar days, site-local) | Output             |
+ * |------------------------------------|--------------------|
+ * | `<= 0` (today or already past)     | `'Today, 23 May'`  |
+ * | `1`                                | `'Tomorrow, 24 May'` |
+ * | `>= 2`                             | `'Tue, 26 May'`    |
  */
 export function formatNextRunDate(iso: string, timezoneName: string, now: Date): string {
-    const target = dayjs(iso).tz(timezoneName).startOf('day');
-    const present = dayjs(now).tz(timezoneName).startOf('day');
-    const diffDays = target.diff(present, 'day');
-    if (diffDays <= 0) return '';
-    if (diffDays === 1) return 'Tomorrow';
-    if (diffDays < 7) return dayjs(iso).tz(timezoneName).format('ddd');
-    return dayjs(iso).tz(timezoneName).format('ddd D MMM');
+    const target = dayjs(iso).tz(timezoneName);
+    const targetDay = target.startOf('day');
+    const presentDay = dayjs(now).tz(timezoneName).startOf('day');
+    const diffDays = targetDay.diff(presentDay, 'day');
+    const datePart = target.format('D MMM');
+    if (diffDays <= 0) return `Today, ${datePart}`;
+    if (diffDays === 1) return `Tomorrow, ${datePart}`;
+    return `${target.format('ddd')}, ${datePart}`;
 }
 
 /**


### PR DESCRIPTION
## Ticket

[APP-48](http://192.168.2.100:7123/home/browse/APP-48/) — Fix next-run tile display issues

## Summary

- Round zone runtime to whole minutes in the cycle strip legend + accessibility label (kills `96.30000000000001 min` floating-point noise).
- Remove the yellow sun-glyph SVG from both `sunset` and `sunrise` chart labels — text only now.
- Right-anchor the `sunrise` label so it stops overflowing the chart on narrow screens.
- Replace the next-run hero subtitle (zone order · cycles · ends at) with a `Today, 23 May` / `Tomorrow, 24 May` / `Sat, 23 May` date label.
- Drop the outer `Next run · America/Edmonton` eyebrow from the home view — the inner card's "Next run" eyebrow already labels the tile.
- Rework `formatNextRunDate` to always return a date string and refresh its test buckets.

## Test plan

- [x] `bun --cwd=./app run test` — 446/446 passing across 63 suites
- [x] `bun --cwd=./app run typecheck` — clean (one pre-existing `app/modal.tsx` error on main, unrelated)
- [ ] Manual sanity check on device: confirm `96 min` style runtime, no yellow glyphs, sunrise label fits, date label renders, no top-of-page timezone eyebrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)