### PR TITLE
[API-72] Don't schedule irrigation cycles before 12am local

### DIFF
--- a/api/db/schema/schedule-entries.ts
+++ b/api/db/schema/schedule-entries.ts
@@ -17,8 +17,5 @@ export const scheduleEntries = pgTable('schedule_entries', {
     // rows (and rows from a planner that hasn't been re-run since this column
     // was added) read as null — the wire layer surfaces that as `null`.
     sunriseAt: timestamp('sunrise_at', { withTimezone: true }),
-    // Sunset of `date - 1` (the previous evening). The overnight irrigation
-    // block spans `[sunsetAt, sunriseAt]`. Same nullable rationale.
-    sunsetAt: timestamp('sunset_at', { withTimezone: true }),
     ...auditColumns,
 });

--- a/api/drizzle/0014_drop_sunset_at.sql
+++ b/api/drizzle/0014_drop_sunset_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schedule_entries" DROP COLUMN IF EXISTS "sunset_at";

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779464850372,
       "tag": "0013_gigantic_thanos",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1748131200000,
+      "tag": "0014_drop_sunset_at",
+      "breakpoints": true
     }
   ]
 }

--- a/api/models.ts
+++ b/api/models.ts
@@ -142,11 +142,4 @@ export type IrrigationScheduleEntry = {
      * day/night shading without re-fetching weather.
      */
     sunriseAt?: dayjs.Dayjs;
-
-    /**
-     * Optional. Sunset of `date - 1` (the previous evening). The overnight
-     * irrigation block spans `[sunsetAt, sunriseAt]`. Undefined on the first
-     * weather day where the previous evening's sunset isn't known.
-     */
-    sunsetAt?: dayjs.Dayjs;
 }

--- a/api/repositories/schedule-entries/.test.ts
+++ b/api/repositories/schedule-entries/.test.ts
@@ -105,7 +105,6 @@ function buildFutureCycleRow(overrides?: Partial<{
             depletionBeforeMm: 18.5,
             depletionAfterMm: 0,
             sunriseAt: null,
-            sunsetAt: null,
             source: 'scheduled',
             createdAt: NOW,
             updatedAt: NOW,
@@ -344,15 +343,13 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
         expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 12.3 });
     });
 
-    it('persists sunriseAt and sunsetAt as JS Dates on the schedule_entries insert', async () => {
+    it('persists sunriseAt as a JS Date on the schedule_entries insert', async () => {
         const { db, insertCalls } = stubWriterDb({ entries: ['entry-A'] });
         const repo = createScheduleEntriesRepository(db);
         const sunrise = dayjs('2026-05-04T11:30:00.000Z');
-        const sunset = dayjs('2026-05-03T20:45:00.000Z');
         const entry: IrrigationScheduleEntry = {
             ...buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]),
             sunriseAt: sunrise,
-            sunsetAt: sunset,
         };
 
         await repo.replaceForZone('zone-001', [entry], dayjs('2026-05-04'), 0, 'sched-default');
@@ -360,11 +357,9 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
         const entryInsert = insertCalls.find(c => c.table === scheduleEntries);
         expect(entryInsert?.rows[0]?.['sunriseAt']).toBeInstanceOf(Date);
         expect((entryInsert?.rows[0]?.['sunriseAt'] as Date).toISOString()).toBe(sunrise.toISOString());
-        expect(entryInsert?.rows[0]?.['sunsetAt']).toBeInstanceOf(Date);
-        expect((entryInsert?.rows[0]?.['sunsetAt'] as Date).toISOString()).toBe(sunset.toISOString());
     });
 
-    it('persists sunriseAt and sunsetAt as null when the planner entry omits them', async () => {
+    it('persists sunriseAt as null when the planner entry omits it', async () => {
         const { db, insertCalls } = stubWriterDb({ entries: ['entry-A'] });
         const repo = createScheduleEntriesRepository(db);
         const entry = buildEntry('2026-05-04', [{ startTime: '2026-05-04T05:00:00Z', durationMin: 20 }]);
@@ -373,7 +368,6 @@ describe('createScheduleEntriesRepository.replaceForZone', () => {
 
         const entryInsert = insertCalls.find(c => c.table === scheduleEntries);
         expect(entryInsert?.rows[0]?.['sunriseAt']).toBeNull();
-        expect(entryInsert?.rows[0]?.['sunsetAt']).toBeNull();
     });
 });
 
@@ -533,7 +527,6 @@ function buildNextRunRow(overrides?: Partial<NextRunJoinedRow>): NextRunJoinedRo
             depletionAfterMm: 5,
             source: 'scheduled',
             sunriseAt: null,
-            sunsetAt: null,
             createdAt: NOW,
             updatedAt: NOW,
         },

--- a/api/repositories/schedule-entries/index.ts
+++ b/api/repositories/schedule-entries/index.ts
@@ -160,7 +160,6 @@ export function createScheduleEntriesRepository(db: Database): ScheduleEntriesRe
                             depletionBeforeMm: entry.depletionBeforeMm,
                             depletionAfterMm: entry.depletionAfterMm,
                             sunriseAt: entry.sunriseAt?.toDate() ?? null,
-                            sunsetAt: entry.sunsetAt?.toDate() ?? null,
                         },
                     ])
                     .returning({ id: scheduleEntries.id });

--- a/api/repositories/tonight/.test.ts
+++ b/api/repositories/tonight/.test.ts
@@ -18,7 +18,6 @@ function buildEntry(overrides?: Partial<typeof scheduleEntries.$inferSelect>): t
         depletionAfterMm: 0.3,
         source: 'scheduled',
         sunriseAt: new Date('2026-05-21T05:30:00.000Z'),
-        sunsetAt: new Date('2026-05-20T20:30:00.000Z'),
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -686,12 +686,15 @@ describe('planZoneSchedule', () => {
         });
 
         it('should handle high ET with low efficiency and clay soil', () => {
+            // rootDepthM=0.1 caps TAW at 20 mm; precipitationRateMmPerHr=12 keeps
+            // totalRunTime (~100 min) + 4 soak gaps (4×60 = 240 min) ≈ 340 min —
+            // within the 6-hour midnight-to-sunrise window despite cycle splitting.
             const zone = createTestZone({
                 soil: SOIL_TYPES.clay,
                 irrigationEfficiency: 0.6,
                 currentDepletionMm: 0,
-                flowRateLPerMin: 25,
-                areaM2: 60,
+                rootDepthM: 0.1,
+                precipitationRateMmPerHr: 12,
             });
             const weather = createDryPeriod(14, 5.0);
 
@@ -1142,10 +1145,9 @@ describe('planZoneSchedule', () => {
         });
 
         it('drops the day when a busy window blocks every backward placement before earliestStart', () => {
-            // Day 0 (no prevDaySunset → earliestStart = midnight) with a busy window
-            // covering the entire midnight-to-sunrise span leaves no slot the cycle
-            // can backward-slide into. The placer truncates to zero cycles and the
-            // day is skipped.
+            // Day 0 with a busy window covering the entire midnight-to-sunrise span
+            // leaves no slot the cycle can backward-slide into. The placer defers
+            // (returns null) and the day is skipped.
             const zone = singleCycleZone();
             const sunrise = dayjs('2025-10-20').hour(6).minute(0).second(0).millisecond(0);
             const weather = createWeatherDays([
@@ -1193,11 +1195,15 @@ describe('planZoneSchedule', () => {
         });
 
         it('interleaves a second zone\'s cycles into the soak gaps of the first zone (API-66)', () => {
-            // Two identical zones planned sequentially. Zone B receives A's run windows
-            // as busyWindows. Old behaviour: B got pushed past sunrise and lost all
-            // cycles. New behaviour: B's cycles slide earlier, ending at each A
-            // cycle's start — landing inside A's soak gaps.
-            const zone = createTestZone({ currentDepletionMm: 22 });
+            // Two single-cycle zones planned sequentially. Zone B receives A's run
+            // window as a busyWindow. Old behaviour: B got pushed past sunrise and
+            // lost all cycles. New behaviour: B's cycle slides earlier to end at
+            // A's start — landing entirely inside the midnight-to-sunrise window.
+            const zone = createTestZone({
+                currentDepletionMm: 22,
+                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+                precipitationRateMmPerHr: 50,
+            });
             const weather = createWeatherDays([
                 {
                     evapotranspirationMmPerDay: 1.0,
@@ -1564,91 +1570,96 @@ describe('planZoneSchedule', () => {
         });
     });
 
-    describe('sunset gating', () => {
-        // Clay soil: infiltration 4 mm/hr → soak 60 min. Default zone: AWHC=200 mm/m,
-        // rootDepthM=0.3 → TAW=60 mm, RAW=30 mm. With precipitationRateMmPerHr=9 and
-        // currentDepletionMm=29, irrigation fires on day 1 (after 0.85mm Kc×ET per day
-        // accumulates from 29mm to 30.7mm). That depletion triggers 10 cycles; with 60-min
-        // soaks the first cycle starts ~796 min (13h16m) before sunrise — at ~16:44 on day 0.
-        function sunsetGatingZone() {
-            return createTestZone({
-                currentDepletionMm: 29, // Just below RAW (30 mm) — fires on day 1 only.
+    describe('midnight floor (API-72)', () => {
+        // The overnight window is [midnight, sunrise]. No cycle may start before
+        // 00:00 local of the irrigation entry's date.
+
+        it('all placed cycles start at or after midnight of the entry date', () => {
+            // Single-cycle zone fires on day 0. Cycles must fall in [midnight, sunrise].
+            const zone = createTestZone({
+                currentDepletionMm: 22,
+                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+                precipitationRateMmPerHr: 50,
+            });
+            const date = dayjs('2026-05-04');
+            const weather = createWeatherDays(
+                [{ evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunrise: date.hour(6).minute(0).second(0).millisecond(0) }],
+                date,
+            );
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            expect(entries).toHaveLength(1);
+            const midnight = date.startOf('day');
+            for (const cycle of entries[0]!.cycles) {
+                expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(midnight.valueOf());
+            }
+        });
+
+        it('defers a day when the required runtime exceeds the midnight-to-sunrise window', () => {
+            // Clay soil: infiltration 4 mm/hr → soak 60 min. AWHC=200 mm/m,
+            // rootDepthM=0.3 → TAW=60 mm, RAW=30 mm. With precipitationRateMmPerHr=9 and
+            // currentDepletionMm=29, irrigation fires on day 1 (29 + 0.85 ET → 30.7mm).
+            // That triggers 10 cycles; with 60-min soaks the total block is ~796 min —
+            // well over the 6-hour midnight-to-sunrise window → defer both days.
+            const zone = createTestZone({
+                currentDepletionMm: 29,
                 soil: SOIL_TYPES.clay,
                 precipitationRateMmPerHr: 9,
             });
-        }
-
-        it('defers a day when first cycle would begin before the previous evening\'s sunset', () => {
-            // Day 0 sunset at 17:00; first cycle for day 1 lands at ~16:44 on day 0
-            // (before sunset) → the planner defers and returns no entry for day 1.
-            const zone = sunsetGatingZone();
             const weather = createWeatherDays([
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunset: dayjs('2026-05-04').hour(17).minute(0).second(0).millisecond(0) },
+                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
                 { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
             ], dayjs('2026-05-04'));
 
             const { entries } = planZoneSchedule(zone, weather);
 
-            // Day 0: depletion 29 + 0.85 ET = 29.85 < RAW 30 → no entry.
-            // Day 1: first cycle ~16:44 is before sunset 17:00 → gated → no entry.
             expect(entries).toHaveLength(0);
         });
 
-        it('places a day when first cycle starts after the previous evening\'s sunset', () => {
-            // Day 0 sunset at 16:00; first cycle for day 1 lands at ~16:44 on day 0
-            // (after the 16:00 sunset) → placement is allowed.
-            const zone = sunsetGatingZone();
-            const weather = createWeatherDays([
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunset: dayjs('2026-05-04').hour(16).minute(0).second(0).millisecond(0) },
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
-            ], dayjs('2026-05-04'));
-
-            const { entries } = planZoneSchedule(zone, weather);
-
-            // First cycle at ~16:44 is after the 16:00 sunset → entry placed on day 1.
-            expect(entries).toHaveLength(1);
-            expect(entries[0]!.date.format('YYYY-MM-DD')).toBe('2026-05-05');
-        });
-
-        it('never gates dayIndex 0 even when the day has a very late sunset', () => {
-            // prevDaySunset is always undefined for dayIndex=0, so the check is skipped
-            // regardless of what sunset value the day carries.
+        it('places cycles when the required runtime fits within the midnight-to-sunrise window', () => {
+            // High-flow zone: 2 cycles × ~28 min + 15-min soak ≈ 71 min — fits in 6 hours.
             const zone = createTestZone({
-                currentDepletionMm: 31, // Above RAW (30 mm for clay) → fires immediately on day 0.
-                soil: SOIL_TYPES.clay,
-                precipitationRateMmPerHr: 9,
+                currentDepletionMm: 22,
+                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+                precipitationRateMmPerHr: 50,
             });
-            const weather = createWeatherDays([
-                {
-                    evapotranspirationMmPerDay: 1.0,
-                    rainfallMm: 0,
-                    sunrise: dayjs('2026-05-04').hour(6).minute(0).second(0).millisecond(0),
-                    sunset: dayjs('2026-05-04').hour(23).minute(59).second(0).millisecond(0),
-                },
-            ], dayjs('2026-05-04'));
+            const date = dayjs('2026-05-04');
+            const weather = createWeatherDays(
+                [{ evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunrise: date.hour(6).minute(0).second(0).millisecond(0) }],
+                date,
+            );
 
             const { entries } = planZoneSchedule(zone, weather);
 
-            // No prevDaySunset at dayIndex=0 — gate check never runs.
             expect(entries).toHaveLength(1);
-            expect(entries[0]!.date.format('YYYY-MM-DD')).toBe('2026-05-04');
         });
 
-        it('does not gate when no sunset is provided for the previous day', () => {
-            // If the previous day's DailyWeather has no sunset field, prevDaySunset
-            // is undefined and the gate is skipped — irrigation can fire normally.
-            const zone = sunsetGatingZone();
-            // Day 0 has no sunset field → prevDaySunset for day 1 is undefined.
-            const weather = createWeatherDays([
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0 },
-            ], dayjs('2026-05-04'));
+        it('keeps overnight cycles when a late-night past-window ends before midnight of the entry date', () => {
+            // Re-plan at 23:45 on the day before `date`; the past-window is
+            // [epoch, 2026-05-03T23:45]. The cycle is placed in [midnight, sunrise]
+            // of 2026-05-04 — well after the past-window end — so no shift occurs
+            // and the entry fires as planned.
+            const zone = createTestZone({
+                currentDepletionMm: 22,
+                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
+                precipitationRateMmPerHr: 50,
+            });
+            const date = dayjs('2026-05-04');
+            const weather = createWeatherDays(
+                [{ evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunrise: date.hour(6).minute(0).second(0).millisecond(0) }],
+                date,
+            );
+            const pastWindowEnd = dayjs('2026-05-03T23:45:00.000Z');
+            const pastWindow = { start: dayjs(new Date(0)), end: pastWindowEnd };
 
-            const { entries } = planZoneSchedule(zone, weather);
+            const { entries } = planZoneSchedule(zone, weather, [pastWindow]);
 
-            // Gate skipped due to missing sunset → entry placed on day 1.
             expect(entries).toHaveLength(1);
-            expect(entries[0]!.date.format('YYYY-MM-DD')).toBe('2026-05-05');
+            // Cycle lands in [midnight, sunrise] — not shifted by the past-window.
+            const cycle = entries[0]!.cycles[0]!;
+            expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(date.startOf('day').valueOf());
+            expect(cycle.startTime.valueOf()).toBeLessThanOrEqual(date.hour(6).valueOf());
         });
     });
 
@@ -1949,8 +1960,7 @@ describe('planZoneSchedule', () => {
         });
     });
 
-    describe('sunrise/sunset persistence on entries', () => {
-        // Mirrors the singleCycleZone shape used by other describes here.
+    describe('sunrise persistence on entries', () => {
         const singleCycleZone = () => createTestZone({
             currentDepletionMm: 22,
             soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
@@ -1970,41 +1980,6 @@ describe('planZoneSchedule', () => {
             expect(entries).toHaveLength(1);
             expect(entries[0]?.sunriseAt).toBeDefined();
             expect(entries[0]?.sunriseAt?.isSame(sunrise)).toBe(true);
-        });
-
-        it('attaches sunsetAt = the previous day weather sunset when available', () => {
-            // Day 0 has just a sunset; day 1 is the one that triggers irrigation
-            // and should carry the prior day's sunset on its entry.
-            const zone = createTestZone({
-                currentDepletionMm: 21.5, // crosses RAW on day 1
-                soil: { name: 'TestSoil', availableWaterHoldingCapacityMmPerM: 150, infiltrationRateMmPerHr: 100 },
-                precipitationRateMmPerHr: 50,
-            });
-            const day0Sunset = dayjs('2026-05-05').hour(20).minute(30).second(0).millisecond(0);
-            const day1Sunrise = dayjs('2026-05-06').hour(6).minute(0).second(0).millisecond(0);
-            const weather = createWeatherDays([
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunset: day0Sunset },
-                { evapotranspirationMmPerDay: 1.0, rainfallMm: 0, sunrise: day1Sunrise },
-            ], dayjs('2026-05-05'));
-
-            const { entries } = planZoneSchedule(zone, weather);
-
-            const day1Entry = entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-06');
-            expect(day1Entry).toBeDefined();
-            expect(day1Entry?.sunsetAt?.isSame(day0Sunset)).toBe(true);
-        });
-
-        it('omits sunsetAt on day 0 entries where there is no previous-day sunset', () => {
-            const zone = singleCycleZone();
-            const weather = createWeatherDays(
-                [{ evapotranspirationMmPerDay: 1.0, rainfallMm: 0 }],
-                dayjs('2026-05-06'),
-            );
-
-            const { entries } = planZoneSchedule(zone, weather);
-
-            expect(entries).toHaveLength(1);
-            expect(entries[0]?.sunsetAt).toBeUndefined();
         });
     });
 });

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -131,7 +131,6 @@ export function planZoneSchedule(
             const irrigationOutcome = tryPlaceIrrigationForDay({
                 date,
                 sunrise,
-                prevDaySunset: dayIndex > 0 ? weatherHistory[dayIndex - 1]?.sunset : undefined,
                 zone,
                 currentDepletionMillimeters,
                 totalAvailableWaterMillimeters,
@@ -181,8 +180,6 @@ export function planZoneSchedule(
 type PlaceIrrigationInputs = {
     date: dayjs.Dayjs;
     sunrise: dayjs.Dayjs;
-    /** Sunset of the preceding calendar day. When set, the first cycle must start at or after this time. */
-    prevDaySunset?: dayjs.Dayjs;
     zone: Zone;
     currentDepletionMillimeters: number;
     totalAvailableWaterMillimeters: number;
@@ -204,10 +201,8 @@ type PlaceIrrigationOutcome = {
  * day is disallowed or no cycles fit the overnight window — callers treat
  * that as "skip, carry depletion forward."
  *
- * The overnight window is [prevDaySunset, sunrise]. When `prevDaySunset` is
- * provided and the planned cycle block would extend before it, the entire
- * day is deferred (gating). When it isn't provided, the planner falls back
- * to midnight as the floor and truncates cycles that don't fit.
+ * The overnight window is [midnight, sunrise] — no cycle may start before
+ * 00:00 local of the irrigation entry's date.
  *
  * Past-window busy intervals (those starting at the epoch) are split out
  * from cross-zone busy windows and applied as a forward shift *after*
@@ -217,7 +212,7 @@ type PlaceIrrigationOutcome = {
  */
 function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigationOutcome | null {
     const {
-        date, sunrise, prevDaySunset, zone, currentDepletionMillimeters, totalAvailableWaterMillimeters,
+        date, sunrise, zone, currentDepletionMillimeters, totalAvailableWaterMillimeters,
         precipitationRateMillimetersPerHour, infiltrationRateMillimetersPerHour, soakTimeMinutes,
         busyWindowsSoFar, restrictions,
     } = inputs;
@@ -242,11 +237,9 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         ? (infiltrationRateMillimetersPerHour / precipitationRateMillimetersPerHour) * 60
         : totalRunTimeMinutes;
 
-    // Overnight floor: previous evening's sunset when available; otherwise
-    // midnight (truncation mode, used for dayIndex 0 and weather rows
-    // missing sunset data).
-    const hasPrevSunset = prevDaySunset !== undefined;
-    const earliestStart = hasPrevSunset ? prevDaySunset : sunrise.startOf('day');
+    // Overnight floor: midnight (00:00 local) of the irrigation entry's date.
+    // No cycle may start before this time.
+    const earliestStart = sunrise.startOf('day');
 
     // The daemon plumbs a "past window" — { start: epoch, end: now } — as a
     // busy interval that pushes past-dated cycles forward. It's handled
@@ -265,7 +258,6 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         sunrise,
         soakTimeMinutes,
         earliestStart,
-        hasPrevSunset,
         crossZoneBusyWindows,
     );
 
@@ -280,9 +272,10 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
     }
 
     // Past-window handling differs by schedule shape (API-66):
-    //  - default: shift past-due cycles forward to fire at-or-after `now`,
-    //    even if that lands past sunrise. The daemon would rather fire a
-    //    late cycle than skip the day.
+    //  - default: shift past-due cycles forward to fire at-or-after `now`.
+    //    After shifting, drop any cycle whose startTime is before midnight of
+    //    `date` (API-72) — a late-night re-plan can push cycles into the
+    //    previous calendar day; those must be deferred, not fired.
     //  - `endBySunrise=true`: daytime irrigation is explicitly forbidden, so
     //    push-forward is wrong. Drop the past-due cycles instead and let
     //    depletion carry forward to the next allowed day.
@@ -295,7 +288,9 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
                 return endMs > nowMs;
             });
         }
-        return deconflictCycles(placedCycles, [pastWindow], soakTimeMinutes);
+        const shifted = deconflictCycles(placedCycles, [pastWindow], soakTimeMinutes);
+        const midnight = date.startOf('day');
+        return shifted.filter(c => !c.startTime.isBefore(midnight));
     })();
 
     if (finalCycles.length === 0) {
@@ -311,7 +306,6 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         depletionBeforeMm: roundTo1Decimal(depletionBeforeIrrigation),
         depletionAfterMm: 0,
         sunriseAt: sunrise,
-        ...(prevDaySunset !== undefined ? { sunsetAt: prevDaySunset } : {}),
     };
     return { cycles: finalCycles, entry };
 }
@@ -326,21 +320,16 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
  * forward-only deconflict cascaded delays and dropped most days for the
  * second zone, see API-66).
  *
- * Behavior when a cycle still doesn't fit (i.e., sliding earlier would land
- * before `earliestStart`):
- *  - `deferIfWindowTooShort=true` (previous-day sunset available): the entire
- *    day is treated as un-irrigatable; the function returns `null` so the
- *    caller defers and carries depletion into the next allowed day.
- *  - `deferIfWindowTooShort=false` (no previous-day sunset): the plan is
- *    truncated to the cycles that do fit; depletion is partially refilled.
+ * When a cycle still doesn't fit (sliding earlier would land before
+ * `earliestStart` = midnight), the entire day is treated as un-irrigatable:
+ * the function returns `null` so the caller defers and carries depletion
+ * into the next allowed day.
  *
  * @param totalRunTimeMinutes - Total irrigation runtime needed.
  * @param maximumCycleMinutes - Maximum duration per cycle (infiltration limit).
  * @param sunrise - End anchor: last cycle ends here (or earlier if busy windows displace it).
  * @param soakTimeMinutes - Soak gap between consecutive cycles of this zone.
- * @param earliestStart - Hard floor: no cycle may start before this time.
- * @param deferIfWindowTooShort - When true, returning `null` signals deferral
- *   rather than truncation.
+ * @param earliestStart - Hard floor: no cycle may start before this time (midnight of the entry date).
  * @param busyWindows - Intervals occupied by other zones (or the past window
  *   if handled here). Cycles slide earlier to avoid overlap.
  * @returns Cycles in chronological order (earliest first), `null` when the
@@ -352,7 +341,6 @@ function placeCyclesBackwardAvoidingBusy(
     sunrise: dayjs.Dayjs,
     soakTimeMinutes: number,
     earliestStart: dayjs.Dayjs,
-    deferIfWindowTooShort: boolean,
     busyWindows: ReadonlyArray<BusyWindow>,
 ): IrrigationCycle[] | null {
     if (totalRunTimeMinutes <= 0) return [];
@@ -390,8 +378,7 @@ function placeCyclesBackwardAvoidingBusy(
         }
 
         if (cycleStart.isBefore(earliestStart)) {
-            if (deferIfWindowTooShort) return null;
-            break; // truncate
+            return null; // defer: window too short to fit the required cycles
         }
 
         cyclesInReverse.push({ startTime: cycleStart, durationMin: perCycleMinutes });

--- a/api/schedules/dynamic/multi-zone.test.ts
+++ b/api/schedules/dynamic/multi-zone.test.ts
@@ -109,12 +109,9 @@ const START = dayjs('2026-05-04'); // Monday
 const COMPACT: Partial<Zone> = { precipitationRateMmPerHr: 30 };
 
 /**
- * Weather days with both `sunrise` (06:00) and `sunset` (20:00) populated so
- * `tryPlaceIrrigationForDay` uses the previous day's sunset as the
- * `earliestStart` floor on day 1 and later, giving zones a much wider
- * overnight placement window. Day 0 still has no `prevDaySunset` (the
- * weather array doesn't include a day -1), so day-0 placements fall back to
- * the midnight → sunrise truncate window.
+ * Weather days with both `sunrise` (06:00) and `sunset` (20:00) populated.
+ * The planner's overnight window is always [midnight, sunrise] (API-72);
+ * the `sunset` field is present in the data but no longer affects placement.
  */
 function gatedWeather(days: number, etPerDay = 2.0, rainfall?: ReadonlyArray<number>): DailyWeather[] {
     return Array.from({ length: days }, (_, i) => {

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -338,7 +338,6 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
                         depletionBeforeMm: entry.depletionBeforeMm,
                         depletionAfterMm: entry.depletionAfterMm,
                         sunriseAt: entry.sunriseAt?.toDate() ?? null,
-                        sunsetAt: entry.sunsetAt?.toDate() ?? null,
                     }],
                 });
                 if (entry.cycles.length === 0) continue;

--- a/api/service/schedules-list/.test.ts
+++ b/api/service/schedules-list/.test.ts
@@ -52,7 +52,6 @@ function buildEntry(overrides?: Partial<EntryRow>): EntryRow {
         depletionAfterMm: 0.3,
         source: 'scheduled',
         sunriseAt: null,
-        sunsetAt: null,
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,

--- a/api/service/tonight/.test.ts
+++ b/api/service/tonight/.test.ts
@@ -31,7 +31,6 @@ function buildEntry(overrides?: Partial<EntryRow>): EntryRow {
         depletionAfterMm: 0.3,
         source: 'scheduled',
         sunriseAt: new Date('2026-05-21T05:30:00.000Z'),
-        sunsetAt: new Date('2026-05-20T20:30:00.000Z'),
         createdAt: NOW,
         updatedAt: NOW,
         ...overrides,
@@ -209,28 +208,26 @@ describe('getTonightSummary', () => {
             expect(result.zoneOrder).toEqual(['North']);
         });
 
-        it('formats sunset and sunrise as HH:MM site-local and uses them for axis bounds', async () => {
+        it('formats sunrise as HH:MM site-local and uses it for axisEnd; sunset is always null', async () => {
             bootTonightWith([{
-                entry: buildEntry({
-                    sunriseAt: new Date('2026-05-21T05:30:00.000Z'),
-                    sunsetAt: new Date('2026-05-20T20:30:00.000Z'),
-                }),
+                entry: buildEntry({ sunriseAt: new Date('2026-05-21T05:30:00.000Z') }),
                 cycle: buildCycle({ startTime: new Date('2026-05-21T03:00:00.000Z'), durationMin: 30 }),
                 zone: buildZone(),
             }]);
 
             const result = await getTonightSummary(NOW);
 
-            expect(result.sunset).toBe('20:30');
+            expect(result.sunset).toBeNull();
             expect(result.sunrise).toBe('05:30');
-            expect(result.axisStart).toBe('20:30');
+            // axisStart falls back to first cycle start time; axisEnd = sunrise.
+            expect(result.axisStart).toBe('03:00');
             expect(result.axisEnd).toBe('05:30');
         });
 
-        it('falls back axisStart/axisEnd to HH:MM of startTime/endsAt when sunrise/sunset columns are null', async () => {
+        it('falls back axisStart/axisEnd to HH:MM of startTime/endsAt when sunriseAt column is null', async () => {
             const start = new Date('2026-05-21T03:00:00.000Z');
             bootTonightWith([{
-                entry: buildEntry({ sunriseAt: null, sunsetAt: null }),
+                entry: buildEntry({ sunriseAt: null }),
                 cycle: buildCycle({ startTime: start, durationMin: 30 }),
                 zone: buildZone(),
             }]);

--- a/api/service/tonight/index.ts
+++ b/api/service/tonight/index.ts
@@ -137,11 +137,9 @@ function buildDto(rows: TonightJoinedRow[], siteTimezone: string): TonightDto {
     const allCycleEnds: Date[] = [];
     const zoneAccumulator = new Map<string, ZoneAccumulator>();
     let firstSunriseAt: Date | null = null;
-    let firstSunsetAt: Date | null = null;
 
     for (const row of rows) {
         if (firstSunriseAt === null && row.entry.sunriseAt !== null) firstSunriseAt = row.entry.sunriseAt;
-        if (firstSunsetAt === null && row.entry.sunsetAt !== null) firstSunsetAt = row.entry.sunsetAt;
 
         if (row.cycle === null) continue;
         cyclesFiring.push(row.cycle.firedAt !== null && row.cycle.closedAt === null);
@@ -178,7 +176,7 @@ function buildDto(rows: TonightJoinedRow[], siteTimezone: string): TonightDto {
         return a.name.localeCompare(b.name);
     });
 
-    const sunset = firstSunsetAt !== null ? formatSiteLocal(firstSunsetAt, siteTimezone) : null;
+    const sunset = null;
     const sunrise = firstSunriseAt !== null ? formatSiteLocal(firstSunriseAt, siteTimezone) : null;
 
     const dtoZones: TonightZone[] = zonesSorted.map(z => ({


### PR DESCRIPTION
## Ticket

[API-72](http://192.168.2.100:7123/irrigo/browse/API-72/) Don't schedule irrigation cycles before 12am local

## Summary

- Collapses the overnight irrigation window from `[prevDaySunset, sunrise]` to `[midnight, sunrise]` — no cycle may now start before 00:00 local time of the entry date.
- Removes `prevDaySunset` / `hasPrevSunset` / `deferIfWindowTooShort` from the planner; `earliestStart` is always `date.startOf('day')`.
- Adds a post-shift midnight filter in the non-`endBySunrise` past-window path to drop any cycle that somehow lands before midnight after forward deconfliction.
- Drops `schedule_entries.sunset_at` DB column (`0014_drop_sunset_at.sql`), removes `sunsetAt` from `IrrigationScheduleEntry` model, repository insert, and `TonightDto` (sunset is now always null; axisStart already falls back to cycle start time).
- Replaces sunset-gating tests with midnight-floor tests; removes sunsetAt fixture fields from all downstream test files.