### PR TITLE
[API-77] Busy-window-aware per-zone clamp; placer/arm-time overlap agreement

### DIFF
--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -337,7 +337,12 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
                 return endMs > nowMs;
             });
         }
-        const shifted = deconflictCycles(placedCycles, [pastWindow], soakTimeMinutes);
+        // Forward-shift must dodge both the past-window AND cross-zone busy
+        // windows (API-77). Pre-fix this only considered the past-window, so a
+        // cycle pushed past `now` could land on top of an in-flight cycle or
+        // an earlier zone's planned interval — the daemon then caught it at
+        // arm time and refused to arm, leaving the row persisted but dead.
+        const shifted = deconflictCycles(placedCycles, [pastWindow, ...crossZoneBusyWindows], soakTimeMinutes);
         const midnight = date.startOf('day');
         return shifted.filter(c => !c.startTime.isBefore(midnight));
     })();

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -206,6 +206,13 @@ type PlaceIrrigationOutcome = {
  * The overnight window is [midnight, sunrise] — no cycle may start before
  * 00:00 local of the irrigation entry's date.
  *
+ * Cycle sizing uses an iterative downward retry (API-77): the closed-form
+ * `maxRunTimeMinutes` gives an upper bound on N against the empty window,
+ * but cross-zone busy windows can consume so much of the residual gaps that
+ * the placer can't fit N cycles. The caller retries with N-1, N-2, … until
+ * placement succeeds or N=0. The `actualTotalRunTime` drives the partial-
+ * refill `appliedDepthMm` / `depletionAfterMm` math.
+ *
  * Past-window busy intervals (those starting at the epoch) are split out
  * from cross-zone busy windows and applied as a forward shift *after*
  * overnight-window validation, so a cycle whose planned time has already
@@ -257,11 +264,7 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         console.warn(`planner: zone ${zone.id} (${zone.name}): overnight window (${windowMinutes} min) too short to fit even one cycle (maxCycle ${maximumCycleMinutes.toFixed(1)} min) on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
         return null;
     }
-    const totalRunTimeMinutes = Math.min(fullRefillRunTimeMinutes, maxRunTimeMinutes);
-    const grossIrrigationDepthMillimeters = (totalRunTimeMinutes / 60) * precipitationRateMillimetersPerHour;
-    if (totalRunTimeMinutes < fullRefillRunTimeMinutes) {
-        console.log(`planner: zone ${zone.id} (${zone.name}): clamping run time ${fullRefillRunTimeMinutes.toFixed(1)} → ${totalRunTimeMinutes.toFixed(1)} min on ${date.format('YYYY-MM-DD')} (window ${windowMinutes} min); applying ${grossIrrigationDepthMillimeters.toFixed(1)} of ${fullRefillGrossDepthMillimeters.toFixed(1)} mm.`);
-    }
+    const initialTotalRunTimeMinutes = Math.min(fullRefillRunTimeMinutes, maxRunTimeMinutes);
 
     // The daemon plumbs a "past window" — { start: epoch, end: now } — as a
     // busy interval that pushes past-dated cycles forward. It's handled
@@ -274,23 +277,47 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         ? busyWindowsSoFar.filter(w => w !== pastWindow)
         : busyWindowsSoFar;
 
-    const placedCycles = placeCyclesBackwardAvoidingBusy(
-        totalRunTimeMinutes,
-        maximumCycleMinutes,
-        sunrise,
-        soakTimeMinutes,
-        earliestStart,
-        crossZoneBusyWindows,
-    );
+    // Iterative downward cap (API-77). The closed-form `maxRunTimeMinutes`
+    // sizes against the *empty* overnight window; with earlier zones already
+    // planted, the residual gaps may not fit the chosen N cycles. Try N, then
+    // N-1, etc., until the placer succeeds. Shrinking N is more honest than
+    // a residual-time closed form because interleaving into soak gaps fits
+    // cycles when arithmetic says no. The first non-null placement wins.
+    const initialN = computeInitialCycleCount(initialTotalRunTimeMinutes, maximumCycleMinutes);
+    let placedCycles: IrrigationCycle[] | null = null;
+    let actualTotalRunTimeMinutes = 0;
+    for (let n = initialN; n >= 1; n--) {
+        const candidateRunTime = candidateTotalRunTime(n, fullRefillRunTimeMinutes, maximumCycleMinutes);
+        const candidatePerCycle = roundTo1Decimal(candidateRunTime / n);
+        if (candidatePerCycle <= 0) continue;
+        const candidate = placeCyclesBackwardAvoidingBusy(
+            n,
+            candidatePerCycle,
+            sunrise,
+            soakTimeMinutes,
+            earliestStart,
+            crossZoneBusyWindows,
+        );
+        if (candidate !== null) {
+            placedCycles = candidate;
+            actualTotalRunTimeMinutes = n * candidatePerCycle;
+            break;
+        }
+    }
 
     if (placedCycles === null) {
-        console.warn(`planner: zone ${zone.id} (${zone.name}): overnight window too short to fit the planned cycles on ${date.format('YYYY-MM-DD')} — deferring irrigation.`);
+        console.warn(`planner: zone ${zone.id} (${zone.name}): no cycle count from ${initialN} down fit the overnight window's residual gaps on ${date.format('YYYY-MM-DD')} — deferring irrigation.`);
         return null;
     }
 
     if (placedCycles.length === 0) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles fit the overnight window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
         return null;
+    }
+
+    const grossIrrigationDepthMillimeters = (actualTotalRunTimeMinutes / 60) * precipitationRateMillimetersPerHour;
+    if (actualTotalRunTimeMinutes < fullRefillRunTimeMinutes) {
+        console.log(`planner: zone ${zone.id} (${zone.name}): clamping run time ${fullRefillRunTimeMinutes.toFixed(1)} → ${actualTotalRunTimeMinutes.toFixed(1)} min on ${date.format('YYYY-MM-DD')} (window ${windowMinutes} min, ${placedCycles.length} cycle(s)); applying ${grossIrrigationDepthMillimeters.toFixed(1)} of ${fullRefillGrossDepthMillimeters.toFixed(1)} mm.`);
     }
 
     // Past-window handling differs by schedule shape (API-66):
@@ -349,8 +376,9 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
  * For `maxCycleMinutes <= 0` (no infiltration limit), a single uninterrupted
  * cycle is allowed up to the full window — there's no per-cycle ceiling.
  *
- * Exposed for upcoming partial-refill tests (API-75). Kept inside this module
- * because callers shouldn't need to reason about cycle math directly.
+ * Sizes against the *empty* window — API-77 wraps this in an outer downward
+ * retry that shrinks N when the residual gaps after cross-zone placement
+ * can't hold the closed-form plan.
  */
 function computeMaxRunTimeMinutes(maxCycleMinutes: number, soakTimeMinutes: number, windowMinutes: number): number {
     if (windowMinutes <= 0) return 0;
@@ -358,6 +386,30 @@ function computeMaxRunTimeMinutes(maxCycleMinutes: number, soakTimeMinutes: numb
     const cyclesThatFit = Math.floor((windowMinutes + soakTimeMinutes) / (maxCycleMinutes + soakTimeMinutes));
     if (cyclesThatFit <= 0) return 0;
     return cyclesThatFit * maxCycleMinutes;
+}
+
+/**
+ * Returns the initial cycle count (N) the iterative downward retry should
+ * start from, given a total runtime and per-cycle infiltration cap. Matches
+ * the pre-API-77 placer's internal derivation: N=1 for the no-cap / single-
+ * cycle case, otherwise `ceil(totalRunTime / maxCycle)`.
+ */
+function computeInitialCycleCount(totalRunTimeMinutes: number, maximumCycleMinutes: number): number {
+    if (totalRunTimeMinutes <= 0) return 0;
+    if (maximumCycleMinutes <= 0 || totalRunTimeMinutes <= maximumCycleMinutes) return 1;
+    return Math.ceil(totalRunTimeMinutes / maximumCycleMinutes);
+}
+
+/**
+ * Returns the candidate total runtime for `n` cycles inside the iterative
+ * downward retry: capped at the full-refill runtime (no point watering past
+ * a full refill) and at `n * maxCycle` (the infiltration ceiling for `n`
+ * cycles). When `maxCycle <= 0` (no infiltration limit) the only cap is
+ * the full refill.
+ */
+function candidateTotalRunTime(n: number, fullRefillRunTimeMinutes: number, maximumCycleMinutes: number): number {
+    if (maximumCycleMinutes <= 0) return fullRefillRunTimeMinutes;
+    return Math.min(fullRefillRunTimeMinutes, n * maximumCycleMinutes);
 }
 
 
@@ -381,37 +433,31 @@ function computeMaxRunTimeMinutes(maxCycleMinutes: number, soakTimeMinutes: numb
  * When a cycle still doesn't fit (sliding earlier would land before
  * `earliestStart` = midnight), the entire day is treated as un-irrigatable:
  * the function returns `null` so the caller defers and carries depletion
- * into the next allowed day.
+ * into the next allowed day. The caller (API-77) wraps this in an iterative
+ * downward retry, calling with progressively smaller `numberOfCycles` until
+ * placement succeeds.
  *
- * @param totalRunTimeMinutes - Total irrigation runtime needed.
- * @param maximumCycleMinutes - Maximum duration per cycle (infiltration limit).
+ * @param numberOfCycles - Number of cycles to lay down (chosen by the caller's
+ *   downward retry). Returns `[]` when zero.
+ * @param perCycleMinutes - Per-cycle duration. The caller picks this such
+ *   that `numberOfCycles * perCycleMinutes` matches the desired total runtime.
  * @param sunrise - End anchor: last cycle ends here (or earlier if busy windows displace it).
  * @param soakTimeMinutes - Soak gap between consecutive cycles of this zone.
  * @param earliestStart - Hard floor: no cycle may start before this time (midnight of the entry date).
  * @param busyWindows - Intervals occupied by other zones (or the past window
  *   if handled here). Cycles slide earlier to avoid overlap.
  * @returns Cycles in chronological order (earliest first), `null` when the
- *   day must be deferred, or `[]` when nothing needs to run.
+ *   day must be deferred, or `[]` when `numberOfCycles === 0`.
  */
 function placeCyclesBackwardAvoidingBusy(
-    totalRunTimeMinutes: number,
-    maximumCycleMinutes: number,
+    numberOfCycles: number,
+    perCycleMinutes: number,
     sunrise: dayjs.Dayjs,
     soakTimeMinutes: number,
     earliestStart: dayjs.Dayjs,
     busyWindows: ReadonlyArray<BusyWindow>,
 ): IrrigationCycle[] | null {
-    if (totalRunTimeMinutes <= 0) return [];
-
-    let numberOfCycles: number;
-    let perCycleMinutes: number;
-    if (maximumCycleMinutes <= 0 || totalRunTimeMinutes <= maximumCycleMinutes) {
-        numberOfCycles = 1;
-        perCycleMinutes = roundTo1Decimal(totalRunTimeMinutes);
-    } else {
-        numberOfCycles = Math.ceil(totalRunTimeMinutes / maximumCycleMinutes);
-        perCycleMinutes = roundTo1Decimal(totalRunTimeMinutes / numberOfCycles);
-    }
+    if (numberOfCycles <= 0 || perCycleMinutes <= 0) return [];
 
     const cyclesInReverse: IrrigationCycle[] = [];
     let cursor: dayjs.Dayjs = sunrise; // latest-allowed end for the next placed cycle (walking backward)

--- a/api/schedules/dynamic/multi-zone.test.ts
+++ b/api/schedules/dynamic/multi-zone.test.ts
@@ -882,4 +882,100 @@ describe('planZoneSchedule — multi-zone matrix', () => {
             expect(day0.depletionAfterMm).toBe(0);
         });
     });
+
+    describe('Theme J — Busy-window-aware clamp (API-77)', () => {
+        // Production-shaped "East" zone: clay soil just under the 5 mm/hr
+        // soak boundary (infiltration 4.8 mm/hr → 60-min soak), low precip
+        // (12 mm/hr). At 49.5 mm depletion the closed-form picks 5×24-min
+        // cycles whose 360-min span exactly fills the 360-min window — a
+        // single zone fits, but 3 sequential zones can't all fit 5 cycles
+        // each via interleaving (B's 5th cycle would land before midnight).
+        // Pre-API-77 the placer returned null and the night deferred entirely.
+        const CLAY_SLOW = { name: 'ClaySlow', availableWaterHoldingCapacityMmPerM: 165, infiltrationRateMmPerHr: 4.8 };
+        const EAST_LIKE_ZONE: Partial<Zone> = {
+            soil: CLAY_SLOW,
+            rootDepthM: 0.3,
+            allowableDepletionFraction: 0.5,
+            irrigationEfficiency: 0.8,
+            precipitationRateMmPerHr: 12,
+        };
+
+        it(`32. 3 zones × 49.5 mm depletion (East-like profile) — every zone gets at least one cycle on day 0; later zones' plans shrink rather than deferring.`, () => {
+            const zones = [
+                makeZone('a', { ...EAST_LIKE_ZONE, currentDepletionMm: 49.5 }),
+                makeZone('b', { ...EAST_LIKE_ZONE, currentDepletionMm: 49.5 }),
+                makeZone('c', { ...EAST_LIKE_ZONE, currentDepletionMm: 49.5 }),
+            ];
+            const weather = gatedWeather(7);
+
+            const results = planAllZonesSequentially(zones, weather);
+
+            // Each zone fires on day 0 — none defer to null. This is the
+            // central acceptance criterion: pre-API-77 the placer returned
+            // null for zone B (and C) and the entry was dropped.
+            const day0a = day0CyclesSorted(results.get('a')!, '2026-05-04');
+            const day0b = day0CyclesSorted(results.get('b')!, '2026-05-04');
+            const day0c = day0CyclesSorted(results.get('c')!, '2026-05-04');
+            expect(day0a.length).toBeGreaterThanOrEqual(1);
+            expect(day0b.length).toBeGreaterThanOrEqual(1);
+            expect(day0c.length).toBeGreaterThanOrEqual(1);
+            // No cross-zone overlap across the night.
+            assertNoCrossZoneOverlap(results);
+            assertProjectedDepletionSane(results, zones);
+            // Later zones shrink to fit; total cycles non-increasing across A→B→C.
+            expect(day0b.length).toBeLessThanOrEqual(day0a.length);
+            expect(day0c.length).toBeLessThanOrEqual(day0b.length);
+        });
+
+        it(`33. Synthetic cross-zone busy windows occupying most of the night — planner still emits a non-null plan and avoids the busy intervals.`, () => {
+            // Pre-plant two busy windows covering ~70% of the 360-min night
+            // (00:00 — 02:00 and 03:00 — 05:00). Zone A's closed-form would
+            // place 5 East-like cycles; the iterative retry must shrink N.
+            const date = START; // 2026-05-04
+            const busyWindows: BusyWindow[] = [
+                { start: date.hour(0).minute(0), end: date.hour(2).minute(0) },
+                { start: date.hour(3).minute(0), end: date.hour(5).minute(0) },
+            ];
+            const zone = makeZone('a', { ...EAST_LIKE_ZONE, currentDepletionMm: 49.5 });
+            const weather = gatedWeather(7);
+
+            const { entries } = planZoneSchedule(zone, weather, busyWindows);
+
+            expect(entries.length).toBeGreaterThan(0);
+            const day0 = entries[0]!;
+            expect(day0.cycles.length).toBeGreaterThanOrEqual(1);
+            // No cycle overlaps any busy window.
+            for (const cycle of day0.cycles) {
+                const cycleStart = cycle.startTime;
+                const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+                for (const window of busyWindows) {
+                    const overlaps = cycleStart.isBefore(window.end) && cycleEnd.isAfter(window.start);
+                    expect(overlaps).toBe(false);
+                }
+            }
+        });
+
+        it(`34. Easy case (3 zones with COMPACT profile, 22.5 mm depletion) — full refill for every zone; the retry does not over-shrink.`, () => {
+            const zones = [
+                makeZone('a', { currentDepletionMm: 22.5 }),
+                makeZone('b', { currentDepletionMm: 22.5 }),
+                makeZone('c', { currentDepletionMm: 22.5 }),
+            ];
+            const weather = gatedWeather(7);
+
+            const results = planAllZonesSequentially(zones, weather);
+
+            for (const [zoneId, result] of results) {
+                const day0 = result.entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+                expect(day0, `zone ${zoneId} missing day-0 entry`).toBeDefined();
+                const zone = zones.find(z => z.id === zoneId)!;
+                const fullRefillGross = day0!.depletionBeforeMm / zone.irrigationEfficiency;
+                // appliedDepthMm should match the full refill within rounding.
+                expect(Math.abs(day0!.appliedDepthMm - fullRefillGross)).toBeLessThanOrEqual(0.1);
+                expect(day0!.depletionAfterMm).toBe(0);
+            }
+            assertNoCrossZoneOverlap(results);
+            assertProjectedDepletionSane(results, zones);
+        });
+    });
 });

--- a/api/schedules/dynamic/multi-zone.test.ts
+++ b/api/schedules/dynamic/multi-zone.test.ts
@@ -582,14 +582,7 @@ describe('planZoneSchedule — multi-zone matrix', () => {
     describe('Theme F — Past-window mechanics', () => {
         const pastWindow = (now: Dayjs): BusyWindow => ({ start: dayjs(new Date(0)), end: now });
 
-        it('21. Past window without endBySunrise — every zone\'s day-0 cycles shift to start at-or-after now.', () => {
-            // Note (known planner limitation): when multiple zones get the
-            // past-window forward shift, each zone's cycles are re-anchored
-            // independently against the pastWindow only — not against the
-            // already-shifted cross-zone cycles. Result: B's shifted cycles
-            // can collide with A's shifted cycles. Tracked separately as a
-            // planner follow-up; this scenario only asserts the "shifted to
-            // at-or-after now" invariant, not cross-zone non-overlap.
+        it(`21. Past window without endBySunrise — every zone's day-0 cycles shift to start at-or-after now AND don't overlap earlier zones' shifted cycles (API-77).`, () => {
             const zones = [
                 makeZone('a', { currentDepletionMm: 22.5 }),
                 makeZone('b', { currentDepletionMm: 22.5 }),
@@ -620,6 +613,10 @@ describe('planZoneSchedule — multi-zone matrix', () => {
                     expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(now.valueOf());
                 }
             }
+            // The past-window forward shift now also dodges cross-zone busy
+            // windows (API-77) — shifted cycles must not collide with cycles
+            // already planted by an earlier zone in the per-zone loop.
+            assertNoCrossZoneOverlap(results);
         });
 
         it('22. Past window WITH endBySunrise — day-0 cycles dropped for every zone.', () => {
@@ -976,6 +973,44 @@ describe('planZoneSchedule — multi-zone matrix', () => {
             }
             assertNoCrossZoneOverlap(results);
             assertProjectedDepletionSane(results, zones);
+        });
+
+        it(`35. Past-window forward-shift respects cross-zone busy windows — pushed cycles don't overlap existing busy intervals.`, () => {
+            // Zone B's backward placement avoids zone A's busy windows; then
+            // the past-window forward shift could push B's cycles on top of
+            // A's windows. Pre-API-77 it did exactly that — now the shift
+            // dodges both pastWindow AND cross-zone busy windows.
+            const date = START; // 2026-05-04
+            const now = date.hour(2).minute(0); // 02:00 — between A's planted intervals
+            // Cross-zone busy windows: simulate zone A having already planted
+            // two windows that bracket `now`. The past-window shift will try
+            // to push B's cycles past 02:00; without the fix it lands on A.
+            const zoneABusyWindows: BusyWindow[] = [
+                { start: date.hour(2).minute(15), end: date.hour(2).minute(45) },
+                { start: date.hour(3).minute(0), end: date.hour(3).minute(30) },
+            ];
+            const pastWindow: BusyWindow = { start: dayjs(new Date(0)), end: now };
+            const busyWindows: BusyWindow[] = [pastWindow, ...zoneABusyWindows];
+
+            const zone = makeZone('b', { currentDepletionMm: 22.5 });
+            const weather = gatedWeather(7);
+
+            const { entries } = planZoneSchedule(zone, weather, busyWindows);
+
+            expect(entries.length).toBeGreaterThan(0);
+            const day0 = entries.find(e => e.date.format('YYYY-MM-DD') === '2026-05-04');
+            expect(day0).toBeDefined();
+            // Every placed cycle starts at-or-after now AND does not overlap
+            // any of A's busy windows.
+            for (const cycle of day0!.cycles) {
+                expect(cycle.startTime.valueOf()).toBeGreaterThanOrEqual(now.valueOf());
+                const cycleStart = cycle.startTime;
+                const cycleEnd = cycle.startTime.add(cycle.durationMin, 'minute');
+                for (const window of zoneABusyWindows) {
+                    const overlaps = cycleStart.isBefore(window.end) && cycleEnd.isAfter(window.start);
+                    expect(overlaps).toBe(false);
+                }
+            }
         });
     });
 });

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -7,7 +7,7 @@ import { grassTypes, irrigationCycles, scheduleEntries, schedules, sites, soilTy
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
-import type { IrrigationScheduleEntry, Zone } from '@/models';
+import type { DailyWeather, IrrigationScheduleEntry, Zone } from '@/models';
 import type { FutureCyclePair, PersistedCycle } from '@/models/cycle';
 import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
 import type { Schedule, SchedulesRepository } from '@/repositories/schedules';
@@ -15,6 +15,7 @@ import type { SitesRepository } from '@/repositories/sites';
 import type { WeatherStateRepository } from '@/repositories/weather-state';
 import type { ZoneJoinedRow, ZonesRepository } from '@/repositories/zones';
 import { joinedRowToZone } from '@/repositories/zones';
+import { planZoneSchedule } from '@/schedules/dynamic';
 import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
 import { bootSystemService } from '@/service/system';
 import { bootDaemonService, computeNextRePlanAt, start } from '.';
@@ -1211,6 +1212,69 @@ describe('start', () => {
                 expect(opens).not.toContain('zone-plan');
                 const warnMessages = warnSpy.mock.calls.map(args => String((args as unknown[])[0]));
                 expect(warnMessages.some(m => m.includes('overlaps a busy window'))).toBe(true);
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        it(`every cycle returned by replaceForZone passes the daemon's busy-window overlap predicate (API-77)`, async () => {
+            // Integration: feed the *real* planner into runPlan and assert
+            // the daemon emits no "overlaps a busy window — not arming"
+            // warnings. Pre-API-77 the planner could shift past-due cycles
+            // on top of cross-zone busy windows; the daemon then refused to
+            // arm them and the warning was a routine event for multi-zone
+            // schedules. Post-fix the planner's output respects the daemon's
+            // overlap predicate by construction.
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                const enabledRows = [
+                    buildJoinedRow({ zone: { id: 'zone-A', name: 'Zone A', currentDepletionMm: 22.5 } }),
+                    buildJoinedRow({ zone: { id: 'zone-B', name: 'Zone B', currentDepletionMm: 22.5 } }),
+                    buildJoinedRow({ zone: { id: 'zone-C', name: 'Zone C', currentDepletionMm: 22.5 } }),
+                ];
+                const futureRow = buildFutureCycleRow({
+                    cycle: { id: 'cycle-inflight', startTime: new Date('2026-05-04T12:30:00.000Z'), durationMin: 60 },
+                    zone: { id: 'zone-inflight' },
+                });
+                const stub = createDaemonReposStub({
+                    enabledZones: enabledRows,
+                    futureCycles: [futureRow],
+                });
+                bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+                const { clock } = createFakeClock(NOW);
+
+                // Synthetic weather: 6:00 sunrise (360-min window).
+                const weather: DailyWeather[] = Array.from({ length: 7 }, (_, i) => {
+                    const date = dayjs('2026-05-04').add(i, 'day');
+                    return {
+                        date,
+                        sunrise: date.hour(6).minute(0).second(0),
+                        sunset: date.hour(20).minute(0).second(0),
+                        rainfallMm: 0,
+                        evapotranspirationMmPerDay: 2.0,
+                    };
+                });
+
+                const control = await start({
+                    clock,
+                    rePlanHourLocal: 4,
+                    runPlan: async (zone, opts) => {
+                        const busy = (opts?.busyWindows ?? []).map(w => ({
+                            start: dayjs(w.start),
+                            end: dayjs(w.end),
+                        }));
+                        return planZoneSchedule(zone, weather, busy);
+                    },
+                    getZoneState: async () => 'off',
+                    openZone: async () => {},
+                    closeZone: async () => {},
+                });
+
+                await control.rePlan();
+
+                const warnMessages = warnSpy.mock.calls.map(args => String((args as unknown[])[0]));
+                const overlapWarnings = warnMessages.filter(m => m.includes('overlaps a busy window'));
+                expect(overlapWarnings).toEqual([]);
             } finally {
                 warnSpy.mockRestore();
             }


### PR DESCRIPTION
## Ticket

[API-77](http://192.168.2.100:7123/home/browse/API-77/) Make API-75 clamp busy-window-aware; audit placer vs arm-time overlap disagreement

## Summary

- **Iterative downward cap retry.** API-75's `computeMaxRunTimeMinutes` sized per-zone runtime against the *empty* overnight window. With earlier zones in the per-zone loop already planted, the closed-form N was too large for the residual gaps — the placer returned `null` and the night deferred entirely. The placer's API now takes `(numberOfCycles, perCycleMinutes)` directly, and `tryPlaceIrrigationForDay` retries with N-1, N-2, …, until placement succeeds or N=0. The actual placed runtime drives the partial-refill `appliedDepthMm` / `depletionAfterMm` math.
- **Cross-zone-aware past-window deconflict.** `deconflictCycles` for the past-window forward shift now receives `[pastWindow, ...crossZoneBusyWindows]` instead of just `[pastWindow]`. Pre-fix, shifting past-due cycles forward could land them on top of in-flight cycles or earlier zones' planned intervals; the daemon caught these at arm time and refused to arm, persisting dead rows.
- **Daemon arm-time invariant test** wires the real planner into `runPlan` and asserts the daemon never logs `'overlaps a busy window — not arming'` for planner output — the placer and the daemon overlap predicate now agree by construction.
- New Theme J tests (32 / 33 / 34 / 35) covering: 3-zone deep-deficit interleave (acceptance scenario), synthetic busy windows triggering shrink, no-shrink regression, and past-window forward-shift respecting cross-zone busy windows. Strengthened Theme F test 21 to assert cross-zone non-overlap after the shift.