### PR TITLE
[APP-46] Gate active-schedule chip RUNNING badge on run state

### DIFF
--- a/app/components/active-schedule-chip/.test.tsx
+++ b/app/components/active-schedule-chip/.test.tsx
@@ -23,13 +23,30 @@ const NO_NEXT_RUN_SCHEDULE: ScheduleListItem = {
 };
 
 describe('ActiveScheduleChip', () => {
-    it('renders the eyebrow, running indicator, schedule name, and countdown.', () => {
+    it('renders the eyebrow, schedule name, and countdown.', () => {
         render(<ActiveScheduleChip schedule={ACTIVE_SCHEDULE} onPress={() => {}} />);
 
         expect(screen.getByText('On profile')).toBeOnTheScreen();
-        expect(screen.getByText('RUNNING')).toBeOnTheScreen();
         expect(screen.getByText('Maintenance')).toBeOnTheScreen();
         expect(screen.getByText('8h 14m')).toBeOnTheScreen();
+    });
+
+    it('hides the RUNNING badge by default (active schedule not firing).', () => {
+        render(<ActiveScheduleChip schedule={ACTIVE_SCHEDULE} onPress={() => {}} />);
+
+        expect(screen.queryByText('RUNNING')).toBeNull();
+    });
+
+    it('hides the RUNNING badge when isRunning is false.', () => {
+        render(<ActiveScheduleChip schedule={ACTIVE_SCHEDULE} onPress={() => {}} isRunning={false} />);
+
+        expect(screen.queryByText('RUNNING')).toBeNull();
+    });
+
+    it('renders the RUNNING badge when isRunning is true.', () => {
+        render(<ActiveScheduleChip schedule={ACTIVE_SCHEDULE} onPress={() => {}} isRunning />);
+
+        expect(screen.getByText('RUNNING')).toBeOnTheScreen();
     });
 
     it('renders an em-dash countdown when nextRun is null.', () => {

--- a/app/components/active-schedule-chip/index.tsx
+++ b/app/components/active-schedule-chip/index.tsx
@@ -17,6 +17,9 @@ export type ActiveScheduleChipProps = {
 
     /** Required. Fires when the chip is pressed (caller routes to the Schedules screen). */
     onPress: () => void;
+
+    /** Whether the active schedule is currently firing. When false/omitted, the RUNNING dot + label are hidden. */
+    isRunning?: boolean;
 };
 
 /**
@@ -24,7 +27,7 @@ export type ActiveScheduleChipProps = {
  * active schedule's identity, running indicator, day mini-strip, and
  * next-run countdown. Tap routes to the Schedules screen.
  */
-export function ActiveScheduleChip({ schedule, onPress }: ActiveScheduleChipProps) {
+export function ActiveScheduleChip({ schedule, onPress, isRunning = false }: ActiveScheduleChipProps) {
     const days = useMemo(() => daysArrayFromAllowed(schedule.allowedDays), [schedule.allowedDays]);
     const countdown = schedule.nextRun?.inLabel ?? '—';
     const handlePress = useCallback(() => onPress(), [onPress]);
@@ -38,10 +41,12 @@ export function ActiveScheduleChip({ schedule, onPress }: ActiveScheduleChipProp
         >
             <View style={styles.headerRow}>
                 <Text style={styles.eyebrow}>On profile</Text>
-                <View style={styles.runningSlot}>
-                    <View style={styles.runningDot} />
-                    <Text style={styles.runningLabel}>RUNNING</Text>
-                </View>
+                {isRunning && (
+                    <View style={styles.runningSlot}>
+                        <View style={styles.runningDot} />
+                        <Text style={styles.runningLabel}>RUNNING</Text>
+                    </View>
+                )}
             </View>
 
             <View style={styles.bodyRow}>

--- a/app/components/home-view/.test.tsx
+++ b/app/components/home-view/.test.tsx
@@ -150,6 +150,29 @@ describe('HomeView', () => {
         expect(screen.getByText('8h 14m')).toBeOnTheScreen();
     });
 
+    it('hides the chip RUNNING badge when next-run state is scheduled (not firing).', async () => {
+        setupSuccessfulFetch();
+        render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+        expect(screen.queryByText('RUNNING')).toBeNull();
+    });
+
+    it('shows the chip RUNNING badge when next-run state is firing.', async () => {
+        mockFetch.mockImplementation(async (input: RequestInfo) => {
+            const url = typeof input === 'string' ? input : input.url;
+            if (url.endsWith('/system')) return jsonResponse(SAMPLE_SYSTEM);
+            if (url.endsWith('/tonight')) return jsonResponse({ ...NEXT_RUN_SCHEDULED, state: 'firing' });
+            if (url.endsWith('/zones')) return jsonResponse({ zones: SAMPLE_ZONES });
+            if (url.endsWith('/schedules')) return jsonResponse([ACTIVE_SCHEDULE]);
+            return jsonResponse({ error: 'unhandled' }, 500);
+        });
+
+        render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(screen.getByText('RUNNING')).toBeOnTheScreen());
+    });
+
     it('routes to /zone/<slug> when a zone tile is pressed.', async () => {
         setupSuccessfulFetch();
         render(<HomeView />, { wrapper: buildApiWrapper().wrapper });

--- a/app/components/home-view/index.tsx
+++ b/app/components/home-view/index.tsx
@@ -84,7 +84,11 @@ export function HomeView() {
                     )}
 
                     {activeSchedule !== null && (
-                        <ActiveScheduleChip schedule={activeSchedule} onPress={handleSchedulePress} />
+                        <ActiveScheduleChip
+                            schedule={activeSchedule}
+                            onPress={handleSchedulePress}
+                            isRunning={nextRun.data?.state === 'firing'}
+                        />
                     )}
                 </View>
             </SystemDisabledWrapper>


### PR DESCRIPTION
## Ticket

[APP-46](http://192.168.2.100:7123/home/browse/APP-46/) — Profile card shows incorrect always-on "RUNNING" badge and "running now" countdown.

## Summary

- Add optional `isRunning` prop (default `false`) to `ActiveScheduleChip` and gate the green-dot + `RUNNING` label JSX behind it. The chip is now presentational; consumers decide when the badge appears.
- `HomeView` passes `isRunning={nextRun.data?.state === 'firing'}` — same source of truth as the next-run hero.
- Updated chip + HomeView Jest suites: split the chip default-render test, added explicit hide-by-default / hide-when-false / show-when-true cases on the chip, and added scheduled-vs-firing assertions on the HomeView wiring. Full app suite green (63 suites / 457 tests).

The "running now" countdown text mentioned in the ticket is sourced from `/schedules` `nextRun.inLabel` and is left for a follow-up API ticket per the ticket description.