### PR TITLE
[API-75] Clamp gross irrigation depth to overnight window

### DIFF
--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1542,11 +1542,14 @@ describe('planZoneSchedule', () => {
 
             const result = planZoneSchedule(zone, weather, [], undefined, { rootDepthM: 0.05 });
 
-            // With currentDepletion clamped to 7.5 mm (overridden TAW), starting
-            // depletion > RAW (1.875 mm) so day-0 triggers and refills to 0.
-            // With ET=0 the projected end-of-day depletion is 0, not 30.
+            // With currentDepletion clamped to 7.5 mm (overridden TAW=7.5 mm),
+            // starting depletion (7.5) > RAW (3.75) so day-0 triggers. The
+            // applied gross is also capped at TAW=7.5 mm, but efficiency 0.8
+            // delivers only 6.0 mm net to the root zone — so depletionAfter
+            // is 7.5 − 6.0 = 1.5 mm (API-75). With ET=0 the projected
+            // end-of-day depletion equals that residual.
             expect(result.entries[0]?.depletionBeforeMm).toBeCloseTo(7.5, 1);
-            expect(result.projectedNextDepletionMm).toBe(0);
+            expect(result.projectedNextDepletionMm).toBeCloseTo(1.5, 5);
         });
 
         it('produces materially different output when the same fixture is planned under different override modes', () => {
@@ -1596,12 +1599,14 @@ describe('planZoneSchedule', () => {
             }
         });
 
-        it('defers a day when the required runtime exceeds the midnight-to-sunrise window', () => {
+        it('partially refills when the full-refill runtime exceeds the midnight-to-sunrise window (API-75)', () => {
             // Clay soil: infiltration 4 mm/hr → soak 60 min. AWHC=200 mm/m,
             // rootDepthM=0.3 → TAW=60 mm, RAW=30 mm. With precipitationRateMmPerHr=9 and
             // currentDepletionMm=29, irrigation fires on day 1 (29 + 0.85 ET → 30.7mm).
-            // That triggers 10 cycles; with 60-min soaks the total block is ~796 min —
-            // well over the 6-hour midnight-to-sunrise window → defer both days.
+            // Full refill would need ~10 cycles with 60-min soaks (~796 min, far
+            // beyond the 360-min overnight window). Pre-API-75 the day deferred
+            // entirely; now the planner clamps gross to what fits, partially
+            // refills, and carries the residual to the next allowed night.
             const zone = createTestZone({
                 currentDepletionMm: 29,
                 soil: SOIL_TYPES.clay,
@@ -1614,7 +1619,19 @@ describe('planZoneSchedule', () => {
 
             const { entries } = planZoneSchedule(zone, weather);
 
-            expect(entries).toHaveLength(0);
+            expect(entries.length).toBeGreaterThan(0);
+            for (const entry of entries) {
+                // Every placed entry's cycles fit inside [midnight, sunrise].
+                const midnight = entry.date.startOf('day');
+                const sunrise = entry.sunriseAt!;
+                for (const cycle of entry.cycles) {
+                    expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(midnight.valueOf());
+                    const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+                    expect(cycleEnd.valueOf()).toBeLessThanOrEqual(sunrise.valueOf() + 1000);
+                }
+                // Partial refill: depletionAfter is the residual, not zero.
+                expect(entry.depletionAfterMm).toBeGreaterThan(0);
+            }
         });
 
         it('places cycles when the required runtime fits within the midnight-to-sunrise window', () => {

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -153,10 +153,12 @@ export function planZoneSchedule(
 
                 irrigationSchedule.push(irrigationOutcome.entry);
 
-                // Reset depletion to zero after irrigation, then re-apply
-                // the day's net ET for the post-irrigation portion.
+                // Start the post-irrigation portion from the entry's residual
+                // depletion (zero on a full refill, positive on a partial
+                // refill clamped by the overnight window — see API-75), then
+                // re-apply the day's net ET for the post-irrigation hours.
                 currentDepletionMillimeters = clampValue(
-                    cropEvapotranspiration - effectiveRainfallMillimeters,
+                    irrigationOutcome.entry.depletionAfterMm + cropEvapotranspiration - effectiveRainfallMillimeters,
                     0,
                     totalAvailableWaterMillimeters
                 );
@@ -228,18 +230,38 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
     }
 
     const depletionBeforeIrrigation = currentDepletionMillimeters;
-    const grossIrrigationDepthMillimeters = Math.min(
+    const fullRefillGrossDepthMillimeters = Math.min(
         currentDepletionMillimeters / zone.irrigationEfficiency,
         totalAvailableWaterMillimeters,
     );
-    const totalRunTimeMinutes = (grossIrrigationDepthMillimeters / precipitationRateMillimetersPerHour) * 60;
+    const fullRefillRunTimeMinutes = (fullRefillGrossDepthMillimeters / precipitationRateMillimetersPerHour) * 60;
     const maximumCycleMinutes = infiltrationRateMillimetersPerHour > 0
         ? (infiltrationRateMillimetersPerHour / precipitationRateMillimetersPerHour) * 60
-        : totalRunTimeMinutes;
+        : fullRefillRunTimeMinutes;
 
     // Overnight floor: midnight (00:00 local) of the irrigation entry's date.
     // No cycle may start before this time.
     const earliestStart = sunrise.startOf('day');
+
+    // Cap runtime at what tonight's overnight window can physically hold
+    // (API-75). The closed-form picks the largest N where
+    // `N·maxCycle + (N-1)·soak ≤ windowMinutes`, then maxRunTime = N·maxCycle.
+    // When the full-refill runtime exceeds this cap, we accept a partial
+    // refill — depletionAfter reflects the residual and carries forward to
+    // the next allowed day. Without this clamp, deep deficits on low-
+    // infiltration soils defer forever because every full refill is longer
+    // than [midnight, sunrise].
+    const windowMinutes = sunrise.diff(earliestStart, 'minute');
+    const maxRunTimeMinutes = computeMaxRunTimeMinutes(maximumCycleMinutes, soakTimeMinutes, windowMinutes);
+    if (maxRunTimeMinutes <= 0) {
+        console.warn(`planner: zone ${zone.id} (${zone.name}): overnight window (${windowMinutes} min) too short to fit even one cycle (maxCycle ${maximumCycleMinutes.toFixed(1)} min) on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
+        return null;
+    }
+    const totalRunTimeMinutes = Math.min(fullRefillRunTimeMinutes, maxRunTimeMinutes);
+    const grossIrrigationDepthMillimeters = (totalRunTimeMinutes / 60) * precipitationRateMillimetersPerHour;
+    if (totalRunTimeMinutes < fullRefillRunTimeMinutes) {
+        console.log(`planner: zone ${zone.id} (${zone.name}): clamping run time ${fullRefillRunTimeMinutes.toFixed(1)} → ${totalRunTimeMinutes.toFixed(1)} min on ${date.format('YYYY-MM-DD')} (window ${windowMinutes} min); applying ${grossIrrigationDepthMillimeters.toFixed(1)} of ${fullRefillGrossDepthMillimeters.toFixed(1)} mm.`);
+    }
 
     // The daemon plumbs a "past window" — { start: epoch, end: now } — as a
     // busy interval that pushes past-dated cycles forward. It's handled
@@ -298,16 +320,44 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         return null;
     }
 
+    // Net depth that actually reaches the root zone after losses. `depletionAfter`
+    // is the residual depletion after this event — zero on a full refill,
+    // positive when the overnight-window clamp limited the applied gross
+    // (API-75). The planner's day loop carries this residual into tomorrow.
+    const netAppliedDepthMillimeters = grossIrrigationDepthMillimeters * zone.irrigationEfficiency;
+    const depletionAfterIrrigation = Math.max(0, depletionBeforeIrrigation - netAppliedDepthMillimeters);
+
     const entry: IrrigationScheduleEntry = {
         date,
         zoneId: zone.id,
         cycles: finalCycles,
         appliedDepthMm: roundTo1Decimal(grossIrrigationDepthMillimeters),
         depletionBeforeMm: roundTo1Decimal(depletionBeforeIrrigation),
-        depletionAfterMm: 0,
+        depletionAfterMm: roundTo1Decimal(depletionAfterIrrigation),
         sunriseAt: sunrise,
     };
     return { cycles: finalCycles, entry };
+}
+
+/**
+ * Returns the largest total runtime (minutes) whose cycle layout fits inside
+ * `windowMinutes` given the per-cycle infiltration cap (`maxCycleMinutes`) and
+ * the intra-zone soak gap. Closed form: pick the largest `N` where
+ * `N·maxCycle + (N-1)·soak ≤ windowMinutes`, then `maxRunTime = N·maxCycle`.
+ * Returns 0 when not even one minimum-width cycle fits.
+ *
+ * For `maxCycleMinutes <= 0` (no infiltration limit), a single uninterrupted
+ * cycle is allowed up to the full window — there's no per-cycle ceiling.
+ *
+ * Exposed for upcoming partial-refill tests (API-75). Kept inside this module
+ * because callers shouldn't need to reason about cycle math directly.
+ */
+function computeMaxRunTimeMinutes(maxCycleMinutes: number, soakTimeMinutes: number, windowMinutes: number): number {
+    if (windowMinutes <= 0) return 0;
+    if (maxCycleMinutes <= 0) return windowMinutes;
+    const cyclesThatFit = Math.floor((windowMinutes + soakTimeMinutes) / (maxCycleMinutes + soakTimeMinutes));
+    if (cyclesThatFit <= 0) return 0;
+    return cyclesThatFit * maxCycleMinutes;
 }
 
 

--- a/api/schedules/dynamic/multi-zone.test.ts
+++ b/api/schedules/dynamic/multi-zone.test.ts
@@ -806,4 +806,80 @@ describe('planZoneSchedule — multi-zone matrix', () => {
             assertNoCrossZoneOverlap(combined);
         });
     });
+
+    describe('Theme I — Partial refill when full-refill exceeds the overnight window (API-75)', () => {
+        // Production-shaped zone: clay-loam soil (5 mm/hr infiltration → 45-min
+        // soak, 165 AWHC/m), default root 0.3 m, low precipitation (18.75 mm/hr).
+        // Full-refill runtime at TAW depletion (49.5 mm) is ~14 h — well past
+        // the 360-min midnight-to-sunrise window. Pre-API-75 this deferred the
+        // night forever; now the planner clamps to a partial refill and carries
+        // the residual into the next allowed night.
+        const CLAY_LOAM_SLOW = { name: 'ClayLoamSlow', availableWaterHoldingCapacityMmPerM: 165, infiltrationRateMmPerHr: 5 };
+        const PARTIAL_REFILL_ZONE: Partial<Zone> = {
+            soil: CLAY_LOAM_SLOW,
+            rootDepthM: 0.3,
+            allowableDepletionFraction: 0.5,
+            irrigationEfficiency: 0.8,
+            precipitationRateMmPerHr: 18.75,
+        };
+
+        it('29. Single zone with deep deficit: cycles fit the window; entry reflects a partial refill.', () => {
+            const zone = makeZone('a', { ...PARTIAL_REFILL_ZONE, currentDepletionMm: 49.5 });
+            const weather = gatedWeather(7);
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            expect(entries.length).toBeGreaterThan(0);
+            const day0 = entries[0]!;
+            // All cycles fit inside [midnight, sunrise].
+            const midnight = day0.date.startOf('day');
+            const sunrise = day0.sunriseAt!;
+            for (const cycle of day0.cycles) {
+                expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(midnight.valueOf());
+                const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+                expect(cycleEnd.valueOf()).toBeLessThanOrEqual(sunrise.valueOf() + 1000);
+            }
+            // Clamp activated: applied gross is less than full-refill gross
+            // (depletion / efficiency) and depletionAfter is the residual.
+            const fullRefillGross = day0.depletionBeforeMm / zone.irrigationEfficiency;
+            expect(day0.appliedDepthMm).toBeLessThan(fullRefillGross);
+            expect(day0.depletionAfterMm).toBeGreaterThan(0);
+            const expectedAfter = day0.depletionBeforeMm - day0.appliedDepthMm * zone.irrigationEfficiency;
+            expect(day0.depletionAfterMm).toBeCloseTo(expectedAfter, 0);
+        });
+
+        it('30. Follow-on night picks up the residual.', () => {
+            const zone = makeZone('a', { ...PARTIAL_REFILL_ZONE, currentDepletionMm: 49.5 });
+            const weather = gatedWeather(7);
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            // The deficit doesn't clear in one night — the planner emits a
+            // follow-on entry on day 1 to keep irrigating.
+            expect(entries.length).toBeGreaterThanOrEqual(2);
+            const day0 = entries[0]!;
+            const day1 = entries[1]!;
+            // Day 1's depletionBefore picks up the residual from day 0 plus
+            // ~1 day of ET; it must NOT reset to the seed value or to 0.
+            expect(day1.depletionBeforeMm).toBeGreaterThan(0);
+            expect(day1.depletionBeforeMm).toBeLessThan(day0.depletionBeforeMm);
+        });
+
+        it('31. Fits-in-one-night zones remain unchanged: no clamp, full refill.', () => {
+            // Default loam + COMPACT precip — the standard multi-zone profile.
+            // Full-refill runtime (~60 min) fits well within the 360-min window.
+            const zone = makeZone('a', { currentDepletionMm: 22.5 });
+            const weather = gatedWeather(7);
+
+            const { entries } = planZoneSchedule(zone, weather);
+
+            expect(entries.length).toBeGreaterThan(0);
+            const day0 = entries[0]!;
+            // Full refill: applied gross ≈ depletionBefore / efficiency (within
+            // 1-decimal rounding) and the residual depletion is zero.
+            const fullRefillGross = day0.depletionBeforeMm / zone.irrigationEfficiency;
+            expect(Math.abs(day0.appliedDepthMm - fullRefillGross)).toBeLessThanOrEqual(0.1);
+            expect(day0.depletionAfterMm).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
## Ticket

[API-75](http://192.168.2.100:7123/home/browse/API-75/) Cap gross irrigation depth at the overnight window instead of deferring full refill

## Summary

- The planner sized every irrigation event for a full refill (`depletion / efficiency`) and either fit every cycle in `[midnight, sunrise]` or returned `null` (defer). For low-infiltration soils (clay-loam, 5 mm/hr → 45-min soak) the full-refill runtime at the *trigger* depletion already exceeded the ~5.5-h overnight window — every night deferred and no cycles ever fired. Caught during post-API-74 verification.
- Fix: compute `maxRunTimeMinutes = N · maxCycle` where N is the largest count satisfying `N·maxCycle + (N-1)·soak ≤ windowMinutes`. Clamp `totalRunTimeMinutes` to this cap and recompute `grossDepth`. Record the clamped gross as `appliedDepthMm` and set `depletionAfterMm = max(0, depletionBefore − applied·efficiency)`. The planner's day loop carries the residual into the next allowed night.
- New Theme I scenarios (29-31) in `multi-zone.test.ts` cover: single zone with deep deficit produces a partial refill that fits the window; the follow-on night picks up the residual; fits-in-one-night zones remain unchanged.
- Two existing tests were rewritten because they pinned down behavior API-75 explicitly changes: (a) the TAW-cap test asserted `projectedNextDepletionMm = 0` after a refill that physically can't reach zero (efficiency < 1 + applied capped at TAW); (b) the "defers when runtime exceeds window" test asserted the old defer-forever behavior — now rewritten to assert partial-refill cycles fit `[midnight, sunrise]` with `depletionAfter > 0`.

## Verification

- `bun --cwd=./api run type-check` — passes
- `bun --cwd=./api test` — 833 pass / 0 fail across 46 files