### PR TITLE
[APP-41] Optimistic update for master irrigation toggle

### DIFF
--- a/app/components/master-toggle/.test.tsx
+++ b/app/components/master-toggle/.test.tsx
@@ -134,4 +134,52 @@ describe('MasterToggle', () => {
 
         await waitFor(() => expect(screen.getByLabelText('Main switch')).toBeOnTheScreen());
     });
+
+    it('flips the card surface immediately when the toggle is pressed, before the mutation resolves.', async () => {
+        // Initial GET returns disabled; the enable POST never resolves so
+        // the user-visible state can only have flipped optimistically.
+        mockFetch.mockImplementationOnce(async () => jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockImplementationOnce(() => new Promise(() => {}));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Enable irrigation')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Enable irrigation'));
+        });
+
+        // Every surface flips on the optimistic cache write — palette
+        // doesn't read from this assertion, but the eyebrow, title,
+        // subtitle, and toggle label all derive from the same cached
+        // value, so this proves the optimistic write reached the UI.
+        await waitFor(() => expect(screen.getByText('System on')).toBeOnTheScreen());
+        expect(screen.getByText('Irrigation enabled')).toBeOnTheScreen();
+        expect(screen.getByText('Scheduling & manual runs allowed')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Disable irrigation')).toBeOnTheScreen();
+    });
+
+    it('rolls the card back and surfaces the error message in the subtitle when the mutation fails.', async () => {
+        // Initial GET returns disabled. The enable POST fails. The
+        // post-settle re-fetch (still under mockFetch.mockResolvedValue)
+        // also returns disabled, so the rolled-back state survives.
+        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'HA 502' }, 502));
+
+        render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByLabelText('Enable irrigation')).toBeOnTheScreen());
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Enable irrigation'));
+        });
+
+        // After the mutation rejects, the subtitle shows the error...
+        await waitFor(() => expect(screen.getByText(/Last attempt failed:/)).toBeOnTheScreen());
+        // ...and the rest of the card is back to its pre-tap (OFF) state.
+        expect(screen.getByText('System off')).toBeOnTheScreen();
+        expect(screen.getByText('Irrigation disabled')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Enable irrigation')).toBeOnTheScreen();
+    });
 });

--- a/app/hooks/system/.test.tsx
+++ b/app/hooks/system/.test.tsx
@@ -70,4 +70,68 @@ describe('useSetSystemEnabled', () => {
         expect(client.getQueryState(keys.zones.list())?.isInvalidated).toBe(true);
         expect(client.getQueryState(keys.schedules.list())?.isInvalidated).toBe(true);
     });
+
+    it('writes the optimistic system state into the cache synchronously on mutate.', async () => {
+        // Fetch never resolves so the mutation stays in-flight; the
+        // optimistic cache write should be observable immediately.
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'old' });
+
+        const { result } = renderHook(() => useSetSystemEnabled(), { wrapper });
+
+        act(() => {
+            result.current.mutate(true);
+        });
+
+        await waitFor(() => {
+            const cached = client.getQueryData<{ irrigationEnabled: boolean; since: string }>(
+                keys.system.state(),
+            );
+            expect(cached?.irrigationEnabled).toBe(true);
+            expect(cached?.since).not.toBe('old');
+        });
+    });
+
+    it('rolls the system cache back to the previous value when the mutation rejects.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'HA 502' }, 502));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'old' });
+
+        const { result } = renderHook(() => useSetSystemEnabled(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync(true).catch(() => undefined);
+        });
+
+        expect(result.current.isError).toBe(true);
+        // Cache restored to the snapshot taken before the optimistic write.
+        expect(client.getQueryData(keys.system.state())).toEqual({
+            irrigationEnabled: false,
+            since: 'old',
+        });
+    });
+
+    it('still invalidates system, next-run, zones, and schedules after a failed flip.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'HA 502' }, 502));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'x' });
+        client.setQueryData(keys.nextRun.summary(), { state: 'idle' });
+        client.setQueryData(keys.zones.list(), []);
+        client.setQueryData(keys.schedules.list(), []);
+
+        const { result } = renderHook(() => useSetSystemEnabled(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync(true).catch(() => undefined);
+        });
+
+        expect(client.getQueryState(keys.system.state())?.isInvalidated).toBe(true);
+        expect(client.getQueryState(keys.nextRun.summary())?.isInvalidated).toBe(true);
+        expect(client.getQueryState(keys.zones.list())?.isInvalidated).toBe(true);
+        expect(client.getQueryState(keys.schedules.list())?.isInvalidated).toBe(true);
+    });
 });

--- a/app/hooks/system/index.ts
+++ b/app/hooks/system/index.ts
@@ -15,17 +15,38 @@ export function useSystem(): UseQueryResult<SystemStateDto, ApiError> {
     });
 }
 
+type OptimisticContext = { previous: SystemStateDto | undefined };
+
 /**
- * Flips the master irrigation kill switch. Every flip triggers an
- * immediate re-plan on the api, so this invalidates everything that
- * depends on the schedule: system state, the next-run plan, the zone
- * list, and the schedules list.
+ * Flips the master irrigation kill switch. The cache update is optimistic:
+ * `onMutate` writes the requested state into the system query cache so the
+ * master-toggle card flips palette, title, subtitle, and the toggle thumb
+ * the moment the user taps. If the server rejects the flip, `onError`
+ * rolls the cache back. `onSettled` re-runs the schedule-wide invalidation
+ * cascade — system, next-run, zones, schedules — for both success and
+ * failure paths, since a failed flip can still leave the cache stale.
  */
-export function useSetSystemEnabled(): UseMutationResult<SystemStateDto, ApiError, boolean> {
+export function useSetSystemEnabled(): UseMutationResult<SystemStateDto, ApiError, boolean, OptimisticContext> {
     const queryClient = useQueryClient();
-    return useMutation<SystemStateDto, ApiError, boolean>({
+    return useMutation<SystemStateDto, ApiError, boolean, OptimisticContext>({
         mutationFn: (enabled: boolean) => (enabled ? enableSystem() : disableSystem()),
-        onSuccess: () => {
+        onMutate: async enabled => {
+            // Cancel any in-flight refetch so it can't resolve after the
+            // optimistic write and clobber it with stale server data.
+            await queryClient.cancelQueries({ queryKey: keys.system.state() });
+            const previous = queryClient.getQueryData<SystemStateDto>(keys.system.state());
+            queryClient.setQueryData<SystemStateDto>(keys.system.state(), {
+                irrigationEnabled: enabled,
+                since: new Date().toISOString(),
+            });
+            return { previous };
+        },
+        onError: (_err, _enabled, context) => {
+            if (context?.previous !== undefined) {
+                queryClient.setQueryData(keys.system.state(), context.previous);
+            }
+        },
+        onSettled: () => {
             queryClient.invalidateQueries({ queryKey: keys.system.all() });
             queryClient.invalidateQueries({ queryKey: keys.nextRun.all() });
             queryClient.invalidateQueries({ queryKey: keys.zones.all() });


### PR DESCRIPTION
## Ticket

[APP-41](http://192.168.2.100:7123/home/browse/APP-41/) — Master irrigation toggle has no in-flight feedback

## Summary

- Wire `onMutate` / `onError` / `onSettled` into `useSetSystemEnabled` so the system query cache flips synchronously when the master toggle is pressed.
- The master-toggle card already derives its palette, eyebrow, title, subtitle, and toggle label from `system.data.irrigationEnabled`, so the optimistic write flips every surface in one shot — no component changes required.
- On mutation failure the cache rolls back to the snapshot, and the existing `Last attempt failed: <message>` subtitle renders the error.
- Invalidation moves from `onSuccess` to `onSettled` so a failed flip still triggers the system / next-run / zones / schedules refresh cascade.

## Test plan

- [x] `bun --cwd=./app run test` — 451/451 passing across 63 suites (was 444 before)
- [x] `bun --cwd=./app run typecheck` — clean (one pre-existing `app/modal.tsx` error already on `main`)
- [ ] Manual: in airplane mode, tap the master toggle on the Home screen — card should flip instantly and revert when the request fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)