### PR TITLE
[API-70] Cache Open-Meteo responses with a 10-minute TTL

### DIFF
--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { fetchWithRetry, getWeatherData } from '.';
+import { __resetWeatherCacheForTests, fetchWithRetry, getWeatherData } from '.';
 
 // Production defaults wait 500 ms then 1500 ms between attempts; tests
 // short-circuit both via `minTimeout: 0` so the retry loop runs without
@@ -39,6 +39,7 @@ describe('Weather Data', () => {
 
     beforeEach(() => {
         mockFetch.mockClear();
+        __resetWeatherCacheForTests();
         errorSpy = spyOn(console, 'error').mockImplementation(() => {});
     });
 
@@ -310,6 +311,115 @@ describe('Weather Data', () => {
         const calledUrl = new URL((mockFetch.mock.calls[0] as any[])[0] as string);
         expect(calledUrl.hostname).toBe('api.open-meteo.com');
         expect(calledUrl.searchParams.get('apikey')).toBeNull();
+    });
+});
+
+describe('Weather caching', () => {
+    let errorSpy: ReturnType<typeof spyOn>;
+    let logSpy: ReturnType<typeof spyOn>;
+
+    const sampleResponse = {
+        latitude: 51.0,
+        longitude: -114.0,
+        generationtime_ms: 0.5,
+        utc_offset_seconds: 0,
+        timezone: 'GMT',
+        timezone_abbreviation: 'GMT',
+        elevation: 1045,
+        daily_units: {
+            time: 'iso8601',
+            sunrise: 'iso8601',
+            sunset: 'iso8601',
+            rain_sum: 'mm',
+            et0_fao_evapotranspiration: 'mm',
+        },
+        daily: {
+            time: ['2026-05-24', '2026-05-25'],
+            sunrise: ['2026-05-24T05:41', '2026-05-25T05:40'],
+            sunset: ['2026-05-24T21:24', '2026-05-25T21:25'],
+            rain_sum: [0, 0],
+            et0_fao_evapotranspiration: [4.0, 4.0],
+        },
+    };
+
+    const stubSuccess = () => mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => sampleResponse,
+    } as Response);
+
+    beforeEach(() => {
+        mockFetch.mockClear();
+        __resetWeatherCacheForTests();
+        errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+        logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        errorSpy.mockRestore();
+        logSpy.mockRestore();
+    });
+
+    it('returns the cached value on a second call within the TTL — no upstream fetch', async () => {
+        stubSuccess();
+        const fixedNow = () => 1_700_000_000_000;
+        const params = { latitude: 51.0447, longitude: -114.0719, forecastDays: 7, timezone: 'America/Edmonton' };
+
+        const first = await getWeatherData(params, { now: fixedNow });
+        const second = await getWeatherData(params, { now: fixedNow });
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(second).toBe(first); // reference-equal — same cached array
+    });
+
+    it('refetches after the TTL has expired', async () => {
+        stubSuccess();
+        stubSuccess();
+        let virtualNow = 1_700_000_000_000;
+        const now = () => virtualNow;
+        const params = { latitude: 51.0447, longitude: -114.0719 };
+
+        await getWeatherData(params, { now });
+        // Advance past the default 10 min TTL (with 1 ms slack).
+        virtualNow += 10 * 60_000 + 1;
+        await getWeatherData(params, { now });
+
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('keys the cache by (latitude, longitude, forecastDays, timezone) so each variant misses independently', async () => {
+        stubSuccess();
+        stubSuccess();
+        stubSuccess();
+        stubSuccess();
+        const fixedNow = () => 1_700_000_000_000;
+        const base = { latitude: 51.0, longitude: -114.0, forecastDays: 7, timezone: 'America/Edmonton' };
+
+        await getWeatherData(base, { now: fixedNow });
+        await getWeatherData({ ...base, latitude: 51.1 }, { now: fixedNow });
+        await getWeatherData({ ...base, forecastDays: 14 }, { now: fixedNow });
+        await getWeatherData({ ...base, timezone: 'UTC' }, { now: fixedNow });
+
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('does not populate the cache when the upstream call fails', async () => {
+        // Three persistent 503s exhaust the retry loop on the first attempt.
+        // Note: this test pays the ~2 s retry-backoff cost because
+        // `getWeatherData` doesn't expose `fetchWithRetry`'s timing knobs.
+        mockFetch
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
+            .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response);
+        const params = { latitude: 51.0, longitude: -114.0 };
+        await expect(getWeatherData(params, { now: () => 0 })).rejects.toThrow(/503/);
+
+        // Subsequent successful call should fetch again — proving the prior
+        // failure did not pollute the cache.
+        stubSuccess();
+        await getWeatherData(params, { now: () => 0 });
+
+        // 3 failed + 1 successful = 4 fetch attempts total.
+        expect(mockFetch).toHaveBeenCalledTimes(4);
     });
 });
 

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -52,6 +52,45 @@ export type WeatherDataParams = {
 };
 
 /**
+ * Optional second-arg knobs on `getWeatherData`. Tuned for test-injection of
+ * the cache clock and TTL; production callers pass nothing and inherit the
+ * 10-minute default. See API-70.
+ */
+export type WeatherDataOptions = {
+    /** Optional. Cache TTL override in ms. Defaults to `WEATHER_CACHE_TTL_MS`. */
+    ttlMs?: number;
+
+    /** Optional. Clock injection for testability. Defaults to `Date.now`. */
+    now?: () => number;
+};
+
+/**
+ * Process-local TTL cache for Open-Meteo responses. Open-Meteo's forecast can
+ * shift between calls within minutes (model refreshes, rolling forecast
+ * window, ET₀ adjustments); without caching, two back-to-back re-plans can
+ * produce different schedules from the same site state. See API-70.
+ *
+ * Keyed by `${latitude}|${longitude}|${forecastDays}|${timezone ?? ''}` — the
+ * full set of request parameters that vary between callers. `apiKey` is
+ * deliberately omitted; it's a process-wide constant, not a request input.
+ */
+type WeatherCacheEntry = { value: DailyWeather[]; expiresAt: number };
+const cache = new Map<string, WeatherCacheEntry>();
+
+/** 10 minutes — long enough to dedupe rapid re-plan storms, short enough that a "stale" forecast can't drift far from reality (Open-Meteo's model refreshes hourly). */
+const WEATHER_CACHE_TTL_MS = 10 * 60_000;
+
+/**
+ * Test seam. Clears every cached weather response so each `bun test` case
+ * starts with an empty cache.
+ *
+ * @internal
+ */
+export function __resetWeatherCacheForTests(): void {
+    cache.clear();
+}
+
+/**
  * `p-retry` timing defaults tuned for Open-Meteo's free-tier reliability
  * profile. 2 retries → 3 total attempts. `factor: 3` + `minTimeout: 500`
  * produces the 500 ms → 1500 ms backoff. Tests override `minTimeout` /
@@ -120,16 +159,33 @@ export async function fetchWithRetry(url: string, retryOptions: PRetryOptions = 
  * responses and network-layer errors are retried up to two times with
  * exponential backoff before the final failure surfaces to the caller.
  *
+ * Successful responses are cached for `WEATHER_CACHE_TTL_MS` (10 min) keyed
+ * by `(latitude, longitude, forecastDays, timezone)` so rapid re-plans see a
+ * stable forecast and produce deterministic schedules.
+ *
  * @param params - Weather data request parameters
+ * @param options - Cache TTL / clock overrides for tests
  * @returns Promise resolving to array of daily weather data
  * @throws Error if the API request fails after all retries
  */
-export async function getWeatherData(params: WeatherDataParams): Promise<DailyWeather[]> {
+export async function getWeatherData(
+    params: WeatherDataParams,
+    options?: WeatherDataOptions,
+): Promise<DailyWeather[]> {
     if (process.env.OPEN_METEO_ENABLED === 'false') {
         throw new Error('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
     }
 
     const { latitude, longitude, forecastDays = 7, timezone } = params;
+    const ttlMs = options?.ttlMs ?? WEATHER_CACHE_TTL_MS;
+    const now = options?.now ?? Date.now;
+
+    const cacheKey = `${latitude}|${longitude}|${forecastDays}|${timezone ?? ''}`;
+    const cached = cache.get(cacheKey);
+    if (cached !== undefined && cached.expiresAt > now()) {
+        console.log(`weather: cache hit for ${cacheKey}.`);
+        return cached.value;
+    }
 
     const apiKey = process.env.OPEN_METEO_API_KEY || undefined;
     const baseUrl = apiKey
@@ -156,10 +212,11 @@ export async function getWeatherData(params: WeatherDataParams): Promise<DailyWe
     const parseTime = (t: string): dayjs.Dayjs =>
         timezone ? dayjs.tz(t, timezone) : dayjs(t);
 
+    let parsed: DailyWeather[];
     try {
         const data = await response.json() as OpenMeteoResponse;
 
-        return data.daily.time.map((time, index) => ({
+        parsed = data.daily.time.map((time, index) => ({
             date: parseTime(time),
             sunrise: parseTime(data.daily.sunrise[index]!),
             sunset: parseTime(data.daily.sunset[index]!),
@@ -171,4 +228,9 @@ export async function getWeatherData(params: WeatherDataParams): Promise<DailyWe
         console.error(`weather: Open-Meteo response could not be parsed: ${detail}`);
         throw new Error(`Open-Meteo response parse error: ${detail}`);
     }
+
+    // Store only on successful parse — failed fetches and parse errors throw
+    // above without polluting the cache.
+    cache.set(cacheKey, { value: parsed, expiresAt: now() + ttlMs });
+    return parsed;
 }

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { runScheduleForZone } from '.';
+import { __resetWeatherCacheForTests } from '../data/weather';
 import { createTestZone } from '../mock/zone';
 
 const mockFetch = mock(() => Promise.resolve({} as Response));
@@ -37,6 +38,7 @@ const stubSuccess = () => mockFetch.mockResolvedValueOnce({
 describe('runScheduleForZone', () => {
     beforeEach(() => {
         mockFetch.mockClear();
+        __resetWeatherCacheForTests();
     });
 
     it(`passes the zone's location coordinates and default 7-day forecast to the weather API`, async () => {
@@ -113,6 +115,8 @@ describe('runScheduleForZone', () => {
     });
 
     it('forwards busyWindows to the planner so cycles avoid them', async () => {
+        // Single stub — the second `runScheduleForZone` call hits the API-70
+        // weather cache (same lat/lon/forecastDays/timezone) and skips fetch.
         stubSuccess();
         const zone = createTestZone({
             currentDepletionMm: 22,
@@ -122,7 +126,6 @@ describe('runScheduleForZone', () => {
         });
 
         // Baseline plan without busy windows — captures the natural cycle placement.
-        stubSuccess();
         const baseline = await runScheduleForZone(zone);
         const baselineCycle = baseline.entries[0]!.cycles[0]!;
         const baselineDay = baseline.entries[0]!.date.format('YYYY-MM-DD');
@@ -176,12 +179,15 @@ describe('runScheduleForZone', () => {
             location: { lat: 51.0447, lon: -114.0719 },
         });
 
-        // Baseline — Maintenance-style cadence against the stubbed 3-day forecast.
+        // Single stub — the second `runScheduleForZone` call hits the API-70
+        // weather cache (same lat/lon/forecastDays/timezone) and skips the
+        // fetch entirely.
         stubSuccess();
+
+        // Baseline — Maintenance-style cadence against the stubbed 3-day forecast.
         const baseline = await runScheduleForZone(zone);
 
         // Overseeding-style overrides: RAW ≈ 1.875 mm, ET ≈ 3.4 mm/day → daily.
-        stubSuccess();
         const overseeding = await runScheduleForZone(zone, {
             overrides: { rootDepthM: 0.05, allowableDepletionFraction: 0.25 },
         });


### PR DESCRIPTION
## Ticket

[API-70](http://192.168.2.100:7123/home/browse/API-70/) — Cache Open-Meteo weather responses.

## Summary

- Adds a process-local TTL cache inside `getWeatherData` in [api/data/weather/index.ts](api/data/weather/index.ts). Successful responses are stored under `${latitude}|${longitude}|${forecastDays}|${timezone ?? ''}` for 10 minutes. `apiKey` is deliberately excluded from the key (process-wide constant, not a request parameter).
- Adds a backward-compatible second arg `options?: { ttlMs?: number; now?: () => number }` so tests can inject the clock and TTL. Production callers (`runScheduleForZone` is the only one) keep their call sites unchanged.
- Exports `__resetWeatherCacheForTests()` as an `@internal` test seam; weather tests + the `runScheduleForZone` suite call it in `beforeEach` for clean isolation.
- Cache writes happen **after** successful parse, so failed fetches and parse errors never pollute the cache (covered by a regression test).
- Two existing schedule tests that queued two stubSuccess calls were tightened to one — the second `runScheduleForZone` call now hits the cache rather than the queue. Annotated inline so the reduction is intentional, not an oversight.

## Test plan

- [x] `bun --cwd=./api test data/weather` — 24 / 24 (4 new caching tests).
- [x] `bun --cwd=./api test` — 826 / 826 across 46 suites.
- [x] `bun --cwd=./api run type-check` — clean.
- [ ] Manual smoke (post-merge): toggle the master switch on/off rapidly; api logs should show one `weather: fetched …` line per 10-minute window followed by `weather: cache hit for …` for subsequent rapid re-plans.