### PR TITLE
[APP-55] Fix zone tiles always showing "Last ran just now"

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -889,7 +889,7 @@ describe('buildApp GET /zones', () => {
             precipitationRateMmPerHr: null,
             currentDepletionMm: 12.4,
             rawMm: 21,
-            lastFiredAt: '2026-05-13',
+            lastFiredAt: '2026-05-13T05:00:00.000Z',
             lastAppliedMm: 14,
             homeAssistantEntityId: 'switch.sprinkler_controller_north_zone',
             patch: 'a',

--- a/api/models/zone.ts
+++ b/api/models/zone.ts
@@ -27,13 +27,14 @@ export type ZoneSummary = {
 };
 
 /**
- * Latest schedule-entry row per zone, as returned by `loadLatestScheduleEntries`.
- * `date` is the entry-date column (Postgres `date`, day-granularity) serialised
- * as a `YYYY-MM-DD` string. `appliedDepthMm` is the gross depth that was applied
- * to the zone on that date.
+ * Most-recent actual fire per zone, as returned by `loadLatestFires`. `firedAt`
+ * is the `irrigation_cycles.fired_at` timestamp of the latest cycle that
+ * actually opened the valve — *not* the latest `schedule_entries.date`, which
+ * would also include planned future entries written by the nightly planner.
+ * `appliedDepthMm` is the gross depth of the parent `schedule_entries` row.
  */
 export type LatestZoneFire = {
     zoneId: string;
-    date: string;
+    firedAt: Date;
     appliedDepthMm: number;
 };

--- a/api/repositories/zones/.test.ts
+++ b/api/repositories/zones/.test.ts
@@ -141,21 +141,48 @@ function stubSummaryJoinDb(rows: SummaryJoinedRow[]): { db: Database; getSelectC
     return { db, whereCalls, getSelectColumns: () => selectColumns };
 }
 
-function stubLatestEntriesDb(rows: LatestZoneFire[]): { db: Database; onCalls: Array<ReadonlyArray<unknown>>; orderByCalls: Array<ReadonlyArray<unknown>> } {
+type StubLatestFiresHandles = {
+    db: Database;
+    onCalls: Array<ReadonlyArray<unknown>>;
+    fromCalls: Array<unknown>;
+    innerJoinCalls: Array<{ table: unknown; on: unknown }>;
+    whereCalls: Array<unknown>;
+    orderByCalls: Array<ReadonlyArray<unknown>>;
+};
+
+function stubLatestFiresDb(rows: LatestZoneFire[]): StubLatestFiresHandles {
     const onCalls: Array<ReadonlyArray<unknown>> = [];
+    const fromCalls: Array<unknown> = [];
+    const innerJoinCalls: Array<{ table: unknown; on: unknown }> = [];
+    const whereCalls: Array<unknown> = [];
     const orderByCalls: Array<ReadonlyArray<unknown>> = [];
 
     const runOrderBy = async (...exprs: ReadonlyArray<unknown>): Promise<LatestZoneFire[]> => {
         orderByCalls.push(exprs);
         return rows;
     };
+    const whereChain = { orderBy: runOrderBy };
+    const runWhere = (cond: unknown) => {
+        whereCalls.push(cond);
+        return whereChain;
+    };
+    const innerJoinChain = { where: runWhere };
+    const runInnerJoin = (table: unknown, on: unknown) => {
+        innerJoinCalls.push({ table, on });
+        return innerJoinChain;
+    };
+    const fromChain = { innerJoin: runInnerJoin };
+    const runFrom = (table: unknown) => {
+        fromCalls.push(table);
+        return fromChain;
+    };
     const runSelectDistinctOn = (on: ReadonlyArray<unknown>) => {
         onCalls.push(on);
-        return { from: () => ({ orderBy: runOrderBy }) };
+        return { from: runFrom };
     };
 
     const db = { selectDistinctOn: runSelectDistinctOn } as unknown as Database;
-    return { db, onCalls, orderByCalls };
+    return { db, onCalls, fromCalls, innerJoinCalls, whereCalls, orderByCalls };
 }
 
 function summaryRow(overrides?: {
@@ -437,29 +464,41 @@ describe('createZonesRepository.advanceDepletion', () => {
     });
 });
 
-describe('createZonesRepository.loadLatestScheduleEntries', () => {
+describe('createZonesRepository.loadLatestFires', () => {
     it('returns the rows produced by the distinct-on query', async () => {
         const entries: LatestZoneFire[] = [
-            { zoneId: 'zone-1', date: '2026-05-13', appliedDepthMm: 14 },
-            { zoneId: 'zone-2', date: '2026-05-12', appliedDepthMm: 9 },
+            { zoneId: 'zone-1', firedAt: new Date('2026-05-13T05:00:00.000Z'), appliedDepthMm: 14 },
+            { zoneId: 'zone-2', firedAt: new Date('2026-05-12T05:00:00.000Z'), appliedDepthMm: 9 },
         ];
-        const { db } = stubLatestEntriesDb(entries);
+        const { db } = stubLatestFiresDb(entries);
         const repo = createZonesRepository(db);
 
-        const result = await repo.loadLatestScheduleEntries();
+        const result = await repo.loadLatestFires();
 
         expect(result).toEqual(entries);
     });
 
-    it('groups the distinct-on result by zoneId and orders descending by date', async () => {
-        const { db, onCalls, orderByCalls } = stubLatestEntriesDb([]);
+    it('groups the distinct-on result by zoneId and orders descending by fired_at', async () => {
+        const { db, onCalls, orderByCalls } = stubLatestFiresDb([]);
         const repo = createZonesRepository(db);
 
-        await repo.loadLatestScheduleEntries();
+        await repo.loadLatestFires();
 
         expect(onCalls).toHaveLength(1);
         expect(onCalls[0]).toHaveLength(1);
         expect(orderByCalls).toHaveLength(1);
         expect(orderByCalls[0]).toHaveLength(2);
+    });
+
+    it('reads from irrigation_cycles joined to schedule_entries and filters by non-null fired_at', async () => {
+        const { db, fromCalls, innerJoinCalls, whereCalls } = stubLatestFiresDb([]);
+        const repo = createZonesRepository(db);
+
+        await repo.loadLatestFires();
+
+        expect(fromCalls).toHaveLength(1);
+        expect(innerJoinCalls).toHaveLength(1);
+        expect(innerJoinCalls[0]?.table).toBeDefined();
+        expect(whereCalls).toHaveLength(1);
     });
 });

--- a/api/repositories/zones/index.ts
+++ b/api/repositories/zones/index.ts
@@ -1,6 +1,6 @@
-import { desc, eq, sql } from 'drizzle-orm';
+import { desc, eq, isNotNull, sql } from 'drizzle-orm';
 import type { Database } from '@/db';
-import { grassTypes, scheduleEntries, sites, soilTypes, zones } from '@/db/schema';
+import { grassTypes, irrigationCycles, scheduleEntries, sites, soilTypes, zones } from '@/db/schema';
 import type { Zone } from '@/models';
 import type { LatestZoneFire } from '@/models/zone';
 
@@ -53,8 +53,14 @@ export interface ZonesRepository {
     /** Loads the zones × grass × soil joined rows used by the summary payload. */
     loadJoinedRowsForSummary(): Promise<SummaryJoinedRow[]>;
 
-    /** Loads the most-recent `schedule_entries` row per zone (one row per zone that has fired). */
-    loadLatestScheduleEntries(): Promise<LatestZoneFire[]>;
+    /**
+     * Loads the most-recent actual fire per zone — the `irrigation_cycles` row
+     * with the largest `fired_at` per zone (joined to its parent
+     * `schedule_entries` for `applied_depth_mm`). Filters out cycles that
+     * never opened (`fired_at IS NULL`). Zones that have never fired return
+     * no row.
+     */
+    loadLatestFires(): Promise<LatestZoneFire[]>;
 
     /**
      * Writes `current_depletion_mm` for the zone. Called by the daemon on two
@@ -130,15 +136,24 @@ export function createZonesRepository(db: Database): ZonesRepository {
                 .where(sql`true`);
         },
 
-        loadLatestScheduleEntries: async () => {
-            return db
+        loadLatestFires: async () => {
+            const rows = await db
                 .selectDistinctOn([scheduleEntries.zoneId], {
                     zoneId: scheduleEntries.zoneId,
-                    date: scheduleEntries.date,
+                    firedAt: irrigationCycles.firedAt,
                     appliedDepthMm: scheduleEntries.appliedDepthMm,
                 })
-                .from(scheduleEntries)
-                .orderBy(scheduleEntries.zoneId, desc(scheduleEntries.date));
+                .from(irrigationCycles)
+                .innerJoin(scheduleEntries, eq(irrigationCycles.scheduleEntryId, scheduleEntries.id))
+                .where(isNotNull(irrigationCycles.firedAt))
+                .orderBy(scheduleEntries.zoneId, desc(irrigationCycles.firedAt));
+            // `firedAt` is nullable in the schema; the `isNotNull` filter
+            // above guarantees the column is set on every returned row.
+            return rows.map(row => ({
+                zoneId: row.zoneId,
+                firedAt: row.firedAt!,
+                appliedDepthMm: row.appliedDepthMm,
+            }));
         },
 
         advanceDepletion: async (zoneId, depletionMm) => {

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -268,7 +268,7 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         findById: async () => null,
         count: async () => counts,
         loadJoinedRowsForSummary: async () => [],
-        loadLatestScheduleEntries: async () => [],
+        loadLatestFires: async () => [],
         advanceDepletion: async (zoneId, depletionMm) => {
             depletionAdvances.push({ zoneId, depletionMm });
             for (const row of enabledZoneRows) {

--- a/api/service/daemon/reconcile.test.ts
+++ b/api/service/daemon/reconcile.test.ts
@@ -85,7 +85,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonService
             findById: async () => null,
             count: async () => ({ total: 0, enabled: 0 }),
             loadJoinedRowsForSummary: async () => [],
-            loadLatestScheduleEntries: async () => [],
+            loadLatestFires: async () => [],
             advanceDepletion: async () => {},
         },
         sites: { loadTimezone: async () => 'UTC' },

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -119,7 +119,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository, onAdvanceDeple
             findById: async () => null,
             count: async () => ({ total: 0, enabled: 0 }),
             loadJoinedRowsForSummary: async () => [],
-            loadLatestScheduleEntries: async () => [],
+            loadLatestFires: async () => [],
             advanceDepletion: async (zoneId, mm) => { onAdvanceDepletion?.(zoneId, mm); },
         },
         sites: { loadTimezone: async () => 'UTC' },

--- a/api/service/zones/.test.ts
+++ b/api/service/zones/.test.ts
@@ -55,7 +55,7 @@ function fakeRepo(impl: Partial<ZonesRepository>): ZonesRepository {
         findById: async () => null,
         count: async () => ({ total: 0, enabled: 0 }),
         loadJoinedRowsForSummary: async () => [],
-        loadLatestScheduleEntries: async () => [],
+        loadLatestFires: async () => [],
         ...impl,
     };
 }
@@ -90,14 +90,14 @@ describe('mapJoinedRowToSummary', () => {
         expect(summary.lastAppliedMm).toBeNull();
     });
 
-    it('formats lastFiredAt as YYYY-MM-DD and passes through lastAppliedMm', () => {
+    it('serialises lastFiredAt as an ISO-8601 UTC timestamp and passes through lastAppliedMm', () => {
         const summary = mapJoinedRowToSummary(summaryRow(), {
             zoneId: 'zone-001',
-            date: '2026-05-13',
+            firedAt: new Date('2026-05-13T05:00:00.000Z'),
             appliedDepthMm: 14,
         });
 
-        expect(summary.lastFiredAt).toBe('2026-05-13');
+        expect(summary.lastFiredAt).toBe('2026-05-13T05:00:00.000Z');
         expect(summary.lastAppliedMm).toBe(14);
     });
 
@@ -162,12 +162,12 @@ describe('getZoneSummaries', () => {
             }),
         ];
         const entries: LatestZoneFire[] = [
-            { zoneId: 'zone-1', date: '2026-05-13', appliedDepthMm: 14 },
+            { zoneId: 'zone-1', firedAt: new Date('2026-05-13T05:00:00.000Z'), appliedDepthMm: 14 },
         ];
         bootZonesService({
             repo: fakeRepo({
                 loadJoinedRowsForSummary: async () => rows,
-                loadLatestScheduleEntries: async () => entries,
+                loadLatestFires: async () => entries,
             }),
         });
 
@@ -176,7 +176,7 @@ describe('getZoneSummaries', () => {
         expect(result).toHaveLength(2);
         expect(result[0]?.name).toBe('North');
         expect(result[0]?.rawMm).toBe(21);
-        expect(result[0]?.lastFiredAt).toBe('2026-05-13');
+        expect(result[0]?.lastFiredAt).toBe('2026-05-13T05:00:00.000Z');
         expect(result[0]?.lastAppliedMm).toBe(14);
         expect(result[1]?.name).toBe('South');
         expect(result[1]?.lastFiredAt).toBeNull();
@@ -187,7 +187,7 @@ describe('getZoneSummaries', () => {
         bootZonesService({
             repo: fakeRepo({
                 loadJoinedRowsForSummary: async () => [],
-                loadLatestScheduleEntries: async () => [],
+                loadLatestFires: async () => [],
             }),
         });
 
@@ -200,7 +200,7 @@ describe('getZoneSummaries', () => {
         bootZonesService({
             repo: fakeRepo({
                 loadJoinedRowsForSummary: async () => [summaryRow({ zone: { id: 'zone-1' } })],
-                loadLatestScheduleEntries: async () => [],
+                loadLatestFires: async () => [],
             }),
         });
 

--- a/api/service/zones/index.ts
+++ b/api/service/zones/index.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import type { Database } from '@/db';
 import type { Zone } from '@/models';
 import type { LatestZoneFire, ZoneSummary } from '@/models/zone';
@@ -58,7 +57,7 @@ export async function getZoneSummaries(): Promise<ZoneSummary[]> {
     const r = getRepo();
     const [rows, latest] = await Promise.all([
         r.loadJoinedRowsForSummary(),
-        r.loadLatestScheduleEntries(),
+        r.loadLatestFires(),
     ]);
     const latestByZone = new Map<string, LatestZoneFire>(latest.map(entry => [entry.zoneId, entry]));
     const summaries = rows.map(row => mapJoinedRowToSummary(row, latestByZone.get(row.zone.id) ?? null));
@@ -96,7 +95,7 @@ export function mapJoinedRowToSummary(
         precipitationRateMmPerHr: row.zone.precipitationRateMmPerHr,
         currentDepletionMm: row.zone.currentDepletionMm,
         rawMm,
-        lastFiredAt: lastFire ? dayjs(lastFire.date).format('YYYY-MM-DD') : null,
+        lastFiredAt: lastFire ? lastFire.firedAt.toISOString() : null,
         lastAppliedMm: lastFire ? lastFire.appliedDepthMm : null,
         homeAssistantEntityId: row.zone.homeAssistantEntityId,
         patch: row.zone.patch,

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -28,6 +28,16 @@ describe('formatLastRan', () => {
         const isoThreeDaysAgo = new Date(NOW.getTime() - 3 * 24 * 60 * 60_000).toISOString();
         expect(formatLastRan(isoThreeDaysAgo, NOW)).toBe('3 nights ago');
     });
+
+    it('clamps future-dated input to "just now" (defensive: clock skew, upstream bugs). APP-55.', () => {
+        const isoOneHourAhead = new Date(NOW.getTime() + 60 * 60_000).toISOString();
+        expect(formatLastRan(isoOneHourAhead, NOW)).toBe('just now');
+    });
+
+    it('clamps far-future input to "just now" rather than rendering negative day buckets. APP-55.', () => {
+        const isoTwoDaysAhead = new Date(NOW.getTime() + 2 * 24 * 60 * 60_000).toISOString();
+        expect(formatLastRan(isoTwoDaysAhead, NOW)).toBe('just now');
+    });
 });
 
 describe('formatCountdown', () => {

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -22,7 +22,10 @@ export function formatLastRan(iso: string | null, now: Date): string {
     if (iso === null) return '';
     const last = dayjs(iso);
     const present = dayjs(now);
-    const diffMs = present.valueOf() - last.valueOf();
+    // Clamp future-dated input to 0 so clock skew (or upstream data bugs)
+    // can't bucket into a negative `Math.floor(diffMs / MS_PER_DAY)` and
+    // render `'-2 nights ago'`. APP-55.
+    const diffMs = Math.max(0, present.valueOf() - last.valueOf());
     if (diffMs < MS_PER_HOUR) return 'just now';
     if (diffMs < MS_PER_DAY) {
         const hours = Math.floor(diffMs / MS_PER_HOUR);


### PR DESCRIPTION
## Ticket

[APP-55](http://192.168.2.100:7123/home/browse/APP-55/) — Zone tiles incorrectly show "Last ran just now"

## Summary

- **API**: `loadLatestScheduleEntries` was reading the latest `schedule_entries` row per zone — which the planner populates with *future* entries — and emitting that as `lastFiredAt`. Replaced with `loadLatestFires`, which queries `irrigation_cycles` for the most recent `fired_at IS NOT NULL` per zone (joined to `schedule_entries` for `applied_depth_mm`) and emits a full ISO-8601 UTC timestamp instead of a date-only string.
- **Client**: `formatLastRan` had no guard against negative `diffMs`, so any future-dated input trivially collapsed to `'just now'`. Clamped `diffMs` to `Math.max(0, …)` as defense-in-depth against clock skew or upstream data bugs.

## Test plan

- [ ] On the home screen, every zone tile reads "No prior runs." until a zone actually fires (assuming a fresh DB).
- [ ] After a real fire, the tile transitions through `just now` → `Xh ago` → `last night` → `N nights ago` as time advances.
- [ ] `bun --cwd=./api test` passes (835/0).
- [ ] `bun --cwd=./app run test` passes (464/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)