### PR TITLE
[APP-43] Hide the firing-state badge in the next-run tile

### DIFF
--- a/app/components/next-run-hero/.test.tsx
+++ b/app/components/next-run-hero/.test.tsx
@@ -131,7 +131,7 @@ describe('NextRunHero', () => {
         expect(screen.getByText('Scheduled')).toBeOnTheScreen();
     });
 
-    it('renders the Firing badge when state is firing.', () => {
+    it('does not render a badge when state is firing (APP-43).', () => {
         render(
             <NextRunHero
                 nextRun={{ ...SCHEDULED_NEXT_RUN, state: 'firing' }}
@@ -140,7 +140,14 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.getByText('Firing')).toBeOnTheScreen();
+        // The body of the card still renders — just the badge is suppressed.
+        expect(screen.getByText('10:23 pm')).toBeOnTheScreen();
+        // None of the badge labels appear.
+        expect(screen.queryByText('Firing')).toBeNull();
+        expect(screen.queryByText('Scheduled')).toBeNull();
+        expect(screen.queryByText('Skipped rain')).toBeNull();
+        expect(screen.queryByText('Skipped')).toBeNull();
+        expect(screen.queryByText('Idle')).toBeNull();
     });
 
     it('renders the embedded compact CycleStrip with the per-zone palette applied.', () => {

--- a/app/components/next-run-hero/index.tsx
+++ b/app/components/next-run-hero/index.tsx
@@ -68,6 +68,7 @@ export function NextRunHero({ nextRun, siteTimezone, now }: NextRunHeroProps) {
 
     const timeOfDay = formatTimeOfDay(nextRun.startTime, resolvedTimezone);
     const dateLabel = formatNextRunDate(nextRun.startTime, resolvedTimezone, resolvedNow);
+    const badgeLabel = badgeLabelForState(nextRun.state);
 
     return (
         <View style={[styles.card, styles.cardActive]} accessibilityLabel={`Next run at ${timeOfDay}`}>
@@ -78,7 +79,7 @@ export function NextRunHero({ nextRun, siteTimezone, now }: NextRunHeroProps) {
                     <Text style={styles.subtitle}>{dateLabel}</Text>
                 </View>
 
-                <Badge tone={badgeToneForState(nextRun.state)}>{badgeLabelForState(nextRun.state)}</Badge>
+                {badgeLabel !== null && <Badge tone={badgeToneForState(nextRun.state)}>{badgeLabel}</Badge>}
             </View>
 
             {cycleStripNight !== null && (
@@ -96,12 +97,13 @@ function badgeToneForState(state: NextRunState): BadgeTone {
     return 'neutral';
 }
 
-function badgeLabelForState(state: NextRunState): string {
+function badgeLabelForState(state: NextRunState): string | null {
     switch (state) {
         case 'scheduled':
             return 'Scheduled';
         case 'firing':
-            return 'Firing';
+            // Hidden — the badge isn't meaningful to operators during a run (APP-43).
+            return null;
         case 'skipped-rain':
             return 'Skipped rain';
         case 'skipped-manual':


### PR DESCRIPTION
## Ticket

[APP-43](http://192.168.2.100:7123/home/browse/APP-43/) Hide "Firing" badge state in next-run tile

## Summary

- `badgeLabelForState('firing')` now returns `null`; the `<Badge>` only renders when the label is non-null. Other badge states ("Scheduled", "Skipped rain", "Skipped", "Idle") render as before.
- Flipped the existing "renders the Firing badge" test to assert the absence of every badge label when the state is firing.