### PR TITLE
[APP-58] Wire the app header and nav drawer into the layout

### DIFF
--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 
 const mockUseFonts = jest.fn();
 const mockHideAsync = jest.fn(() => Promise.resolve());
 const mockStatusBar = jest.fn();
 const mockStackScreen = jest.fn();
+const mockRouterPush = jest.fn();
+const mockUsePathname = jest.fn(() => '/');
+const mockHeaderProps = jest.fn();
+const mockDrawerProps = jest.fn();
 
 jest.mock('expo-font', () => ({
     useFonts: (...args: unknown[]) => mockUseFonts(...args),
@@ -32,7 +36,50 @@ jest.mock('expo-router', () => {
     };
     return {
         Stack,
-        useRouter: () => ({ push: jest.fn() }),
+        useRouter: () => ({ push: mockRouterPush }),
+        usePathname: () => mockUsePathname(),
+    };
+});
+
+// Stand-ins for Header and NavDrawer keep this layout test focused on
+// wiring (does the layout render them? does it pass the right props?)
+// without dragging in React Query plumbing that the components themselves
+// already cover under @/components/header and @/components/nav-drawer.
+jest.mock('@/components/header', () => {
+    const { Pressable, Text, View } = require('react-native');
+    return {
+        Header: (props: { onMenuPress: () => void }) => {
+            mockHeaderProps(props);
+            return (
+                <View accessibilityLabel='App header'>
+                    <Pressable accessibilityLabel='Open menu' onPress={props.onMenuPress}>
+                        <Text>menu</Text>
+                    </Pressable>
+                </View>
+            );
+        },
+    };
+});
+
+jest.mock('@/components/nav-drawer', () => {
+    const { Text, View } = require('react-native');
+    return {
+        NavDrawer: (props: {
+            visible: boolean;
+            activeId: string;
+            onClose: () => void;
+            onSelect: (id: string) => void;
+        }) => {
+            mockDrawerProps(props);
+            return (
+                <View
+                    accessibilityLabel='Navigation drawer'
+                    accessibilityState={{ expanded: props.visible }}
+                >
+                    <Text>active:{props.activeId}</Text>
+                </View>
+            );
+        },
     };
 });
 
@@ -76,6 +123,11 @@ describe('RootLayout', () => {
         mockStatusBar.mockClear();
         mockHideAsync.mockClear();
         mockStackScreen.mockClear();
+        mockRouterPush.mockReset();
+        mockUsePathname.mockReset();
+        mockUsePathname.mockReturnValue('/');
+        mockHeaderProps.mockClear();
+        mockDrawerProps.mockClear();
     });
 
     it('renders the navigation stack once fonts load.', () => {
@@ -107,5 +159,87 @@ describe('RootLayout', () => {
         render(<RootLayout />);
 
         expect(screen.getByLabelText('Status bar backdrop')).toBeOnTheScreen();
+    });
+
+    it('renders the app header above the stack (APP-58).', () => {
+        render(<RootLayout />);
+
+        expect(screen.getByLabelText('App header')).toBeOnTheScreen();
+    });
+
+    it('renders the nav drawer hidden by default (APP-58).', () => {
+        render(<RootLayout />);
+
+        const drawer = screen.getByLabelText('Navigation drawer');
+        expect(drawer).toBeOnTheScreen();
+        expect(drawer.props.accessibilityState).toMatchObject({ expanded: false });
+    });
+
+    it('opens the drawer when the header menu button is pressed (APP-58).', () => {
+        render(<RootLayout />);
+
+        fireEvent.press(screen.getByLabelText('Open menu'));
+
+        expect(screen.getByLabelText('Navigation drawer').props.accessibilityState).toMatchObject({ expanded: true });
+    });
+
+    it('passes activeId derived from usePathname to the drawer (APP-58).', () => {
+        mockUsePathname.mockReturnValue('/schedules');
+
+        render(<RootLayout />);
+
+        expect(screen.getByText('active:schedules')).toBeOnTheScreen();
+    });
+
+    it('maps /zone/<slug> paths onto the zones nav id (APP-58).', () => {
+        mockUsePathname.mockReturnValue('/zone/north');
+
+        render(<RootLayout />);
+
+        expect(screen.getByText('active:zones')).toBeOnTheScreen();
+    });
+
+    it('maps /activity onto the activity nav id (APP-58).', () => {
+        mockUsePathname.mockReturnValue('/activity');
+
+        render(<RootLayout />);
+
+        expect(screen.getByText('active:activity')).toBeOnTheScreen();
+    });
+
+    it('falls back to the home nav id for unknown pathnames (APP-58).', () => {
+        mockUsePathname.mockReturnValue('/unknown-route');
+
+        render(<RootLayout />);
+
+        expect(screen.getByText('active:home')).toBeOnTheScreen();
+    });
+
+    it('routes via expo-router when the drawer selects a destination (APP-58).', () => {
+        render(<RootLayout />);
+
+        // The drawer stand-in captured the onSelect prop; invoke it directly
+        // to verify routing without driving the real drawer animation.
+        const drawerProps = mockDrawerProps.mock.calls.at(-1)?.[0] as { onSelect: (id: string) => void };
+        drawerProps.onSelect('schedules');
+
+        expect(mockRouterPush).toHaveBeenCalledWith('/schedules');
+    });
+
+    it('collapses the drawer when its onClose handler fires (APP-58).', () => {
+        render(<RootLayout />);
+
+        // Open the drawer first.
+        fireEvent.press(screen.getByLabelText('Open menu'));
+        expect(screen.getByLabelText('Navigation drawer').props.accessibilityState).toMatchObject({ expanded: true });
+
+        // Then trigger onClose via the captured drawer prop (wrapped in act
+        // so the React Native state update commits before the assertion).
+        const drawerProps = mockDrawerProps.mock.calls.at(-1)?.[0] as { onClose: () => void };
+        act(() => {
+            drawerProps.onClose();
+        });
+
+        expect(screen.getByLabelText('Navigation drawer').props.accessibilityState).toMatchObject({ expanded: false });
     });
 });

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,12 +1,16 @@
+import { useState } from 'react';
+import { View } from 'react-native';
 import { DarkTheme, ThemeProvider, type Theme } from '@react-navigation/native';
-import { Stack } from 'expo-router';
+import { Stack, usePathname, useRouter } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ApiProvider } from '@/api/provider';
 import { FontLoader } from '@/components/font-loader';
+import { Header } from '@/components/header';
+import { NavDrawer, type NavItemId } from '@/components/nav-drawer';
 import { NotificationsBridge } from '@/components/notifications-bridge';
 import { StatusBarBackdrop } from '@/components/status-bar-backdrop';
 import '../global.css';
@@ -31,15 +35,27 @@ export const irrigoDarkTheme: Theme = {
     },
 };
 
+const ROUTE_FOR_NAV_ID: Record<NavItemId, string> = {
+    home: '/',
+    zones: '/zones',
+    schedules: '/schedules',
+    activity: '/activity',
+};
+
+function pathnameToActiveId(pathname: string): NavItemId {
+    if (pathname.startsWith('/zone')) return 'zones';
+    if (pathname.startsWith('/schedules')) return 'schedules';
+    if (pathname.startsWith('/activity')) return 'activity';
+    return 'home';
+}
+
 export default function RootLayout() {
     return (
         <ApiProvider>
             <FontLoader>
                 <SafeAreaProvider>
                     <ThemeProvider value={irrigoDarkTheme}>
-                        <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: '#000000' } }}>
-                            <Stack.Screen name='modal' options={{ presentation: 'modal', title: 'Modal' }} />
-                        </Stack>
+                        <AppShell />
                         <NotificationsBridge />
                         <StatusBarBackdrop />
                         <StatusBar style='light' />
@@ -47,5 +63,35 @@ export default function RootLayout() {
                 </SafeAreaProvider>
             </FontLoader>
         </ApiProvider>
+    );
+}
+
+/**
+ * Renders the persistent app chrome (header + drawer) around the route
+ * stack. Owns the drawer's open/closed state and maps the current
+ * `usePathname()` onto the drawer's `activeId`. APP-22 / APP-58.
+ */
+function AppShell() {
+    const insets = useSafeAreaInsets();
+    const router = useRouter();
+    const pathname = usePathname();
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    const activeId = pathnameToActiveId(pathname);
+
+    return (
+        <View style={{ flex: 1 }}>
+            <View style={{ paddingTop: insets.top, backgroundColor: '#000000' }}>
+                <Header onMenuPress={() => setDrawerOpen(true)} />
+            </View>
+            <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: '#000000' } }}>
+                <Stack.Screen name='modal' options={{ presentation: 'modal', title: 'Modal' }} />
+            </Stack>
+            <NavDrawer
+                visible={drawerOpen}
+                onClose={() => setDrawerOpen(false)}
+                activeId={activeId}
+                onSelect={(id) => router.push(ROUTE_FOR_NAV_ID[id] as never)}
+            />
+        </View>
     );
 }

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -43,10 +43,12 @@ const ROUTE_FOR_NAV_ID: Record<NavItemId, string> = {
 };
 
 function pathnameToActiveId(pathname: string): NavItemId {
-    if (pathname.startsWith('/zone')) return 'zones';
-    if (pathname.startsWith('/schedules')) return 'schedules';
-    if (pathname.startsWith('/activity')) return 'activity';
-    return 'home';
+    // Strip trailing 's' off each plural id so `/zone/<slug>` resolves to
+    // the same tab as `/zones` (no separate /zone/* schedules / activity
+    // detail routes exist, but the form holds for them too).
+    return (Object.keys(ROUTE_FOR_NAV_ID) as NavItemId[]).find(
+        id => id !== 'home' && pathname.startsWith('/' + id.replace(/s$/, '')),
+    ) ?? 'home';
 }
 
 export default function RootLayout() {

--- a/app/components/home-view/index.tsx
+++ b/app/components/home-view/index.tsx
@@ -46,7 +46,7 @@ export function HomeView() {
     return (
         <ScrollView
             style={styles.scroll}
-            contentContainerStyle={[styles.content, { paddingTop: insets.top + 16, paddingBottom: insets.bottom + 32 }]}
+            contentContainerStyle={[styles.content, { paddingTop: 16, paddingBottom: insets.bottom + 32 }]}
         >
             <MasterToggle />
 


### PR DESCRIPTION
## Ticket

[APP-58](http://192.168.2.100:7123/home/browse/APP-58/) — App header not rendered — re-implement per APP-22 spec

## Summary

- The `<Header>` and `<NavDrawer>` components built for APP-22 and APP-23 were complete and tested but never wired into the production tree. The root layout pinned `headerShown: false` and rendered no replacement chrome.
- Added an `AppShell` component inside `RootLayout` that renders `<Header>` above the `<Stack>` (wrapped in `paddingTop: insets.top` so it sits below the status bar) with `<NavDrawer>` as a sibling. Open/close state lives in `AppShell`; `activeId` is derived from `usePathname()`; selections route via `useRouter().push(...)`.
- Dropped `insets.top` from the home view's content padding now that the header consumes the status-bar inset.
- Added 9 new tests in `app/_layout.test.tsx` covering header rendering, drawer open/close, all 4 pathname → activeId branches, and route-on-select.

## Test plan

- [ ] On the home screen: header renders with hamburger + Irrigo wordmark + refresh icon above the master toggle.
- [ ] Tap hamburger → drawer slides in. Tap scrim or close → drawer slides out.
- [ ] Tap refresh → POST `/replan` issued; refresh icon disables while in flight.
- [ ] When master irrigation is off: hamburger greys/disables, brand row dims to 0.45 opacity, refresh disables.
- [ ] `bun --cwd=./app run test` passes (473/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)