### PR TITLE
[API-71] Remove depletion write from planner; advance on relay close and nightly tick

### DIFF
--- a/api/repositories/schedule-entries/.test.ts
+++ b/api/repositories/schedule-entries/.test.ts
@@ -193,7 +193,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
         const repo = createScheduleEntriesRepository(db);
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
 
-        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
+        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 'sched-default');
 
         expect(deleteCalls).toHaveLength(1);
         expect(deleteCalls[0]?.table).toBe(scheduleEntries);
@@ -208,7 +208,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
             buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
         ];
 
-        await repo.replaceForZone('zone-001', entries, dayjs('2026-05-04'), 0, 'sched-overseed');
+        await repo.replaceForZone('zone-001', entries, dayjs('2026-05-04'), 'sched-overseed');
 
         const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
         expect(entryInserts).toHaveLength(2);
@@ -225,7 +225,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
             buildEntry('2026-05-06', [{ startTime: '2026-05-06T05:00:00Z', durationMin: 25 }]),
         ];
 
-        await repo.replaceForZone('zone-001', entries, dayjs('2026-05-04'), 0, 'sched-default');
+        await repo.replaceForZone('zone-001', entries, dayjs('2026-05-04'), 'sched-default');
 
         const entryInserts = insertCalls.filter(c => c.table === scheduleEntries);
         expect(entryInserts).toHaveLength(2);
@@ -247,7 +247,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
             { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
         ]);
 
-        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
+        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 'sched-default');
 
         const cycleInserts = insertCalls.filter(c => c.table === irrigationCycles);
         expect(cycleInserts).toHaveLength(1);
@@ -270,7 +270,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
             { startTime: '2026-05-04T05:30:00Z', durationMin: 15 },
         ]);
 
-        const result = await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
+        const result = await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 'sched-default');
 
         expect(result.cycles).toHaveLength(2);
         expect(result.cycles[0]?.id).toBe('cycle-A1');
@@ -292,7 +292,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
             buildEntry('2026-05-05', [{ startTime: '2026-05-05T05:00:00Z', durationMin: 15 }]),
         ];
 
-        const result = await repo.replaceForZone('zone-001', entries, dayjs('2026-05-04'), 0, 'sched-default');
+        const result = await repo.replaceForZone('zone-001', entries, dayjs('2026-05-04'), 'sched-default');
 
         expect(result.cycles).toHaveLength(2);
         expect(result.cycles[0]?.entryDate).toBe('2026-05-04');
@@ -303,7 +303,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
         const { db, deleteCalls, insertCalls } = stubWriterDb();
         const repo = createScheduleEntriesRepository(db);
 
-        const result = await repo.replaceForZone('zone-001', [], dayjs('2026-05-04'), 0, 'sched-default');
+        const result = await repo.replaceForZone('zone-001', [], dayjs('2026-05-04'), 'sched-default');
 
         expect(deleteCalls).toHaveLength(1);
         expect(insertCalls).toHaveLength(0);
@@ -315,33 +315,11 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
         const repo = createScheduleEntriesRepository(db);
         const entry = buildEntry('2026-05-04', []);
 
-        const result = await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
+        const result = await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 'sched-default');
 
         expect(insertCalls.filter(c => c.table === scheduleEntries)).toHaveLength(1);
         expect(insertCalls.filter(c => c.table === irrigationCycles)).toHaveLength(0);
         expect(result.cycles).toEqual([]);
-    });
-
-    it('writes the projected next-day depletion to zones.current_depletion_mm', async () => {
-        const { db, updateCalls } = stubWriterDb();
-        const repo = createScheduleEntriesRepository(db);
-        const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
-
-        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 7.5, 'sched-default');
-
-        expect(updateCalls).toHaveLength(1);
-        expect(updateCalls[0]?.table).toBe(zones);
-        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 7.5 });
-    });
-
-    it('writes the depletion update even when the entries array is empty', async () => {
-        const { db, updateCalls } = stubWriterDb();
-        const repo = createScheduleEntriesRepository(db);
-
-        await repo.replaceForZone('zone-002', [], dayjs('2026-05-04'), 12.3, 'sched-default');
-
-        expect(updateCalls).toHaveLength(1);
-        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 12.3 });
     });
 
     it('persists sunriseAt and sunsetAt as JS Dates on the schedule_entries insert', async () => {
@@ -355,7 +333,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
             sunsetAt: sunset,
         };
 
-        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
+        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 'sched-default');
 
         const entryInsert = insertCalls.find(c => c.table === scheduleEntries);
         expect(entryInsert?.rows[0]?.['sunriseAt']).toBeInstanceOf(Date);
@@ -369,7 +347,7 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
         const repo = createScheduleEntriesRepository(db);
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
 
-        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
+        await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 'sched-default');
 
         const entryInsert = insertCalls.find(c => c.table === scheduleEntries);
         expect(entryInsert?.rows[0]?.['sunriseAt']).toBeNull();

--- a/api/repositories/schedule-entries/index.ts
+++ b/api/repositories/schedule-entries/index.ts
@@ -61,14 +61,12 @@ export interface ScheduleEntriesRepository {
 
     /**
      * Replaces today's-and-future schedule_entries for a zone with the
-     * planner's fresh output. Also writes `current_depletion_mm` on the zone
-     * (per-zone atomic with the schedule write).
+     * planner's fresh output. Pure write — does not touch `current_depletion_mm`.
      */
     replaceForZone(
         zoneId: string,
         entries: ReadonlyArray<IrrigationScheduleEntry>,
         today: dayjs.Dayjs,
-        projectedNextDepletionMm: number,
         scheduleId: string,
     ): Promise<ReplaceForZoneResult>;
 
@@ -137,7 +135,7 @@ export function createScheduleEntriesRepository(db: Database): ScheduleEntriesRe
             return pairs;
         },
 
-        replaceForZone: async (zoneId, entries, today, projectedNextDepletionMm, scheduleId) => {
+        replaceForZone: async (zoneId, entries, today, scheduleId) => {
             const todayIso = today.format('YYYY-MM-DD');
             console.log(`schedule-entries: replacing schedule for zone ${zoneId} from ${todayIso} (${entries.length} entry/entries).`);
 
@@ -197,12 +195,6 @@ export function createScheduleEntriesRepository(db: Database): ScheduleEntriesRe
                     });
                 }
             }
-
-            await db
-                .update(zones)
-                .set({ currentDepletionMm: projectedNextDepletionMm })
-                .where(eq(zones.id, zoneId));
-            console.log(`schedule-entries: persisted current_depletion_mm=${projectedNextDepletionMm} for zone ${zoneId}.`);
 
             return { cycles: persisted };
         },

--- a/api/repositories/zones/.test.ts
+++ b/api/repositories/zones/.test.ts
@@ -397,6 +397,46 @@ describe('createZonesRepository.loadJoinedRowsForSummary', () => {
     });
 });
 
+function stubUpdateDb(): { db: Database; updateCalls: Array<{ table: unknown; values: Record<string, unknown>; conditions: unknown }> } {
+    const updateCalls: Array<{ table: unknown; values: Record<string, unknown>; conditions: unknown }> = [];
+    const db = {
+        update: (table: unknown) => ({
+            set: (values: Record<string, unknown>) => ({
+                where: (conditions: unknown) => {
+                    updateCalls.push({ table, values, conditions });
+                    return Promise.resolve();
+                },
+            }),
+        }),
+    } as unknown as Database;
+    return { db, updateCalls };
+}
+
+describe('createZonesRepository.advanceDepletion', () => {
+    it('issues a single UPDATE on zones with the supplied depletionMm value', async () => {
+        const { db, updateCalls } = stubUpdateDb();
+        const repo = createZonesRepository(db);
+
+        await repo.advanceDepletion('zone-001', 7.5);
+
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0]?.table).toBe(zones);
+        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 7.5 });
+    });
+
+    it('issues a separate UPDATE for each call (two zones produce two updates)', async () => {
+        const { db, updateCalls } = stubUpdateDb();
+        const repo = createZonesRepository(db);
+
+        await repo.advanceDepletion('zone-A', 3.2);
+        await repo.advanceDepletion('zone-B', 0);
+
+        expect(updateCalls).toHaveLength(2);
+        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 3.2 });
+        expect(updateCalls[1]?.values).toEqual({ currentDepletionMm: 0 });
+    });
+});
+
 describe('createZonesRepository.loadLatestScheduleEntries', () => {
     it('returns the rows produced by the distinct-on query', async () => {
         const entries: LatestZoneFire[] = [

--- a/api/repositories/zones/index.ts
+++ b/api/repositories/zones/index.ts
@@ -55,6 +55,14 @@ export interface ZonesRepository {
 
     /** Loads the most-recent `schedule_entries` row per zone (one row per zone that has fired). */
     loadLatestScheduleEntries(): Promise<LatestZoneFire[]>;
+
+    /**
+     * Writes `current_depletion_mm` for the zone. Called by the daemon on two
+     * paths: (1) the nightly scheduled re-plan, which persists
+     * `projectedNextDepletionMm` as the next morning's starting depletion; and
+     * (2) `runClose`, which resets depletion to 0 after irrigation actually fires.
+     */
+    advanceDepletion(zoneId: string, depletionMm: number): Promise<void>;
 }
 
 /**
@@ -131,6 +139,11 @@ export function createZonesRepository(db: Database): ZonesRepository {
                 })
                 .from(scheduleEntries)
                 .orderBy(scheduleEntries.zoneId, desc(scheduleEntries.date));
+        },
+
+        advanceDepletion: async (zoneId, depletionMm) => {
+            await db.update(zones).set({ currentDepletionMm: depletionMm }).where(eq(zones.id, zoneId));
+            console.log(`zones: advanced current_depletion_mm=${depletionMm} for zone ${zoneId}.`);
         },
     };
 }

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -222,7 +222,7 @@ type DaemonStubInputs = {
 
 function createDaemonReposStub(inputs?: DaemonStubInputs) {
     const cycleUpdates: CycleUpdate[] = [];
-    const zoneUpdates: Array<{ zoneId: string; currentDepletionMm: number }> = [];
+    const depletionAdvances: Array<{ zoneId: string; depletionMm: number }> = [];
     const inserts: InsertCall[] = [];
     const deletes: Array<{ table: unknown }> = [];
     const weatherStateUpserts: Array<Record<string, unknown>> = [];
@@ -267,6 +267,12 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         count: async () => counts,
         loadJoinedRowsForSummary: async () => [],
         loadLatestScheduleEntries: async () => [],
+        advanceDepletion: async (zoneId, depletionMm) => {
+            depletionAdvances.push({ zoneId, depletionMm });
+            for (const row of enabledZoneRows) {
+                if (row.zone.id === zoneId) row.zone.currentDepletionMm = depletionMm;
+            }
+        },
     };
 
     let weatherStateRow: Date | null = inputs?.lastSuccessfulFetchAt ?? null;
@@ -323,7 +329,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
             if (inputs?.inFlightCyclesError) throw inputs.inFlightCyclesError;
             return inputs?.inFlightCycles ?? [];
         },
-        replaceForZone: async (zoneId, entries, _today, projectedNextDepletionMm, scheduleId) => {
+        replaceForZone: async (zoneId, entries, _today, scheduleId) => {
             deletes.push({ table: scheduleEntries });
             const cycles: PersistedCycle[] = [];
             for (const entry of entries) {
@@ -359,11 +365,6 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
                     });
                 }
             }
-            zoneUpdates.push({ zoneId, currentDepletionMm: projectedNextDepletionMm });
-            // Reflect the write back into the stubbed enabledZones so the next load returns it.
-            for (const row of enabledZoneRows) {
-                if (row.zone.id === zoneId) row.zone.currentDepletionMm = projectedNextDepletionMm;
-            }
             return { cycles };
         },
         markCycleFired: async (cycleId, firedAt) => {
@@ -386,7 +387,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         repos: { zones: zonesRepo, sites: sitesRepo, schedules: schedulesRepo, scheduleEntries: scheduleEntriesRepo, weatherState: weatherStateRepo },
         alertsDb,
         cycleUpdates,
-        zoneUpdates,
+        depletionAdvances,
         inserts,
         deletes,
         weatherStateUpserts,
@@ -817,32 +818,63 @@ describe('start', () => {
         expect(closes).toEqual([futureRow.zone.id]);
     });
 
-    it('persists projected depletion so the next rePlan reads the updated value, not the seed', async () => {
+    it('nightly tick advances currentDepletionMm; public rePlan() is idempotent (no depletion write)', async () => {
+        // API-71: operator replans must not mutate zone depletion; only the
+        // nightly scheduled tick (isScheduledTick=true) should call advanceDepletion.
+        // NOW = 2026-05-04T12:00:00Z; with rePlanHourLocal=20 + UTC the tick fires
+        // 8h later at 2026-05-04T20:00:00Z.
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-001', currentDepletionMm: 0 } });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 7.5 }),
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        // Advance past the nightly re-plan tick (20:00 UTC, 8h from NOW=12:00).
+        await advanceTo(new Date('2026-05-04T20:00:01.000Z'));
+
+        expect(stub.depletionAdvances).toEqual([
+            { zoneId: 'zone-001', depletionMm: 7.5 },
+        ]);
+    });
+
+    it('two consecutive operator rePlan() calls produce no depletionAdvances (API-71 regression)', async () => {
         const enabledRow = buildJoinedRow({ zone: { id: 'zone-001', currentDepletionMm: 0 } });
         const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
         bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
         const { clock } = createFakeClock(NOW);
-        const seenDepletionsByCall: number[] = [];
+        const insertsAfterFirst: number[] = [];
 
         const control = await start({
             clock,
             rePlanHourLocal: 4,
-            runPlan: async zone => {
-                seenDepletionsByCall.push(zone.currentDepletionMm);
-                return { entries: [], projectedNextDepletionMm: 7.5 };
-            },
+            runPlan: async () => ({
+                entries: [buildEntry('2026-05-05', [{ startTime: '2026-05-05T05:00:00Z', durationMin: 20 }])],
+                projectedNextDepletionMm: 7.5,
+            }),
             openZone: async () => {},
             closeZone: async () => {},
         });
 
         await control.rePlan();
-        await control.rePlan();
+        insertsAfterFirst.push(stub.inserts.filter(c => c.table === scheduleEntries).length);
+        const insertsSnapshot = stub.inserts.filter(c => c.table === scheduleEntries).map(i => i.rows[0]);
 
-        expect(stub.zoneUpdates).toEqual([
-            { zoneId: 'zone-001', currentDepletionMm: 7.5 },
-            { zoneId: 'zone-001', currentDepletionMm: 7.5 },
-        ]);
-        expect(seenDepletionsByCall).toEqual([0, 7.5]);
+        await control.rePlan();
+        const insertsAfterSecond = stub.inserts.filter(c => c.table === scheduleEntries);
+
+        // No depletion should have been written by either operator replan.
+        expect(stub.depletionAdvances).toHaveLength(0);
+        // Both replans should produce the same schedule entries (idempotent).
+        expect(insertsAfterSecond).toHaveLength(insertsAfterFirst[0]! * 2);
+        expect(insertsAfterSecond[0]?.rows[0]).toEqual(insertsSnapshot[0]);
     });
 
     it('does not emit schedule-begun or schedule-ended for boot-armed cycles', async () => {

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -166,15 +166,19 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         const delay = Math.max(0, next.getTime() - clock.now().getTime());
         console.log(`daemon: next re-plan scheduled at ${next.toISOString()} (${delay}ms from now).`);
         const handle = clock.setTimeout(() => {
-            rePlan().catch(err => {
+            _rePlan(true).catch(err => {
                 console.error('daemon: unhandled error in scheduled re-plan.', err);
             });
         }, delay);
         registry.setRePlanHandle(handle);
     };
 
-    const rePlan = async (): Promise<void> => {
-        console.log('daemon: re-plan starting.');
+    // Private implementation. `isScheduledTick` distinguishes the nightly
+    // daemon-scheduled re-plan (which should persist projectedNextDepletionMm
+    // so tomorrow's plan starts honest) from operator-triggered replans (which
+    // must be idempotent and must not mutate zone state). See API-71.
+    const _rePlan = async (isScheduledTick: boolean): Promise<void> => {
+        console.log(`daemon: re-plan starting (scheduled=${isScheduledTick}).`);
         registry.cancelOpenTimers(clock);
 
         const system = await getSystemState();
@@ -222,8 +226,14 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                     forecastDays: 14,
                 });
                 const { cycles } = await scheduleEntriesRepo.replaceForZone(
-                    zone.id, entries, today, projectedNextDepletionMm, activeSchedule.id,
+                    zone.id, entries, today, activeSchedule.id,
                 );
+                // Only the nightly scheduled tick advances currentDepletionMm.
+                // Operator replans (isScheduledTick=false) are intentionally
+                // idempotent — they plan against current state without mutating it.
+                if (isScheduledTick) {
+                    await zonesRepo.advanceDepletion(zone.id, projectedNextDepletionMm);
+                }
                 for (const cycle of cycles) {
                     const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);
                     const overlaps = busyWindows.some(w => cycle.startTime < w.end && cycleEnd > w.start);
@@ -265,6 +275,8 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         scheduleNextRePlan();
         console.log('daemon: re-plan complete.');
     };
+
+    const rePlan = (): Promise<void> => _rePlan(false);
 
     const shutdown = async (): Promise<void> => {
         console.log('daemon: shutdown starting.');

--- a/api/service/daemon/reconcile.test.ts
+++ b/api/service/daemon/reconcile.test.ts
@@ -86,6 +86,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonService
             count: async () => ({ total: 0, enabled: 0 }),
             loadJoinedRowsForSummary: async () => [],
             loadLatestScheduleEntries: async () => [],
+            advanceDepletion: async () => {},
         },
         sites: { loadTimezone: async () => 'UTC' },
         schedules: {

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -112,7 +112,7 @@ function recordingScheduleEntriesRepo(): { repo: ScheduleEntriesRepository; upda
     return { repo, updates };
 }
 
-function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonServiceRepos {
+function defaultRepos(scheduleEntries: ScheduleEntriesRepository, onAdvanceDepletion?: (zoneId: string, mm: number) => void): DaemonServiceRepos {
     return {
         zones: {
             loadEnabled: async () => [],
@@ -120,6 +120,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonService
             count: async () => ({ total: 0, enabled: 0 }),
             loadJoinedRowsForSummary: async () => [],
             loadLatestScheduleEntries: async () => [],
+            advanceDepletion: async (zoneId, mm) => { onAdvanceDepletion?.(zoneId, mm); },
         },
         sites: { loadTimezone: async () => 'UTC' },
         schedules: {
@@ -241,6 +242,32 @@ describe('armCycle', () => {
         await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
 
         expect(calls.some(c => c.event === 'schedule-begun')).toBe(true);
+    });
+
+    it('calls advanceDepletion(zone.id, 0) on the zones repo after the relay closes', async () => {
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const registry = new TimerRegistry();
+        const { notifier } = recordingNotifier();
+        const { alerter } = recordingAlerter();
+        const { repo } = recordingScheduleEntriesRepo();
+        const depletionAdvances: Array<{ zoneId: string; mm: number }> = [];
+        setDaemonRepos({ repos: defaultRepos(repo, (zoneId, mm) => depletionAdvances.push({ zoneId, mm })) });
+
+        armCycle({
+            clock,
+            registry,
+            zone: buildZone({ id: 'zone-depletion' }),
+            cycle: buildCycle({ id: 'cycle-dep', durationMin: 5 }),
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier,
+            alerter,
+        });
+
+        await advanceTo(new Date('2026-05-04T13:05:01.000Z'));
+
+        expect(depletionAdvances).toHaveLength(1);
+        expect(depletionAdvances[0]).toEqual({ zoneId: 'zone-depletion', mm: 0 });
     });
 
     it('records HA open-failure alert and skips firedAt write on openZone error', async () => {

--- a/api/service/daemon/runtime.ts
+++ b/api/service/daemon/runtime.ts
@@ -2,7 +2,7 @@ import type { Alerter } from '@/alerts';
 import type { Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import type { Notifier } from '@/notifications';
-import { getScheduleEntriesRepo } from './state';
+import { getScheduleEntriesRepo, getZonesRepo } from './state';
 
 /**
  * Opaque handle returned by `Clock.setTimeout`. The runtime doesn't introspect
@@ -234,6 +234,7 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
 
     const closedAt = clock.now();
     await getScheduleEntriesRepo().markCycleClosed(cycle.id, closedAt);
+    await getZonesRepo().advanceDepletion(zone.id, 0);
     registry.clearInFlight(cycle.id);
     console.log(`daemon: closed zone ${zone.id} for cycle ${cycle.id} at ${closedAt.toISOString()}.`);
 


### PR DESCRIPTION
## Ticket

[API-71](http://192.168.2.100:7123/home/browse/API-71/) Planner self-mutates current_depletion_mm, breaking re-plan determinism

## Summary

- `replaceForZone` no longer writes `projectedNextDepletionMm` back to `zones.current_depletion_mm` — every call to the planner is now a pure read of zone state, making operator replans idempotent.
- Added `ZonesRepository.advanceDepletion(zoneId, mm)` with two correct callsites: (1) `runClose` resets to 0 when a relay closes (soil is refilled); (2) the nightly 20:00 `_rePlan(isScheduledTick=true)` writes `projectedNextDepletionMm` so tomorrow's plan starts from an honest depletion baseline.
- An `isScheduledTick` flag on the internal `_rePlan` function distinguishes the daemon's nightly timer from operator HTTP replans, which must not mutate zone state.