### PR TITLE
[API-69] Sort enabled zones and active schedules for deterministic planning

### DIFF
--- a/api/repositories/schedules/.test.ts
+++ b/api/repositories/schedules/.test.ts
@@ -31,12 +31,13 @@ function buildSchedule(overrides?: Partial<Schedule>): Schedule {
 function createStub(rowsByPredicate: Schedule[]) {
     const selectCalls: SelectCall[] = [];
     const updateCalls: UpdateCall[] = [];
+    const orderByCalls: Array<ReadonlyArray<unknown>> = [];
     const rows: Schedule[] = [...rowsByPredicate];
 
     // Leaf handlers — the actual SELECT/UPDATE logic. Lifting them out keeps
     // the Drizzle-mimicking chain wiring (`select().from().where()` etc.) down
     // to a single line per operation in the `db` object.
-    const runSelectWhere = async (cond: unknown): Promise<Array<{ schedule: Schedule }>> => {
+    const runQuery = async (cond: unknown): Promise<Array<{ schedule: Schedule }>> => {
         selectCalls.push({ where: cond });
         const params = extractParamValues(cond);
         if (params.length === 0) {
@@ -49,6 +50,23 @@ function createStub(rowsByPredicate: Schedule[]) {
         }
         const slug = params[0]!;
         return rows.filter(r => r.slug === slug).map(s => ({ schedule: s }));
+    };
+
+    // Wraps `runQuery` so the returned value is both a thenable (existing
+    // callers `await` straight off `.where()`) and exposes `.orderBy()` —
+    // API-69 chains orderBy on the production `loadActiveBySite` path.
+    const runSelectWhere = (cond: unknown) => {
+        const result = runQuery(cond);
+        return {
+            then: <TResult1, TResult2>(
+                onfulfilled?: ((value: Array<{ schedule: Schedule }>) => TResult1 | PromiseLike<TResult1>) | null,
+                onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+            ) => result.then(onfulfilled, onrejected),
+            orderBy: (...args: ReadonlyArray<unknown>) => {
+                orderByCalls.push(args);
+                return result;
+            },
+        };
     };
 
     const runUpdateWhere = async (values: Partial<Schedule>, cond: unknown): Promise<void> => {
@@ -72,7 +90,7 @@ function createStub(rowsByPredicate: Schedule[]) {
         transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(db),
     } as unknown as Database;
 
-    return { db, selectCalls, updateCalls, getRows: () => [...rows] };
+    return { db, selectCalls, updateCalls, orderByCalls, getRows: () => [...rows] };
 }
 
 function extractParamValues(cond: unknown): string[] {
@@ -158,6 +176,16 @@ describe('createSchedulesRepository.loadActiveBySite', () => {
         const result = await repo.loadActiveBySite();
 
         expect(result.size).toBe(0);
+    });
+
+    it('appends .orderBy(schedules.id) for stable iteration order (API-69 hygiene)', async () => {
+        const { db, orderByCalls } = createStub([buildSchedule({ isActive: true })]);
+        const repo = createSchedulesRepository(db);
+
+        await repo.loadActiveBySite();
+
+        expect(orderByCalls).toHaveLength(1);
+        expect(orderByCalls[0]).toContain(schedules.id);
     });
 });
 

--- a/api/repositories/schedules/index.ts
+++ b/api/repositories/schedules/index.ts
@@ -91,10 +91,16 @@ export function createSchedulesRepository(db: Database): SchedulesRepository {
         },
 
         loadActiveBySite: async () => {
+            // Stable `ORDER BY` is currently latent — `loadActiveBySite` keys
+            // into a `Map<siteId, Schedule>` so iteration order doesn't bite
+            // the planner. Added for hygiene so a future caller that walks
+            // `.values()` doesn't inherit Postgres' heap-order quirk. See
+            // API-69.
             const rows = await db
                 .select({ schedule: schedules })
                 .from(schedules)
-                .where(eq(schedules.isActive, true));
+                .where(eq(schedules.isActive, true))
+                .orderBy(schedules.id);
 
             const map = new Map<string, Schedule>();
             for (const row of rows) map.set(row.schedule.siteId, row.schedule);

--- a/api/repositories/zones/.test.ts
+++ b/api/repositories/zones/.test.ts
@@ -78,27 +78,48 @@ function buildJoinedRow(overrides?: Partial<{
 }
 
 type WhereCall = { conditions: unknown };
+type OrderByCall = ReadonlyArray<unknown>;
 
-function buildJoinChainStub<TRow>(whereCalls: WhereCall[], rows: TRow[]) {
+function buildJoinChainStub<TRow>(whereCalls: WhereCall[], orderByCalls: OrderByCall[], rows: TRow[]) {
     const chain = {
         innerJoin: () => chain,
         where: (conditions: unknown) => {
             whereCalls.push({ conditions });
-            return Promise.resolve(rows);
+            // The returned object is both thenable (so callers that `await`
+            // straight off `.where()` keep working) and exposes `.orderBy()`
+            // (so callers that chain orderBy resolve to the same rows). API-69
+            // adds the orderBy chain on the production `loadEnabled` path.
+            const whereResult = {
+                then: <TResult1, TResult2>(
+                    onfulfilled?: ((value: TRow[]) => TResult1 | PromiseLike<TResult1>) | null,
+                    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+                ) => Promise.resolve(rows).then(onfulfilled, onrejected),
+                orderBy: (...args: ReadonlyArray<unknown>) => {
+                    orderByCalls.push(args);
+                    return Promise.resolve(rows);
+                },
+            };
+            return whereResult;
         },
     };
     return chain;
 }
 
-function stubLoaderDb(rows: ZoneJoinedRow[]): { db: Database; whereCalls: WhereCall[]; getSelectColumns: () => unknown } {
+function stubLoaderDb(rows: ZoneJoinedRow[]): {
+    db: Database;
+    whereCalls: WhereCall[];
+    orderByCalls: OrderByCall[];
+    getSelectColumns: () => unknown;
+} {
     const whereCalls: WhereCall[] = [];
+    const orderByCalls: OrderByCall[] = [];
     let selectColumns: unknown;
     const runSelect = (columns: unknown) => {
         selectColumns = columns;
-        return { from: () => buildJoinChainStub(whereCalls, rows) };
+        return { from: () => buildJoinChainStub(whereCalls, orderByCalls, rows) };
     };
     const db = { select: runSelect } as unknown as Database;
-    return { db, whereCalls, getSelectColumns: () => selectColumns };
+    return { db, whereCalls, orderByCalls, getSelectColumns: () => selectColumns };
 }
 
 function stubCountDb(rows: ReadonlyArray<{ total: number; enabled: number }>): Database {
@@ -110,10 +131,11 @@ function stubCountDb(rows: ReadonlyArray<{ total: number; enabled: number }>): D
 
 function stubSummaryJoinDb(rows: SummaryJoinedRow[]): { db: Database; getSelectColumns: () => unknown; whereCalls: WhereCall[] } {
     const whereCalls: WhereCall[] = [];
+    const orderByCalls: OrderByCall[] = [];
     let selectColumns: unknown;
     const runSelect = (columns: unknown) => {
         selectColumns = columns;
-        return { from: () => buildJoinChainStub(whereCalls, rows) };
+        return { from: () => buildJoinChainStub(whereCalls, orderByCalls, rows) };
     };
     const db = { select: runSelect } as unknown as Database;
     return { db, whereCalls, getSelectColumns: () => selectColumns };
@@ -315,6 +337,16 @@ describe('createZonesRepository.loadEnabled', () => {
         const result = await repo.loadEnabled();
 
         expect(result).toEqual([]);
+    });
+
+    it('appends .orderBy(zones.id) so planner iteration is deterministic (API-69)', async () => {
+        const { db, orderByCalls } = stubLoaderDb([buildJoinedRow()]);
+        const repo = createZonesRepository(db);
+
+        await repo.loadEnabled();
+
+        expect(orderByCalls).toHaveLength(1);
+        expect(orderByCalls[0]).toContain(zones.id);
     });
 });
 

--- a/api/repositories/zones/index.ts
+++ b/api/repositories/zones/index.ts
@@ -66,13 +66,20 @@ export interface ZonesRepository {
 export function createZonesRepository(db: Database): ZonesRepository {
     return {
         loadEnabled: async () => {
+            // Stable `ORDER BY` is load-bearing for planner determinism. The
+            // daemon iterates this result and each zone's cycles reserve busy
+            // windows that constrain the next zone — without a fixed order,
+            // Postgres' heap-order results flip between calls (especially
+            // after any write) and produce different schedules from the same
+            // input state. See API-69.
             const rows = await db
                 .select({ zone: zones, grassType: grassTypes, soilType: soilTypes, site: sites })
                 .from(zones)
                 .innerJoin(grassTypes, eq(zones.grassTypeId, grassTypes.id))
                 .innerJoin(soilTypes, eq(zones.soilTypeId, soilTypes.id))
                 .innerJoin(sites, eq(zones.siteId, sites.id))
-                .where(eq(zones.isEnabled, true));
+                .where(eq(zones.isEnabled, true))
+                .orderBy(zones.id);
 
             const result = mapJoinedRowsToZones(rows);
             console.log(`zones: loaded ${result.length} enabled zone(s).`);


### PR DESCRIPTION
## Ticket

[API-69](http://192.168.2.100:7123/home/browse/API-69/) — Sort enabled zones in `loadEnabled` for deterministic planning.

## Summary

- Appends `.orderBy(zones.id)` to `loadEnabled()` in [api/repositories/zones/index.ts](api/repositories/zones/index.ts). Postgres heap-order results were flipping between calls (especially after writes), and since each zone's cycles reserve busy windows that constrain the next zone, swapping iteration order produced materially different schedules — exactly what the master-switch repro showed.
- Appends `.orderBy(schedules.id)` to `loadActiveBySite()` in [api/repositories/schedules/index.ts](api/repositories/schedules/index.ts). Latent today (the result is keyed into a Map, so iteration order doesn't bite), but a `.values()` consumer added later would inherit the same heap-order flakiness — closing the foot-gun now.
- Both production diffs are one-liners with rationale comments referencing API-69.
- Extends both repos' Drizzle-mimicking test stubs so `.where()` returns a thenable that also exposes `.orderBy()`. Adds 2 new tests asserting each method invokes `.orderBy(<id>)`.

## Test plan

- [x] `bun --cwd=./api test repositories/zones repositories/schedules` — 42 / 42 (2 new).
- [x] `bun --cwd=./api test` — 822 / 822 across 46 suites.
- [x] `bun --cwd=./api run type-check` — clean.
- [ ] Manual smoke (post-merge): toggle the master switch on twice in quick succession on the home screen and confirm both re-plans persist identical cycles (compare via `bun --cwd=./api run next-runs` or the DB).