### PR TITLE
Fix oversaturated canvas glow gradient

### DIFF
--- a/app/components/canvas-background.test.tsx
+++ b/app/components/canvas-background.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from '@testing-library/react-native';
 import { StyleSheet, Text } from 'react-native';
+import { Stop } from 'react-native-svg';
 
-import { CanvasBackground } from './canvas-background';
+import {
+    BLUE_GLOW_COLOR,
+    BLUE_GLOW_OPACITY,
+    CanvasBackground,
+    GREEN_GLOW_COLOR,
+    GREEN_GLOW_OPACITY,
+} from './canvas-background';
 
 describe('CanvasBackground', () => {
     it('renders under the default `Irrigo canvas` accessibility label and passes children through.', () => {
@@ -35,5 +42,34 @@ describe('CanvasBackground', () => {
         const root = screen.getByLabelText('Irrigo canvas');
         const style = StyleSheet.flatten(root.props.style) as { backgroundColor?: string };
         expect(style.backgroundColor).toBe('#06090A');
+    });
+
+    it('exposes glow hex colors with alpha split into stopOpacity (renderer-safe form).', () => {
+        // Regression guard: prior implementation baked alpha into rgba() on
+        // `stopColor`, which `react-native-svg` 15.x does not honor on
+        // Android — the canvas rendered as a saturated green/blue gradient
+        // instead of a near-black backdrop with subtle tints.
+        expect(GREEN_GLOW_COLOR).toMatch(/^#[0-9A-Fa-f]{6}$/);
+        expect(BLUE_GLOW_COLOR).toMatch(/^#[0-9A-Fa-f]{6}$/);
+        expect(GREEN_GLOW_OPACITY).toBeLessThan(0.2);
+        expect(BLUE_GLOW_OPACITY).toBeLessThan(0.2);
+    });
+
+    it('renders each gradient with the inner stop using stopOpacity, not rgba alpha in stopColor.', () => {
+        const { root } = render(
+            <CanvasBackground>
+                <Text>child</Text>
+            </CanvasBackground>,
+        );
+
+        const stops = root.findAllByType(Stop);
+        expect(stops.length).toBe(4);
+
+        for (const stop of stops) {
+            const stopColor = stop.props.stopColor as string;
+            expect(stopColor).not.toContain('rgba');
+            expect(stopColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+            expect(stop.props.stopOpacity).toBeDefined();
+        }
     });
 });

--- a/app/components/canvas-background.tsx
+++ b/app/components/canvas-background.tsx
@@ -15,10 +15,15 @@ export type CanvasBackgroundProps = PropsWithChildren<{
 }>;
 
 const BACKGROUND_COLOR = colors.bg;
-// Soft canvas-backdrop tints shared with the modal scrim (grass-glow-3) and
-// info-tinted surfaces (water-glow). See `tailwind.config.ts`.
-const GREEN_GLOW = colors['grass-glow-3'];
-const BLUE_GLOW = colors['water-glow'];
+// Base hex + explicit alpha for each glow. `react-native-svg` does not
+// honor the alpha channel inside an rgba(...) `stopColor` string on every
+// platform, so the canvas tints render saturated when alpha is baked into
+// the color. Splitting the color from `stopOpacity` is the renderer-safe
+// form. Alphas match `grass-glow-3` / `water-glow` in `tailwind.config.ts`.
+export const GREEN_GLOW_COLOR = colors['grass-500'];
+export const GREEN_GLOW_OPACITY = 0.07;
+export const BLUE_GLOW_COLOR = colors['water-500'];
+export const BLUE_GLOW_OPACITY = 0.04;
 
 const GREEN_GRADIENT_ID = 'irrigoCanvasGreenGlow';
 const BLUE_GRADIENT_ID = 'irrigoCanvasBlueGlow';
@@ -36,12 +41,12 @@ export function CanvasBackground({ accessibilityLabel = 'Irrigo canvas', childre
             <Svg style={StyleSheet.absoluteFill} width='100%' height='100%' pointerEvents='none'>
                 <Defs>
                     <RadialGradient id={GREEN_GRADIENT_ID} cx='20%' cy='-5%' r='50%' fx='20%' fy='-5%'>
-                        <Stop offset='0%' stopColor={GREEN_GLOW} />
-                        <Stop offset='100%' stopColor={GREEN_GLOW} stopOpacity={0} />
+                        <Stop offset='0%' stopColor={GREEN_GLOW_COLOR} stopOpacity={GREEN_GLOW_OPACITY} />
+                        <Stop offset='100%' stopColor={GREEN_GLOW_COLOR} stopOpacity={0} />
                     </RadialGradient>
                     <RadialGradient id={BLUE_GRADIENT_ID} cx='90%' cy='50%' r='50%' fx='90%' fy='50%'>
-                        <Stop offset='0%' stopColor={BLUE_GLOW} />
-                        <Stop offset='100%' stopColor={BLUE_GLOW} stopOpacity={0} />
+                        <Stop offset='0%' stopColor={BLUE_GLOW_COLOR} stopOpacity={BLUE_GLOW_OPACITY} />
+                        <Stop offset='100%' stopColor={BLUE_GLOW_COLOR} stopOpacity={0} />
                     </RadialGradient>
                 </Defs>
                 <Rect width='100%' height='100%' fill={`url(#${GREEN_GRADIENT_ID})`} />


### PR DESCRIPTION
## Summary

The Home canvas was rendering as a saturated light-green-to-blue gradient instead of the intended near-black backdrop with subtle radial tints.

## Root cause

`react-native-svg` 15.x (on Android in particular) does not honor the alpha channel inside an `rgba(...)` string passed to `<Stop stopColor>`. The previous implementation in `canvas-background.tsx` set:

```tsx
<Stop offset='0%' stopColor='rgba(111, 227, 155, 0.07)' />
```

The renderer stripped the alpha and applied the default `stopOpacity={1}`, painting the inner stop at full saturation. The outer stop (which had an explicit `stopOpacity={0}`) was fine, hence the visible gradient.

## Fix

Split the color from the alpha — pass solid hex via `stopColor` and the alpha via `stopOpacity`, which is the documented SVG approach:

```tsx
<Stop offset='0%' stopColor={GREEN_GLOW_COLOR} stopOpacity={GREEN_GLOW_OPACITY} />
```

The hex base values (`grass-500` / `water-500`) and target alphas (0.07 / 0.04) match the legacy `grass-glow-3` / `water-glow` tokens, so the intended visual is preserved.

Added two regression-guard assertions to `canvas-background.test.tsx`:
- glow constants are 6-digit hex with subtle alphas
- every rendered `<Stop>` uses solid hex (`stopColor` contains no `rgba`) and has a defined `stopOpacity`

Full app suite: 63 suites / 459 tests passing.