### PR TITLE
[APP-56] Stabilise master-toggle panel height across toggles

### DIFF
--- a/app/components/master-toggle/.test.tsx
+++ b/app/components/master-toggle/.test.tsx
@@ -43,8 +43,25 @@ describe('MasterToggle', () => {
 
         await waitFor(() => expect(screen.getByText('System off')).toBeOnTheScreen());
         expect(screen.getByText('Irrigation disabled')).toBeOnTheScreen();
-        expect(screen.getByText('Master kill switch · all runs blocked')).toBeOnTheScreen();
+        expect(screen.getByText('Scheduling & manual runs blocked')).toBeOnTheScreen();
         expect(screen.getByLabelText('Enable irrigation')).toBeOnTheScreen();
+    });
+
+    it(`subtitle strings for enabled and disabled are the same length so toggling doesn't shift the panel height (APP-56).`, async () => {
+        // Render the enabled card and capture its subtitle.
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: true, since: SAMPLE_TIMESTAMP }));
+        const enabledRender = render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+        await waitFor(() => expect(enabledRender.getByText('Scheduling & manual runs allowed')).toBeOnTheScreen());
+        const enabledSub = enabledRender.getByText('Scheduling & manual runs allowed').props.children as string;
+        enabledRender.unmount();
+
+        // Render the disabled card and capture its subtitle.
+        mockFetch.mockResolvedValueOnce(jsonResponse({ irrigationEnabled: false, since: SAMPLE_TIMESTAMP }));
+        const disabledRender = render(<MasterToggle />, { wrapper: buildApiWrapper().wrapper });
+        await waitFor(() => expect(disabledRender.getByText('Scheduling & manual runs blocked')).toBeOnTheScreen());
+        const disabledSub = disabledRender.getByText('Scheduling & manual runs blocked').props.children as string;
+
+        expect(disabledSub.length).toBe(enabledSub.length);
     });
 
     it('POSTs /system/disable when the toggle is flipped from on to off.', async () => {

--- a/app/components/master-toggle/index.tsx
+++ b/app/components/master-toggle/index.tsx
@@ -65,7 +65,7 @@ export function MasterToggle({ accessibilityLabel = DEFAULT_LABEL }: MasterToggl
                     {mutationErrorSub
                         ?? (on
                             ? 'Scheduling & manual runs allowed'
-                            : 'Master kill switch · all runs blocked')}
+                            : 'Scheduling & manual runs blocked')}
                 </Text>
             </View>
 


### PR DESCRIPTION
## Ticket

[APP-56](http://192.168.2.100:7123/home/browse/APP-56/) Irrigation toggle subtitle causes layout shift on toggle

## Summary

- Rewrote the disabled subtitle from "Master kill switch · all runs blocked" (37 chars) to "Scheduling & manual runs blocked" (32 chars), mirroring the enabled subtitle's structure character-for-character.
- Added a new test (`.test.tsx`) that pins the symmetry invariant: both subtitle strings must be exactly the same length, so future copy edits can't reintroduce the layout shift.