### PR TITLE
[APP-54] Server-drive site timezone via /tonight to fix UTC display

### DIFF
--- a/api/models/tonight.ts
+++ b/api/models/tonight.ts
@@ -41,6 +41,10 @@ export type TonightZone = {
  * aren't yet persisted on the underlying entries. `sunset` / `sunrise` are
  * site-local `HH:MM` strings (or `null` during the bootstrap window before
  * the planner has populated the columns).
+ *
+ * `timezone` is the IANA name of the site the response is anchored to (e.g.
+ * `'America/Edmonton'`). The client uses it to format `startTime` / `endsAt`
+ * in site-local time instead of depending on a build-time env var (APP-54).
  */
 export type TonightDto = {
     state: TonightState;
@@ -50,6 +54,7 @@ export type TonightDto = {
     axisEnd: string | null;
     sunset: string | null;
     sunrise: string | null;
+    timezone: string;
     zoneOrder: string[];
     totalCycles: number;
     zones: TonightZone[];

--- a/api/service/tonight/.test.ts
+++ b/api/service/tonight/.test.ts
@@ -115,6 +115,31 @@ describe('getTonightSummary', () => {
         bootTonightWith([]);
     });
 
+    describe('timezone (APP-54)', () => {
+        it('always includes the resolved site timezone on the DTO — across skipped, idle, and scheduled paths', async () => {
+            // Use a non-UTC timezone to prove the field carries the configured
+            // value rather than a hard-coded default.
+            bootSites('America/Edmonton');
+
+            // Skipped-manual via kill switch.
+            bootSystem(false);
+            expect((await getTonightSummary(NOW)).timezone).toBe('America/Edmonton');
+
+            // Idle (no rows).
+            bootSystem(true);
+            bootTonightWith([]);
+            expect((await getTonightSummary(NOW)).timezone).toBe('America/Edmonton');
+
+            // Scheduled (a tonight row exists).
+            bootTonightWith([{
+                entry: buildEntry(),
+                cycle: buildCycle({ startTime: new Date('2026-05-21T03:00:00.000Z'), durationMin: 30 }),
+                zone: buildZone(),
+            }]);
+            expect((await getTonightSummary(NOW)).timezone).toBe('America/Edmonton');
+        });
+    });
+
     describe('skipped-manual', () => {
         it('returns state: skipped-manual with empty zones when the system kill switch is off', async () => {
             bootSystem(false);

--- a/api/service/tonight/index.ts
+++ b/api/service/tonight/index.ts
@@ -63,13 +63,13 @@ export async function getTonightSummary(now: Date): Promise<TonightDto> {
 
     const system = await getSystemState();
     if (!system.irrigationEnabled) {
-        return emptyDto('skipped-manual');
+        return emptyDto('skipped-manual', siteTimezone);
     }
 
     const activeSchedules = await loadActiveSchedulesBySite();
     for (const sched of activeSchedules.values()) {
         if (sched.skippedNightDate === todaySiteLocal) {
-            return emptyDto('skipped-manual');
+            return emptyDto('skipped-manual', siteTimezone);
         }
     }
 
@@ -86,14 +86,14 @@ export async function getTonightSummary(now: Date): Promise<TonightDto> {
 
     const tonightDate = pickTonightDate(byDate, now);
     if (tonightDate === null) {
-        return emptyDto('idle');
+        return emptyDto('idle', siteTimezone);
     }
 
     const tonightRows = byDate.get(tonightDate) ?? [];
     return buildDto(tonightRows, siteTimezone);
 }
 
-function emptyDto(state: TonightState): TonightDto {
+function emptyDto(state: TonightState, siteTimezone: string): TonightDto {
     return {
         state,
         startTime: null,
@@ -102,6 +102,7 @@ function emptyDto(state: TonightState): TonightDto {
         axisEnd: null,
         sunset: null,
         sunrise: null,
+        timezone: siteTimezone,
         zoneOrder: [],
         totalCycles: 0,
         zones: [],
@@ -160,7 +161,7 @@ function buildDto(rows: TonightJoinedRow[], siteTimezone: string): TonightDto {
     if (allCycleStarts.length === 0) {
         // Edge case: entries exist for the date but no cycles (e.g. day was
         // restricted post-planning). Treat as idle — there's nothing to render.
-        return emptyDto('idle');
+        return emptyDto('idle', siteTimezone);
     }
 
     const state: TonightState = cyclesFiring.some(x => x) ? 'firing' : 'scheduled';
@@ -197,6 +198,7 @@ function buildDto(rows: TonightJoinedRow[], siteTimezone: string): TonightDto {
         axisEnd: sunrise ?? formatSiteLocal(endsAt, siteTimezone),
         sunset,
         sunrise,
+        timezone: siteTimezone,
         zoneOrder: zonesSorted.map(z => z.name),
         totalCycles: allCycleStarts.length,
         zones: dtoZones,

--- a/app/api/types/next-run.ts
+++ b/app/api/types/next-run.ts
@@ -28,6 +28,10 @@ export type NextRunZone = {
  * to `/next-run` — see follow-up API ticket). `startTime` / `endsAt` are
  * ISO-8601 UTC instants (or `null`). `axisStart` / `axisEnd` / `sunset` /
  * `sunrise` are site-local `HH:MM` strings.
+ *
+ * `timezone` is the site's IANA timezone (e.g. `'America/Edmonton'`) — the
+ * client uses it to format `startTime` / `endsAt` in site-local time rather
+ * than relying on a build-time env var (APP-54).
  */
 export type NextRunDto = {
     state: NextRunState;
@@ -37,6 +41,7 @@ export type NextRunDto = {
     axisEnd: string | null;
     sunset: string | null;
     sunrise: string | null;
+    timezone: string;
     zoneOrder: string[];
     totalCycles: number;
     zones: NextRunZone[];

--- a/app/components/home-view/.test.tsx
+++ b/app/components/home-view/.test.tsx
@@ -29,6 +29,7 @@ const NEXT_RUN_SCHEDULED: NextRunDto = {
     axisEnd: '06:00',
     sunset: '20:45',
     sunrise: '05:30',
+    timezone: 'America/Edmonton',
     zoneOrder: ['North'],
     totalCycles: 5,
     zones: [{ name: 'North', slug: 'north', patch: 'a', cycles: [{ start: '22:23', durMin: 15 }] }],
@@ -125,6 +126,24 @@ describe('HomeView', () => {
         // eyebrow is absent. The inner card's own "Next run" eyebrow stays.
         await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
         expect(screen.queryByText(/Next run · America\/Edmonton/)).toBeNull();
+    });
+
+    it('formats the next-run time in the API-provided timezone — env-var EXPO_PUBLIC_SITE_TIMEZONE has no influence (APP-54).', async () => {
+        // Set the env-var hypothesis to a *wrong* timezone. The displayed
+        // time must still match the API's `timezone` field (Edmonton), not
+        // the env-var override (UTC), which would render as 4:23 am.
+        const saved = process.env.EXPO_PUBLIC_SITE_TIMEZONE;
+        process.env.EXPO_PUBLIC_SITE_TIMEZONE = 'UTC';
+        try {
+            setupSuccessfulFetch();
+            render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
+
+            await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
+            expect(screen.queryByText('4:23 am')).toBeNull();
+        } finally {
+            if (saved === undefined) delete process.env.EXPO_PUBLIC_SITE_TIMEZONE;
+            else process.env.EXPO_PUBLIC_SITE_TIMEZONE = saved;
+        }
     });
 
     it('renders a zone tile for every zone returned by /zones.', async () => {

--- a/app/components/home-view/index.tsx
+++ b/app/components/home-view/index.tsx
@@ -12,7 +12,6 @@ import { useNextRun } from '@/hooks/next-run';
 import { useSchedules } from '@/hooks/schedules';
 import { useSystem } from '@/hooks/system';
 import { useZones } from '@/hooks/zones';
-import { getSiteTimezone } from '@/lib/site-timezone';
 import type { ZoneSummary } from '@/api/types/zones';
 import config from '@/tailwind.config';
 
@@ -35,7 +34,6 @@ export function HomeView() {
 
     const irrigationEnabled = system.data?.irrigationEnabled ?? true;
     const activeSchedule = schedules.data?.find(item => item.isActive) ?? null;
-    const siteTimezone = getSiteTimezone();
 
     const handleZonePress = (zone: ZoneSummary): void => {
         router.push(`/zone/${zone.slug}` as never);
@@ -59,7 +57,9 @@ export function HomeView() {
                     ) : nextRun.isError || nextRun.data == null ? (
                         <PlaceholderCard label='Failed to load next run.' tone='error' />
                     ) : (
-                        <NextRunHero nextRun={nextRun.data} siteTimezone={siteTimezone} />
+                        // siteTimezone comes from the API response — single
+                        // source of truth, no env-var dependency (APP-54).
+                        <NextRunHero nextRun={nextRun.data} siteTimezone={nextRun.data.timezone} />
                     )}
 
                     <View style={styles.zonesHeading}>

--- a/app/components/next-run-hero/.test.tsx
+++ b/app/components/next-run-hero/.test.tsx
@@ -17,6 +17,7 @@ const SCHEDULED_NEXT_RUN: NextRunDto = {
     axisEnd: '06:00',
     sunset: '20:45',
     sunrise: '05:30',
+    timezone: 'America/Edmonton',
     zoneOrder: ['North', 'South'],
     totalCycles: 10,
     zones: [
@@ -33,6 +34,7 @@ const IDLE_NEXT_RUN: NextRunDto = {
     axisEnd: null,
     sunset: null,
     sunrise: null,
+    timezone: 'America/Edmonton',
     zoneOrder: [],
     totalCycles: 0,
     zones: [],


### PR DESCRIPTION
## Ticket

[APP-54](http://192.168.2.100:7123/home/browse/APP-54/) Next-run tile shows start time in wrong timezone

## Investigation

The home tile was displaying `6:32am` — matching the raw UTC `startTime`. The three hypotheses on the ticket:

1. `EXPO_PUBLIC_SITE_TIMEZONE` not injected into the APK build → fallback to hardcoded `'America/Edmonton'` — **most likely**.
2. `siteTimezone` prop not forwarded — verifiably false: `home-view/index.tsx:38–62` passes it correctly.
3. `dayjs.tz` plugin not extended — verifiably false: `dayjs.extend(timezone)` runs at `lib/relative-time/index.ts:7–8` on module load.

## Summary

- **API**: `TonightDto` now carries `timezone: string`, populated from `getSiteTimezone()` in the tonight service. Server is now the single source of truth for the site's IANA timezone.
- **App**: `NextRunDto` mirrors the new field. `home-view/index.tsx` reads `nextRun.data.timezone` and passes it as the `siteTimezone` prop — no more `getSiteTimezone()` env-var lookup in the home view.
- **Tests**: a new home-view test sets `EXPO_PUBLIC_SITE_TIMEZONE='UTC'` and asserts the displayed time still matches `America/Edmonton` (the API's value), proving the env var has no influence. API service test asserts `timezone` is present on every DTO path (skipped/idle/scheduled).

If after this lands the time *still* displays as UTC, the remaining hypothesis is Hermes Intl — we'd add an Intl polyfill in a follow-up. But the env-var dependency was the most likely cause and is now eliminated.