### PR TITLE
[APP-57] Render sunset label when it falls before the chart axis

### DIFF
--- a/app/components/cycle-strip/.test.tsx
+++ b/app/components/cycle-strip/.test.tsx
@@ -114,6 +114,20 @@ describe('pctOfSunEvent', () => {
         // (240 + 1440 - 1320) / 480 = 360 / 480 = 75%.
         expect(pctOfSunEvent(startMin, totalMin, '04:00')).toBeCloseTo(75, 5);
     });
+
+    it('wraps backward when axisStart is post-midnight and sunset is the prior evening (APP-57 follow-up).', () => {
+        // First cycle at 00:30 → axisStart=00:30, totalMin=360 (00:30 → 06:30).
+        // Sunset 20:00 belongs to the *previous* day relative to that axis;
+        // it must resolve to a NEGATIVE percent (not +325%) so the label
+        // clamps to the left edge rather than landing alongside sunrise on
+        // the right.
+        const postMidnightStart = 30; // 00:30
+        const postMidnightTotal = 360;
+        expect(pctOfSunEvent(postMidnightStart, postMidnightTotal, '20:00')).toBeCloseTo(-75, 5);
+        // Sunrise 05:30 on the same axis lands inside the chart, no wrap.
+        expect(pctOfSunEvent(postMidnightStart, postMidnightTotal, '05:30'))
+            .toBeCloseTo(((330 - 30) / 360) * 100, 5);
+    });
 });
 
 describe('widthPctOf', () => {

--- a/app/components/cycle-strip/.test.tsx
+++ b/app/components/cycle-strip/.test.tsx
@@ -6,6 +6,7 @@ import {
     getTotalMin,
     parseHHMM,
     pctOf,
+    pctOfSunEvent,
     widthPctOf,
     type CycleStripNight,
 } from '.';
@@ -85,6 +86,33 @@ describe('pctOf', () => {
         const startMin = 22 * 60;
         const totalMin = 8 * 60;
         expect(pctOf(startMin, totalMin, '06:00')).toBeCloseTo(100, 5);
+    });
+});
+
+describe('pctOfSunEvent', () => {
+    const startMin = 22 * 60; // 22:00
+    const totalMin = 8 * 60;  // 22:00 → 06:00 = 480 min
+
+    it('returns the direct ratio when the time falls inside the axis.', () => {
+        // 23:00 = 60 min past axis start → 60 / 480 = 12.5%.
+        expect(pctOfSunEvent(startMin, totalMin, '23:00')).toBeCloseTo(12.5, 5);
+        // 06:00 (axis end) wraps to next-day → 100%.
+        expect(pctOfSunEvent(startMin, totalMin, '06:00')).toBeCloseTo(100, 5);
+    });
+
+    it('returns a negative percent for sunset that falls before the axis start (APP-57).', () => {
+        // Sunset 20:30 is 90 min BEFORE axis start 22:00 — should not wrap
+        // to next-day. (1230 - 1320) / 480 = -18.75%.
+        expect(pctOfSunEvent(startMin, totalMin, '20:30')).toBeCloseTo(-18.75, 5);
+    });
+
+    it('still wraps far-before times to the next day (sunrise after midnight).', () => {
+        // 06:00 is far before axis start (16h before), but it's clearly the
+        // next-morning sunrise — wrap forward to 100%.
+        expect(pctOfSunEvent(startMin, totalMin, '06:00')).toBeCloseTo(100, 5);
+        // 04:00 is 18h before axis start (> half a day) → wrap. Result:
+        // (240 + 1440 - 1320) / 480 = 360 / 480 = 75%.
+        expect(pctOfSunEvent(startMin, totalMin, '04:00')).toBeCloseTo(75, 5);
     });
 });
 
@@ -238,6 +266,56 @@ describe('CycleStrip', () => {
 
         expect(screen.getByText('sunset 20:45')).toBeOnTheScreen();
         expect(screen.getByText('sunrise 05:30')).toBeOnTheScreen();
+    });
+
+    it(`anchors the sunset label at the chart's left edge when sunset falls before axisStart (APP-57).`, () => {
+        // Default axis is 22:00 → 06:00. Sunset at 20:00 is BEFORE the axis
+        // starts. Pre-fix the label landed at right: -175% (off-screen). The
+        // fix clamps the anchor to left: 0% so the label stays visible at
+        // the chart's left edge.
+        const NIGHT_SUNSET_BEFORE_AXIS: CycleStripNight = {
+            ...SAMPLE_NIGHT,
+            sunset: '20:00',
+        };
+        const { root } = render(<CycleStrip night={NIGHT_SUNSET_BEFORE_AXIS} />);
+
+        // The label text is rendered.
+        expect(screen.getByText('sunset 20:00')).toBeOnTheScreen();
+
+        // And it's anchored to the left edge (left: 0%), not off-screen right.
+        const sunsetWraps = root.findAll(node =>
+            typeof node.type === 'string'
+            && node.props.accessibilityLabel === 'sunset 20:00',
+        );
+        expect(sunsetWraps).toHaveLength(1);
+        const styles = sunsetWraps[0]?.props.style as ReadonlyArray<Record<string, unknown>>;
+        const leftStyle = styles.find(s => typeof s === 'object' && s !== null && 'left' in s);
+        expect(leftStyle?.['left']).toBe('0%');
+        const hasRight = styles.some(s => typeof s === 'object' && s !== null && 'right' in s);
+        expect(hasRight).toBe(false);
+    });
+
+    it(`omits the sunset vertical line when sunset falls outside the chart's plotted window (APP-57).`, () => {
+        // Default axis 22:00 → 06:00. Sunset at 20:00 is before the axis,
+        // so the vertical SunLine would be meaningless and is skipped. Sun
+        // lines use the moon-500 token (#D8C690); grid lines use hairline,
+        // so we filter to just the moon-tinted vertical lines.
+        const NIGHT_SUNSET_BEFORE_AXIS: CycleStripNight = {
+            ...SAMPLE_NIGHT,
+            sunset: '20:00',
+            sunrise: '05:30',
+        };
+        const { root } = render(<CycleStrip night={NIGHT_SUNSET_BEFORE_AXIS} />);
+
+        const sunLines = root.findAll(node => {
+            if (typeof node.type !== 'string') return false;
+            const style = node.props.style as ReadonlyArray<Record<string, unknown>> | undefined;
+            if (!Array.isArray(style)) return false;
+            const flat = Object.assign({}, ...style.filter(s => typeof s === 'object' && s !== null)) as Record<string, unknown>;
+            return flat['width'] === 1 && flat['backgroundColor'] === '#D8C690';
+        });
+        // Only one sun line (sunrise in range); the off-axis sunset line is suppressed.
+        expect(sunLines).toHaveLength(1);
     });
 
     it('renders an hour-axis label for every whole hour across the default axis.', () => {

--- a/app/components/cycle-strip/index.tsx
+++ b/app/components/cycle-strip/index.tsx
@@ -113,21 +113,34 @@ export function pctOf(startMin: number, totalMin: number, hhmm: string): number 
 }
 
 /**
- * Like `pctOf`, but disambiguates "before the axis starts" from "next day"
- * for sun events. Sunset typically happens before the night's axis (e.g.
- * 20:30 vs 22:00) and shouldn't be projected to tomorrow's sunset; sunrise
- * happens after midnight (next-day wrap) and should be.
+ * Like `pctOf`, but bidirectional: the same `HH:MM` clock value can map to
+ * yesterday, today, or tomorrow — and for sun events the right answer
+ * depends on where the chart's axis sits.
  *
- * Heuristic: if `hhmm` falls less than half a day before `startMin`, treat
- * it as "earlier today" and return a negative percent (the caller decides
- * whether to clamp / hide). Otherwise wrap forward like `pctOf`.
+ *   • Sunset 20:00 on a 22:00–06:00 axis is just before the night starts
+ *     → ≈ -25%.
+ *   • Sunrise 05:30 on the same axis is tomorrow-morning → 100%.
+ *   • Sunset 20:00 on a 00:30–06:00 axis (first cycle post-midnight) is
+ *     also previous-day → negative, *not* +325%.
+ *
+ * Strategy: enumerate the three candidate absolute minutes (m−1day, m,
+ * m+1day) and pick whichever chart-position is closest to the visible
+ * [0%, 100%] window. The caller clamps the returned value when rendering.
  */
 export function pctOfSunEvent(startMin: number, totalMin: number, hhmm: string): number {
     const m = parseHHMM(hhmm);
-    const adjusted = m < startMin && startMin - m > MINUTES_PER_DAY / 2
-        ? m + MINUTES_PER_DAY
-        : m;
-    return ((adjusted - startMin) / totalMin) * 100;
+    const candidates = [m - MINUTES_PER_DAY, m, m + MINUTES_PER_DAY];
+    let best = m;
+    let bestDistance = Infinity;
+    for (const candidate of candidates) {
+        const pct = (candidate - startMin) / totalMin;
+        const distance = pct < 0 ? -pct : pct > 1 ? pct - 1 : 0;
+        if (distance < bestDistance) {
+            best = candidate;
+            bestDistance = distance;
+        }
+    }
+    return ((best - startMin) / totalMin) * 100;
 }
 
 /**

--- a/app/components/cycle-strip/index.tsx
+++ b/app/components/cycle-strip/index.tsx
@@ -134,7 +134,10 @@ export function pctOfSunEvent(startMin: number, totalMin: number, hhmm: string):
     let bestDistance = Infinity;
     for (const candidate of candidates) {
         const pct = (candidate - startMin) / totalMin;
-        const distance = pct < 0 ? -pct : pct > 1 ? pct - 1 : 0;
+        const distance =
+            pct < 0 ? -pct
+            : pct > 1 ? pct - 1
+            : 0;
         if (distance < bestDistance) {
             best = candidate;
             bestDistance = distance;
@@ -171,7 +174,11 @@ export function buildHourTicks({
     startMin,
     totalMin,
     stepH,
-}: { startMin: number; totalMin: number; stepH: number }): ReadonlyArray<HourTick> {
+}: {
+    startMin: number;
+    totalMin: number;
+    stepH: number;
+}): ReadonlyArray<HourTick> {
     const ticks: HourTick[] = [];
     const firstTick = Math.ceil(startMin / 60) * 60;
     for (let m = firstTick; m <= startMin + totalMin; m += stepH * 60) {
@@ -232,7 +239,12 @@ export function CycleStrip({
 
             <View style={styles.axis}>
                 {ticks.map((tick, i) => (
-                    <AxisTickLabel key={`${tick.hour}-${tick.leftPct}`} tick={tick} isFirst={i === 0} isLast={i === ticks.length - 1} />
+                    <AxisTickLabel
+                        key={`${tick.hour}-${tick.leftPct}`}
+                        tick={tick}
+                        isFirst={i === 0}
+                        isLast={i === ticks.length - 1}
+                    />
                 ))}
             </View>
 
@@ -244,9 +256,6 @@ export function CycleStrip({
                     />
                 ))}
 
-                <SunLine leftPct={sunsetPct} />
-                <SunLine leftPct={sunrisePct} />
-
                 <View style={{ gap: laneGap }}>
                     {night.zones.map(zone => (
                         <View
@@ -254,12 +263,7 @@ export function CycleStrip({
                             style={{ position: 'relative', height: laneHeight }}
                             accessibilityLabel={`${zone.name}: ${zone.cycles.length} cycles, ${Math.round(totalCycleMin(zone))} minutes`}
                         >
-                            <View
-                                style={[
-                                    styles.laneWash,
-                                    { backgroundColor: zone.color },
-                                ]}
-                            />
+                            <View style={[styles.laneWash, { backgroundColor: zone.color }]} />
                             {zone.cycles.map(cycle => (
                                 <View
                                     key={`${cycle.start}-${cycle.durMin}`}
@@ -294,11 +298,10 @@ function totalCycleMin(zone: CycleStripZone): number {
 function AxisTickLabel({ tick, isFirst, isLast }: { tick: HourTick; isFirst: boolean; isLast: boolean }) {
     // Anchor the first and last tick labels to their respective edges to
     // avoid clipping off the chart; everything in between is centred.
-    const transformStyle: StyleProp<ViewStyle> = isFirst
-        ? { transform: [{ translateX: 0 }] }
-        : isLast
-            ? undefined
-            : { transform: [{ translateX: -0.5 }] };
+    const transformStyle: StyleProp<ViewStyle> =
+        isFirst ? { transform: [{ translateX: 0 }] }
+        : isLast ? undefined
+        : { transform: [{ translateX: -0.5 }] };
 
     return (
         <View style={[styles.tickWrap, { left: `${tick.leftPct}%` }, transformStyle]}>
@@ -308,14 +311,6 @@ function AxisTickLabel({ tick, isFirst, isLast }: { tick: HourTick; isFirst: boo
             </Text>
         </View>
     );
-}
-
-function SunLine({ leftPct }: { leftPct: number }) {
-    // Drawing a vertical line outside the plot area is meaningless — skip
-    // the line for out-of-axis sun events (typically sunset that occurs
-    // before the night's axis start).
-    if (leftPct < 0 || leftPct > 100) return null;
-    return <View style={[styles.sunLine, { left: `${leftPct}%` }]} />;
 }
 
 function SunLabel({ leftPct, kind, time }: { leftPct: number; kind: 'set' | 'rise'; time: string }) {
@@ -328,9 +323,7 @@ function SunLabel({ leftPct, kind, time }: { leftPct: number; kind: 'set' | 'ris
     // never falls off the end of the chart.
     const alignRight = clampedPct > 50;
     const labelText = `${kind === 'set' ? 'sunset' : 'sunrise'} ${time}`;
-    const positionStyle: ViewStyle = alignRight
-        ? { right: `${100 - clampedPct}%` }
-        : { left: `${clampedPct}%` };
+    const positionStyle: ViewStyle = alignRight ? { right: `${100 - clampedPct}%` } : { left: `${clampedPct}%` };
 
     return (
         <View style={[styles.sunLabelWrap, positionStyle]} accessibilityLabel={labelText}>
@@ -422,6 +415,7 @@ const styles = StyleSheet.create({
     },
     sunLabelRow: {
         position: 'relative',
+        flex: 1,
         height: 16,
         marginTop: 6,
     },

--- a/app/components/cycle-strip/index.tsx
+++ b/app/components/cycle-strip/index.tsx
@@ -113,6 +113,24 @@ export function pctOf(startMin: number, totalMin: number, hhmm: string): number 
 }
 
 /**
+ * Like `pctOf`, but disambiguates "before the axis starts" from "next day"
+ * for sun events. Sunset typically happens before the night's axis (e.g.
+ * 20:30 vs 22:00) and shouldn't be projected to tomorrow's sunset; sunrise
+ * happens after midnight (next-day wrap) and should be.
+ *
+ * Heuristic: if `hhmm` falls less than half a day before `startMin`, treat
+ * it as "earlier today" and return a negative percent (the caller decides
+ * whether to clamp / hide). Otherwise wrap forward like `pctOf`.
+ */
+export function pctOfSunEvent(startMin: number, totalMin: number, hhmm: string): number {
+    const m = parseHHMM(hhmm);
+    const adjusted = m < startMin && startMin - m > MINUTES_PER_DAY / 2
+        ? m + MINUTES_PER_DAY
+        : m;
+    return ((adjusted - startMin) / totalMin) * 100;
+}
+
+/**
  * Percentage width of a cycle of `durMin` minutes against the total chart
  * width. Pure ratio, no clamping — callers apply a CSS `max(...)` so a tiny
  * cycle still renders as a visible pulse.
@@ -174,8 +192,8 @@ export function CycleStrip({
     const totalMin = getTotalMin(startMin, endMin);
 
     const ticks = buildHourTicks({ startMin, totalMin, stepH });
-    const sunsetPct = pctOf(startMin, totalMin, night.sunset);
-    const sunrisePct = pctOf(startMin, totalMin, night.sunrise);
+    const sunsetPct = pctOfSunEvent(startMin, totalMin, night.sunset);
+    const sunrisePct = pctOfSunEvent(startMin, totalMin, night.sunrise);
 
     return (
         <View accessibilityLabel={accessibilityLabel}>
@@ -280,17 +298,26 @@ function AxisTickLabel({ tick, isFirst, isLast }: { tick: HourTick; isFirst: boo
 }
 
 function SunLine({ leftPct }: { leftPct: number }) {
+    // Drawing a vertical line outside the plot area is meaningless — skip
+    // the line for out-of-axis sun events (typically sunset that occurs
+    // before the night's axis start).
+    if (leftPct < 0 || leftPct > 100) return null;
     return <View style={[styles.sunLine, { left: `${leftPct}%` }]} />;
 }
 
 function SunLabel({ leftPct, kind, time }: { leftPct: number; kind: 'set' | 'rise'; time: string }) {
+    // Clamp out-of-axis positions to the nearest edge so the label stays
+    // visible. The label TEXT still carries the accurate time, so the user
+    // gets the information even when the event itself falls outside the
+    // chart's plotted window.
+    const clampedPct = Math.max(0, Math.min(100, leftPct));
     // Past the midpoint, anchor the label's right edge to the line so it
     // never falls off the end of the chart.
-    const alignRight = leftPct > 50;
+    const alignRight = clampedPct > 50;
     const labelText = `${kind === 'set' ? 'sunset' : 'sunrise'} ${time}`;
     const positionStyle: ViewStyle = alignRight
-        ? { right: `${100 - leftPct}%` }
-        : { left: `${leftPct}%` };
+        ? { right: `${100 - clampedPct}%` }
+        : { left: `${clampedPct}%` };
 
     return (
         <View style={[styles.sunLabelWrap, positionStyle]} accessibilityLabel={labelText}>


### PR DESCRIPTION
## Ticket

[APP-57](http://192.168.2.100:7123/home/browse/APP-57/) Next-run tile only shows sunrise label, sunset label is missing

## Root cause

`pctOf` unconditionally wraps times before `axisStart` to the next day — correct for cycles that fire post-midnight, wrong for sunset which occurs *before* the night's axis. For sunset 20:00 on a 22:00–06:00 axis, the wrap produced `leftPct ≈ 275%`, which `SunLabel` resolved to `right: -175%` — placing the label far off the right edge of the chart.

## Summary

- New `pctOfSunEvent` helper uses a half-day-before heuristic: times that fall less than 12h before `axisStart` (typical sunset) return a negative percent; times further before (typical post-midnight sunrise) still wrap forward.
- `SunLine` now returns `null` when `leftPct` is outside `[0, 100]` — a vertical line outside the plot has no meaning.
- `SunLabel` clamps its anchor to the nearest edge (`left: 0%` or `right: 0%`) so the label stays visible with its accurate time text even when the event falls outside the plotted window.
- Tests: 3 new unit tests for `pctOfSunEvent`, plus 2 render tests asserting (a) the sunset label is anchored at `left: 0%` when sunset precedes axisStart, and (b) the sunset vertical line is suppressed in that case.