### PR TITLE
[APP-50] Paint opaque dark backdrop behind the status bar

### DIFF
--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -44,7 +44,7 @@ jest.mock('react-native-safe-area-context', () => {
         SafeAreaProvider: ({ children }: { children?: React.ReactNode }) => (
             <View>{children}</View>
         ),
-        useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+        useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
     };
 });
 
@@ -102,5 +102,11 @@ describe('RootLayout', () => {
         const registeredNames = mockStackScreen.mock.calls.map(([props]) => props.name);
         expect(registeredNames).toContain('modal');
         expect(registeredNames).not.toContain('(tabs)');
+    });
+
+    it('paints the opaque status-bar backdrop so the system bar is not transparent (APP-50).', () => {
+        render(<RootLayout />);
+
+        expect(screen.getByLabelText('Status bar backdrop')).toBeOnTheScreen();
     });
 });

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -9,6 +9,7 @@ import { ApiProvider } from '@/api/provider';
 import { CanvasBackground } from '@/components/canvas-background';
 import { FontLoader } from '@/components/font-loader';
 import { NotificationsBridge } from '@/components/notifications-bridge';
+import { StatusBarBackdrop } from '@/components/status-bar-backdrop';
 import '../global.css';
 
 // Hold the native splash from auto-hiding so FontLoader can keep it visible
@@ -44,6 +45,7 @@ export default function RootLayout() {
                             </Stack>
                             <NotificationsBridge />
                         </CanvasBackground>
+                        <StatusBarBackdrop />
                         <StatusBar style='light' />
                     </ThemeProvider>
                 </SafeAreaProvider>

--- a/app/components/status-bar-backdrop.test.tsx
+++ b/app/components/status-bar-backdrop.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+let mockTopInset = 0;
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: mockTopInset, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { StatusBarBackdrop } from './status-bar-backdrop';
+
+describe('StatusBarBackdrop', () => {
+    afterEach(() => {
+        mockTopInset = 0;
+    });
+
+    it('renders nothing when the top inset is zero (web / desktop).', () => {
+        mockTopInset = 0;
+
+        render(<StatusBarBackdrop />);
+
+        expect(screen.queryByLabelText('Status bar backdrop')).toBeNull();
+    });
+
+    it('renders an opaque painter with the canvas color and the inset height when the top inset is positive.', () => {
+        mockTopInset = 42;
+
+        render(<StatusBarBackdrop />);
+
+        const painter = screen.getByLabelText('Status bar backdrop');
+        const style = StyleSheet.flatten(painter.props.style) as {
+            backgroundColor?: string;
+            height?: number;
+            position?: string;
+        };
+        expect(style.backgroundColor).toBe('#06090A');
+        expect(style.height).toBe(42);
+        expect(style.position).toBe('absolute');
+    });
+
+    it('honors a custom backdrop color.', () => {
+        mockTopInset = 32;
+
+        render(<StatusBarBackdrop color='#123456' />);
+
+        const painter = screen.getByLabelText('Status bar backdrop');
+        const style = StyleSheet.flatten(painter.props.style) as { backgroundColor?: string };
+        expect(style.backgroundColor).toBe('#123456');
+    });
+});

--- a/app/components/status-bar-backdrop.tsx
+++ b/app/components/status-bar-backdrop.tsx
@@ -1,0 +1,38 @@
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const CANVAS_BG = '#06090A';
+
+export type StatusBarBackdropProps = {
+    /** Optional. Hex/rgba color filling the status-bar inset. Defaults to the canvas base `#06090A`. */
+    color?: string;
+};
+
+/**
+ * Paints an opaque rectangle behind the system status bar so its icons read
+ * cleanly against busy screens. Needed because Android's `edgeToEdgeEnabled`
+ * (set in app.json so the bottom-nav inset behaves) causes the app to draw
+ * under the system bars, and `expo-status-bar`'s `backgroundColor` prop is
+ * ignored when edge-to-edge is on (Expo SDK 54).
+ *
+ * Returns `null` when the top inset is zero (web / desktop) so no spurious
+ * 0-height view is left in the tree.
+ */
+export function StatusBarBackdrop({ color = CANVAS_BG }: StatusBarBackdropProps = {}) {
+    const insets = useSafeAreaInsets();
+    if (insets.top === 0) return null;
+    return (
+        <View
+            accessibilityLabel='Status bar backdrop'
+            pointerEvents='none'
+            style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                height: insets.top,
+                backgroundColor: color,
+            }}
+        />
+    );
+}


### PR DESCRIPTION
## Ticket

[APP-50](http://192.168.2.100:7123/home/browse/APP-50/) Status bar should not be transparent

## Summary

- New `StatusBarBackdrop` component: absolute-positioned `<View>` filling `useSafeAreaInsets().top` with the canvas base `#06090A`. Returns `null` when `insets.top === 0` (web / desktop).
- Rendered inside the root `<SafeAreaProvider> / <ThemeProvider>` as a sibling of `<CanvasBackground>`, so the system status-bar inset has a solid dark backdrop while edge-to-edge stays on for the bottom-nav benefit.
- Tests: 3 new `status-bar-backdrop.test.tsx` cases covering zero-inset, positive-inset (default color + height), and color override; root-layout test asserts the backdrop is present.

## Test plan

- [ ] Rebuild the APK via `./build-apk.sh` and confirm on the Pixel that the status bar has an opaque dark backdrop and content no longer scrolls under the clock.