### PR TITLE
[API-68] Move daily re-plan default from 04:00 to 20:00 local

### DIFF
--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1791,6 +1791,46 @@ describe('planZoneSchedule', () => {
             }
         });
 
+        it('preserves the accumulated depletion on day 1 when day 0 was dropped under 20:00 endBySunrise (API-68)', () => {
+            // Locks in the API-66 carry-forward guarantee under the new API-68
+            // re-plan hour. At 20:00 local, day-0's overnight cycles (planned
+            // backward from day-0 sunrise) are all past-due. They must be
+            // dropped *and* depletion must NOT silently reset — otherwise day 1
+            // would start at a clean ~0 mm and not cross RAW at all on this
+            // horizon.
+            const zone = pastWindowZone();
+            const twentyHundredUtc = dayjs('2026-05-04T20:00:00.000Z');
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
+                ],
+                dayjs('2026-05-04'),
+            ).map((day, i) => ({
+                ...day,
+                sunrise: dayjs(`2026-05-0${4 + i}`).hour(6).minute(0).second(0).millisecond(0),
+            }));
+
+            const result = planZoneSchedule(
+                zone,
+                weather,
+                [{ start: dayjs(new Date(0)), end: twentyHundredUtc }],
+                { allowedDays: null, allowedTimeWindows: null, endBySunrise: true },
+            );
+
+            // Day 0 has no entry; day 1 fires because day-0 depletion carried.
+            const day0 = result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+            const day1 = result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-05');
+            expect(day0).toBeUndefined();
+            expect(day1).toBeDefined();
+
+            // Carry-forward proof: starting depletion was 22; day-0 net ET adds
+            // ~0.85 mm (no irrigation); day-1 net ET adds another ~0.85 mm → day-1
+            // `depletionBeforeMm` should be ~23. If day 0 had silently reset on
+            // drop, day 1's value would be only ~0.85 — well below RAW (22.5).
+            expect(day1!.depletionBeforeMm).toBeGreaterThan(20);
+        });
+
         it('keeps the existing forward-shift behaviour when endBySunrise is false (default)', () => {
             // Regression guard: without endBySunrise the planner still pushes past-due
             // cycles to fire at NOW.

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -502,6 +502,20 @@ describe('start', () => {
         expect(getPendingDelays()).toContain(twentyTwoHoursMs);
     });
 
+    it('defaults `rePlanHourLocal` to 20 — schedules the first re-plan at the next 20:00 local (API-68)', async () => {
+        // NOW = 2026-05-04T12:00:00.000Z. With UTC site timezone and the new
+        // default hour of 20, the next re-plan should fire 8h later at
+        // 2026-05-04T20:00:00.000Z.
+        const stub = createDaemonReposStub();
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, getPendingDelays } = createFakeClock(NOW);
+
+        await start({ clock, siteTimezone: 'UTC' });
+
+        const eightHoursMs = 8 * 60 * 60 * 1000;
+        expect(getPendingDelays()).toContain(eightHoursMs);
+    });
+
     it('returned rePlan() runs the planner for every enabled zone and inserts the planner output', async () => {
         const enabledRow = buildJoinedRow({ zone: { id: 'zone-loaded', name: 'Loaded Zone' } });
         const stub = createDaemonReposStub({ enabledZones: [enabledRow] });

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -40,7 +40,15 @@ import {
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-const DEFAULT_REPLAN_HOUR_LOCAL = 4;
+/**
+ * Default hour-of-day (site-local) for the daily re-plan. 20:00 is chosen
+ * so Open-Meteo's day-0 `rain_sum` reflects ~20 hours of *observed* rain by
+ * the time the planner places tonight's cycles — same-day rainfall lands in
+ * the depletion balance before it can influence cycle placement. Forecast
+ * rain after 20:00 still flows through day-0's remaining forecast hours and
+ * subsequent days unchanged. See API-68.
+ */
+const DEFAULT_REPLAN_HOUR_LOCAL = 20;
 
 export type BootDaemonServiceInput = SetDaemonReposInput;
 


### PR DESCRIPTION
## Ticket

[API-68](http://192.168.2.100:7123/home/browse/API-68/) — Move daily re-plan from 04:00 to 20:00 local time.

## Summary

- Flipped `DEFAULT_REPLAN_HOUR_LOCAL` in [api/service/daemon/index.ts](api/service/daemon/index.ts) from `4` to `20`, with an inline comment explaining the rain-balance rationale.
- At 20:00 local, Open-Meteo's day-0 `rain_sum` reflects ~20 hours of *observed* rain — same-day rain is folded into the depletion balance before tonight's cycles are placed. Forecast rain after 20:00 still flows through day-0's remaining forecast hours and subsequent days.
- Added one daemon-level test: `start({ clock, siteTimezone: 'UTC' })` with no `rePlanHourLocal` schedules the first re-plan timer at +8 h from NOW (12:00 UTC → next 20:00 UTC). Locks the new default in place.
- Added one planner-level test (API-66 carry-forward guarantee under the new hour): with `pastWindow.end` at 20:00 UTC and `endBySunrise=true`, day-0 cycles are dropped, day-1 fires, and day-1's `depletionBeforeMm` is > 20 — proving day-0 depletion carried forward instead of being silently reset.
- Existing `computeNextRePlanAt` tests pass `4` explicitly — they parameterise on the hour and didn't depend on the default, so they keep working unchanged.

## Test plan

- [x] `bun --cwd=./api test service/daemon schedules/dynamic` — 209 / 209 pass (2 new).
- [x] `bun --cwd=./api test` — 795 / 795 pass across 45 suites.
- [x] `bun --cwd=./api run type-check` — clean.
- [ ] Manual smoke (post-merge): `bun --cwd=./api run logs` after the next 20:00 local should show `daemon: next re-plan scheduled at …` for a +24 h delta in the site timezone; `next-runs` shortly after should reflect tonight's cycles with same-day rain accounted for.