### PR TITLE
[API-74] Resolve replan day boundary in site timezone instead of UTC

### DIFF
--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -228,6 +228,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
     const weatherStateUpserts: Array<Record<string, unknown>> = [];
     const alertTableUpdates: Array<{ set: Record<string, unknown>; cond: unknown }> = [];
     const schedulesTableUpdates: Array<{ set: Record<string, unknown> }> = [];
+    const todayArgs: Array<{ source: 'replaceForZone' | 'clearStaleSkipMarkers'; value: dayjs.Dayjs }> = [];
 
     let callOrder = 0;
     let firstClearStaleCallOrder: number | null = null;
@@ -317,9 +318,10 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         disable: async () => null,
         skipActiveTonight: async () => null,
         resumeActiveTonight: async () => null,
-        clearStaleSkipMarkers: async () => {
+        clearStaleSkipMarkers: async (today) => {
             if (firstClearStaleCallOrder === null) firstClearStaleCallOrder = ++callOrder;
             schedulesTableUpdates.push({ set: { skippedNightDate: null } });
+            todayArgs.push({ source: 'clearStaleSkipMarkers', value: today });
         },
     };
 
@@ -329,7 +331,8 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
             if (inputs?.inFlightCyclesError) throw inputs.inFlightCyclesError;
             return inputs?.inFlightCycles ?? [];
         },
-        replaceForZone: async (zoneId, entries, _today, scheduleId) => {
+        replaceForZone: async (zoneId, entries, today, scheduleId) => {
+            todayArgs.push({ source: 'replaceForZone', value: today });
             deletes.push({ table: scheduleEntries });
             const cycles: PersistedCycle[] = [];
             for (const entry of entries) {
@@ -392,6 +395,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         weatherStateUpserts,
         alertTableUpdates,
         schedulesTableUpdates,
+        todayArgs,
         getOrdering: () => ({ clearStale: firstClearStaleCallOrder, activeScheduleRead: firstActiveScheduleReadOrder }),
     };
 }
@@ -874,6 +878,38 @@ describe('start', () => {
         // Both replans should produce the same schedule entries (idempotent).
         expect(insertsAfterSecond).toHaveLength(insertsAfterFirst[0]! * 2);
         expect(insertsAfterSecond[0]?.rows[0]).toEqual(insertsSnapshot[0]);
+    });
+
+    it('resolves the replan day boundary against siteTimezone, not UTC (API-74)', async () => {
+        // 2026-05-05T02:30:00Z is still 2026-05-04 20:30 in America/Edmonton.
+        // Without the timezone fix the daemon would format `today` as
+        // '2026-05-05' and `replaceForZone` would issue `DELETE … WHERE
+        // date >= '2026-05-05'`, leaving the previous day's site-local rows
+        // orphaned in the DB.
+        const utcNow = new Date('2026-05-05T02:30:00.000Z');
+        const enabledRow = buildJoinedRow({ zone: { id: 'zone-001', siteId: 'site-001' } });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock } = createFakeClock(utcNow);
+
+        const control = await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'America/Edmonton',
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+            openZone: async () => {},
+            closeZone: async () => {},
+            getZoneState: async () => 'off',
+        });
+
+        await control.rePlan();
+
+        const replaceForZoneToday = stub.todayArgs.find(t => t.source === 'replaceForZone');
+        const clearStaleToday = stub.todayArgs.find(t => t.source === 'clearStaleSkipMarkers');
+        expect(replaceForZoneToday).toBeDefined();
+        expect(clearStaleToday).toBeDefined();
+        expect(replaceForZoneToday!.value.format('YYYY-MM-DD')).toBe('2026-05-04');
+        expect(clearStaleToday!.value.format('YYYY-MM-DD')).toBe('2026-05-04');
     });
 
     it('does not emit schedule-begun or schedule-ended for boot-armed cycles', async () => {

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -189,7 +189,13 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
             return;
         }
 
-        const today = dayjs(clock.now());
+        // Resolve `today` against the site's IANA timezone so the date cutoff
+        // matches the calendar the planner is using. With the container TZ
+        // unset, a bare `dayjs(now)` formats in UTC — after 18:00 MDT the UTC
+        // calendar rolls forward and `replaceForZone` deletes rows whose
+        // `date >= ${UTC-tomorrow}`, leaving the (still site-local-today) rows
+        // orphaned in the DB. See API-74.
+        const today = dayjs(clock.now()).tz(siteTimezone);
         await schedulesRepo.clearStaleSkipMarkers(today);
 
         const enabledZones = await zonesRepo.loadEnabled();


### PR DESCRIPTION
## Ticket

[API-74](http://192.168.2.100:7123/home/browse/API-74/) Replan day boundary computed in UTC instead of site-local time

## Summary

- The daemon's `_rePlan` built `today` with bare `dayjs(clock.now())`, so `.format('YYYY-MM-DD')` rendered the UTC date. After 18:00 MDT (= 00:00 UTC) the UTC calendar rolls forward while site-local is still the previous day, and `replaceForZone` would delete `date >= ${UTC-tomorrow}` — orphaning the still-site-local-today rows in the DB. Caught during post-API-71/72/73 replan debugging.
- Fix: resolve `today` against the already-loaded `siteTimezone` (`dayjs(clock.now()).tz(siteTimezone)`). Both consumers (`clearStaleSkipMarkers`, `replaceForZone`) already do their own `.format(...)` and now produce the site-local date.
- Added a daemon test that pins `clock.now()` to `2026-05-05T02:30:00Z` (= 2026-05-04 20:30 in America/Edmonton) and asserts the `today` dayjs passed to both repo methods formats to `2026-05-04`, not `2026-05-05`.

## Verification

- `bun --cwd=./api run type-check` — passes
- `bun --cwd=./api test` — 830 pass / 0 fail across 46 files