### PR TITLE
[APP-47] Standardize home-page card style on accent border + elevated background

### DIFF
--- a/app/components/active-schedule-chip/.test.tsx
+++ b/app/components/active-schedule-chip/.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet, type ViewStyle } from 'react-native';
 
 import { ActiveScheduleChip } from '.';
 import type { ScheduleListItem } from '@/api/types/schedules';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
 
 const ACTIVE_SCHEDULE: ScheduleListItem = {
     id: 'sched-active',
@@ -68,5 +72,15 @@ describe('ActiveScheduleChip', () => {
         fireEvent.press(screen.getByLabelText('Open Schedules — active profile Maintenance'));
 
         expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the elevated background and accent-border per the APP-47 home-card standard.', () => {
+        render(<ActiveScheduleChip schedule={ACTIVE_SCHEDULE} onPress={() => {}} />);
+
+        const card = screen.getByLabelText('Open Schedules — active profile Maintenance');
+        const style = StyleSheet.flatten(card.props.style) as ViewStyle;
+
+        expect(style.backgroundColor).toBe(colors.elevated);
+        expect(style.borderColor).toBe(colors['accent-border']);
     });
 });

--- a/app/components/active-schedule-chip/index.tsx
+++ b/app/components/active-schedule-chip/index.tsx
@@ -79,9 +79,9 @@ export function ActiveScheduleChip({ schedule, onPress, isRunning = false }: Act
 
 const styles = StyleSheet.create({
     card: {
-        backgroundColor: colors.surface,
+        backgroundColor: colors.elevated,
         borderWidth: 1,
-        borderColor: colors.border,
+        borderColor: colors['accent-border'],
         borderLeftWidth: 3,
         borderLeftColor: colors.accent,
         padding: 14,

--- a/app/components/zone-tile/.test.tsx
+++ b/app/components/zone-tile/.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet, type ViewStyle } from 'react-native';
 
 import { ZoneTile } from '.';
 import type { ZoneSummary } from '@/api/types/zones';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
 
 const NOW = new Date('2026-05-24T15:00:00.000Z');
 
@@ -86,5 +90,15 @@ describe('ZoneTile', () => {
 
         expect(onPress).toHaveBeenCalledTimes(1);
         expect(onPress).toHaveBeenCalledWith(HEALTHY_ZONE);
+    });
+
+    it('uses the elevated background and accent-border per the APP-47 home-card standard.', () => {
+        render(<ZoneTile zone={HEALTHY_ZONE} onPress={() => {}} now={NOW} />);
+
+        const card = screen.getByLabelText('Open North');
+        const style = StyleSheet.flatten(card.props.style) as ViewStyle;
+
+        expect(style.backgroundColor).toBe(colors.elevated);
+        expect(style.borderColor).toBe(colors['accent-border']);
     });
 });

--- a/app/components/zone-tile/index.tsx
+++ b/app/components/zone-tile/index.tsx
@@ -74,9 +74,9 @@ export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
 
 const styles = StyleSheet.create({
     card: {
-        backgroundColor: colors.surface,
+        backgroundColor: colors.elevated,
         borderWidth: 1,
-        borderColor: colors.border,
+        borderColor: colors['accent-border'],
         borderRadius: 4,
         padding: 14,
         gap: 10,


### PR DESCRIPTION
## Ticket

[APP-47](http://192.168.2.100:7123/home/browse/APP-47/) — Standardize home-page card style on accent border + elevated background.

## Summary

- [app/components/zone-tile/index.tsx](app/components/zone-tile/index.tsx) card style: `backgroundColor: surface → elevated`; `borderColor: border → accent-border`. The `pastRaw` danger-red treatment on the depletion number + footer is unchanged.
- [app/components/active-schedule-chip/index.tsx](app/components/active-schedule-chip/index.tsx) card style: same two swaps. The 3px solid-accent left stripe is preserved — it still adds a "this is the active profile" emphasis on top of the now-thinner accent border on the other three sides.
- `next-run-hero`'s `cardEmpty` branch (grey-bordered "nothing tonight" state) deliberately stays grey for contrast with the new accent-bordered neighbours.
- Added one style-snapshot test per component locking in the new background + border colour via `StyleSheet.flatten`.

## Test plan

- [x] `bun --cwd=./app run test components/zone-tile components/active-schedule-chip` — 15 / 15 (2 new).
- [x] `bun --cwd=./app run test` — 459 / 459 across 63 suites.
- [x] `bun --cwd=./app run typecheck` — clean (modulo the pre-existing `app/modal.tsx` expo-router typed-routes error).
- [ ] Manual smoke (post-merge): open Home and confirm the Master Toggle, Next Run hero, both Zone Tiles, and the active-schedule chip all share the lighter background + green accent border, while the `cardEmpty` state (no zones queued) still renders with the grey border.