### PR TITLE
[APP-61] Add zone filter to the Activity screen

### DIFF
--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 jest.mock('react-native-safe-area-context', () => ({
     useSafeAreaInsets: () => ({ top: 44, bottom: 0, left: 0, right: 0 }),
@@ -7,12 +7,42 @@ jest.mock('react-native-safe-area-context', () => ({
 import type { ActivityDto, ActivityListResult } from '@/api/types/activity';
 import type { AlertDto } from '@/api/types/alerts';
 import type { NextRunDto } from '@/api/types/next-run';
+import type { ZoneSummary } from '@/api/types/zones';
 import { keys } from '@/api/query-keys';
 import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
 
 import { ActivityView } from '.';
 
 const mockFetch = jest.fn();
+
+function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
+    return {
+        id: 'z-1',
+        slug: 'north',
+        name: 'North',
+        isEnabled: true,
+        grassType: { name: 'Fescue' },
+        soilType: { name: 'Loam' },
+        areaM2: 320,
+        rootDepthM: 0.18,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        microclimateFactor: 1,
+        precipitationRateMmPerHr: 10,
+        currentDepletionMm: 14.4,
+        rawMm: 32,
+        lastFiredAt: null,
+        lastAppliedMm: null,
+        homeAssistantEntityId: 'switch.zone_north',
+        patch: 'a',
+        ...overrides,
+    };
+}
+
+const ZONES: ZoneSummary[] = [
+    buildZone({ id: 'z-1', slug: 'north', name: 'North' }),
+    buildZone({ id: 'z-2', slug: 'south', name: 'South' }),
+];
 
 const NEXT_RUN: NextRunDto = {
     state: 'scheduled',
@@ -170,5 +200,97 @@ describe('ActivityView', () => {
 
         expect(screen.getByText('5.0 mm · 30 min')).toBeOnTheScreen();
         expect(screen.getByText('8.0 mm · 40 min')).toBeOnTheScreen();
+    });
+
+    it('renders the "All zones" chip plus one chip per zone returned by /zones (APP-61).', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.zones.list(), ZONES);
+        client.setQueryData(keys.activity.list({}), {
+            pages: [activityResult([buildActivity()])],
+            pageParams: [undefined],
+        });
+
+        render(<ActivityView />, { wrapper });
+
+        expect(screen.getByText('All zones')).toBeOnTheScreen();
+        expect(screen.getByText('North')).toBeOnTheScreen();
+        expect(screen.getByText('South')).toBeOnTheScreen();
+        await waitFor(() => expect(screen.getByLabelText('Show all zones').props.accessibilityState).toMatchObject({ selected: true }));
+    });
+
+    it('refetches /activity scoped to the selected zone when a zone chip is tapped (APP-61).', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.zones.list(), ZONES);
+        mockFetch.mockImplementation(async (input: RequestInfo) => {
+            const url = typeof input === 'string' ? input : input.url;
+            if (url.includes('/activity')) return jsonResponse(activityResult([buildActivity()]));
+            return jsonResponse({ error: 'unhandled' }, 500);
+        });
+
+        render(<ActivityView />, { wrapper });
+
+        // Wait for the default (no-filter) activity fetch to settle.
+        await waitFor(() => {
+            const calls = mockFetch.mock.calls.filter(([u]) => String(u).includes('/activity'));
+            expect(calls.length).toBeGreaterThan(0);
+        });
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Filter to North'));
+        });
+
+        await waitFor(() => {
+            const scopedCall = mockFetch.mock.calls.find(([u]) => {
+                const url = new URL(String(u));
+                return url.pathname === '/activity' && url.searchParams.get('zoneId') === 'z-1';
+            });
+            expect(scopedCall).toBeDefined();
+        });
+    });
+
+    it('refetches /activity without the zoneId param when "All zones" is tapped after a zone selection (APP-61).', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.zones.list(), ZONES);
+        mockFetch.mockImplementation(async (input: RequestInfo) => {
+            const url = typeof input === 'string' ? input : input.url;
+            if (url.includes('/activity')) return jsonResponse(activityResult([buildActivity()]));
+            return jsonResponse({ error: 'unhandled' }, 500);
+        });
+
+        render(<ActivityView />, { wrapper });
+
+        // Pick a zone first.
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Filter to South'));
+        });
+        // Then clear back to All zones.
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Show all zones'));
+        });
+
+        await waitFor(() => {
+            const lastCall = mockFetch.mock.calls
+                .map(([u]) => new URL(String(u)))
+                .reverse()
+                .find(url => url.pathname === '/activity');
+            expect(lastCall).toBeDefined();
+            expect(lastCall?.searchParams.has('zoneId')).toBe(false);
+        });
+    });
+
+    it('updates the eyebrow suffix to the zone name when a zone is selected (APP-61).', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.zones.list(), ZONES);
+        mockFetch.mockImplementation(async () => jsonResponse(activityResult([buildActivity()])));
+
+        render(<ActivityView />, { wrapper });
+
+        expect(screen.getByText('Chronological · all zones')).toBeOnTheScreen();
+
+        await act(async () => {
+            fireEvent.press(screen.getByLabelText('Filter to South'));
+        });
+
+        await waitFor(() => expect(screen.getByText('Chronological · South')).toBeOnTheScreen());
     });
 });

--- a/app/components/activity-view/index.tsx
+++ b/app/components/activity-view/index.tsx
@@ -1,48 +1,69 @@
+import { useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { FireLog } from '@/components/fire-log';
+import { ZoneFilterChipStrip } from '@/components/zone-filter-chip-strip';
 import { FontFamily } from '@/constants/fonts';
 import { useActivity } from '@/hooks/activity';
 import { useNextRun } from '@/hooks/next-run';
+import { useZones } from '@/hooks/zones';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 
 const DEFAULT_TIMEZONE = 'UTC';
+const ALL_ZONES_LABEL = 'all zones';
 
 /**
  * Smart container for the Activity screen. Composes the eyebrow + page
- * title with the chronological fire log sourced from `GET /activity`.
- * Reads `useNextRun()` only for the site timezone (already cached after a
- * Home-screen visit); falls back to UTC when the cache hasn't been primed
- * yet. RN port of `ActivityView` from `Mobile.jsx` — minus the alert
- * region, since alerts have no dismiss affordance yet and lingering
- * non-interactive copy is worse than silence here. APP-32.
+ * title with a zone-filter chip strip and the chronological fire log
+ * sourced from `GET /activity`. Reads `useNextRun()` only for the site
+ * timezone (already cached after a Home-screen visit); falls back to UTC
+ * when the cache hasn't been primed yet. Selecting a zone chip flips
+ * `useActivity({ zoneId })`'s query key, which React Query treats as a
+ * fresh query — so the fire log re-fetches the first page automatically.
+ * RN port of `ActivityView` from `Mobile.jsx` — minus the alert region,
+ * since alerts have no dismiss affordance yet and lingering non-
+ * interactive copy is worse than silence here. APP-32 / APP-61.
  */
 export function ActivityView() {
     const insets = useSafeAreaInsets();
-    const activity = useActivity();
+    const [selectedZoneId, setSelectedZoneId] = useState<string | undefined>(undefined);
+    const activity = useActivity({ ...(selectedZoneId !== undefined ? { zoneId: selectedZoneId } : {}) });
     const nextRun = useNextRun();
+    const zones = useZones();
     const siteTimezone = nextRun.data?.timezone ?? DEFAULT_TIMEZONE;
 
     const rows = activity.data?.pages.flatMap(page => page.activity) ?? [];
+    const selectedZoneName = selectedZoneId === undefined
+        ? null
+        : zones.data?.find(zone => zone.id === selectedZoneId)?.name ?? null;
+    const eyebrowSuffix = selectedZoneName ?? ALL_ZONES_LABEL;
 
     return (
         <ScrollView
             style={styles.scroll}
             contentContainerStyle={[styles.content, { paddingTop: 16, paddingBottom: insets.bottom + 32 }]}
         >
-            <Text style={styles.eyebrow}>Chronological · all zones</Text>
-            <Text style={styles.title}>Activity</Text>
+            <Text style={[styles.eyebrow, styles.inset]}>Chronological · {eyebrowSuffix}</Text>
+            <Text style={[styles.title, styles.inset]}>Activity</Text>
 
-            {activity.isPending ?
-                <PlaceholderCard label='Loading activity…' />
-            : activity.isError || activity.data === undefined ?
-                <PlaceholderCard label='Failed to load activity.' tone='error' />
-            : rows.length === 0 ?
-                <PlaceholderCard label='No runs yet.' />
-            :   <FireLog rows={rows} siteTimezone={siteTimezone} />}
+            <ZoneFilterChipStrip
+                zones={zones.data ?? []}
+                selectedZoneId={selectedZoneId}
+                onSelect={setSelectedZoneId}
+            />
+
+            <View style={styles.inset}>
+                {activity.isPending ?
+                    <PlaceholderCard label='Loading activity…' />
+                : activity.isError || activity.data === undefined ?
+                    <PlaceholderCard label='Failed to load activity.' tone='error' />
+                : rows.length === 0 ?
+                    <PlaceholderCard label='No runs yet.' />
+                :   <FireLog rows={rows} siteTimezone={siteTimezone} />}
+            </View>
         </ScrollView>
     );
 }
@@ -68,6 +89,11 @@ const styles = StyleSheet.create({
     },
     content: {
         gap: 18,
+    },
+    inset: {
+        // Most rows sit 20px in from the screen edge; the chip strip skips
+        // this so it can scroll edge-to-edge while keeping its own internal
+        // padding aligned with the rest of the content.
         paddingHorizontal: 20,
     },
     eyebrow: {

--- a/app/components/zone-filter-chip-strip/.test.tsx
+++ b/app/components/zone-filter-chip-strip/.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { ZoneFilterChipStrip } from '.';
+
+const ZONES = [
+    { id: 'z-1', name: 'North' },
+    { id: 'z-2', name: 'South' },
+];
+
+describe('ZoneFilterChipStrip', () => {
+    it('renders null when the zone list is empty.', () => {
+        const { toJSON } = render(
+            <ZoneFilterChipStrip zones={[]} selectedZoneId={undefined} onSelect={jest.fn()} />,
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('renders the "All zones" chip plus one chip per zone.', () => {
+        render(
+            <ZoneFilterChipStrip zones={ZONES} selectedZoneId={undefined} onSelect={jest.fn()} />,
+        );
+
+        expect(screen.getByText('All zones')).toBeOnTheScreen();
+        expect(screen.getByText('North')).toBeOnTheScreen();
+        expect(screen.getByText('South')).toBeOnTheScreen();
+    });
+
+    it('marks the "All zones" chip selected when selectedZoneId is undefined.', () => {
+        render(
+            <ZoneFilterChipStrip zones={ZONES} selectedZoneId={undefined} onSelect={jest.fn()} />,
+        );
+
+        expect(screen.getByLabelText('Show all zones').props.accessibilityState).toMatchObject({ selected: true });
+        expect(screen.getByLabelText('Filter to North').props.accessibilityState).toMatchObject({ selected: false });
+        expect(screen.getByLabelText('Filter to South').props.accessibilityState).toMatchObject({ selected: false });
+    });
+
+    it('marks the matching zone chip selected and unmarks "All zones" when a zone id is supplied.', () => {
+        render(
+            <ZoneFilterChipStrip zones={ZONES} selectedZoneId='z-1' onSelect={jest.fn()} />,
+        );
+
+        expect(screen.getByLabelText('Show all zones').props.accessibilityState).toMatchObject({ selected: false });
+        expect(screen.getByLabelText('Filter to North').props.accessibilityState).toMatchObject({ selected: true });
+        expect(screen.getByLabelText('Filter to South').props.accessibilityState).toMatchObject({ selected: false });
+    });
+
+    it('fires onSelect with the zone id when a zone chip is tapped.', () => {
+        const onSelect = jest.fn();
+        render(
+            <ZoneFilterChipStrip zones={ZONES} selectedZoneId={undefined} onSelect={onSelect} />,
+        );
+
+        fireEvent.press(screen.getByLabelText('Filter to South'));
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toHaveBeenCalledWith('z-2');
+    });
+
+    it('fires onSelect with undefined when the "All zones" chip is tapped.', () => {
+        const onSelect = jest.fn();
+        render(
+            <ZoneFilterChipStrip zones={ZONES} selectedZoneId='z-1' onSelect={onSelect} />,
+        );
+
+        fireEvent.press(screen.getByLabelText('Show all zones'));
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/app/components/zone-filter-chip-strip/index.tsx
+++ b/app/components/zone-filter-chip-strip/index.tsx
@@ -1,0 +1,127 @@
+import { Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * A single chip's worth of zone metadata. The component only needs the id
+ * and visible name, so callers can pass any object that satisfies it
+ * (e.g. `ZoneSummary` minus the fields the chip doesn't use).
+ */
+export type ZoneFilterChip = {
+    id: string;
+    name: string;
+};
+
+/**
+ * Props for the zone filter chip strip.
+ */
+export type ZoneFilterChipStripProps = {
+    /** Required. Zones to render as filter chips, in display order. */
+    zones: ReadonlyArray<ZoneFilterChip>;
+
+    /** Required. The currently selected zone id, or `undefined` to indicate the "All zones" chip is active. */
+    selectedZoneId: string | undefined;
+
+    /** Required. Fires with the tapped zone id, or `undefined` when the user picks "All zones". */
+    onSelect: (zoneId: string | undefined) => void;
+};
+
+/**
+ * Horizontally-scrollable filter chip strip used above the Activity
+ * screen's `FireLog`. Leads with an "All zones" chip (selected state =
+ * `selectedZoneId === undefined`) followed by one chip per zone. Selected
+ * chips paint with the accent treatment; the rest sit on the standard
+ * surface tone. Returns `null` while the zone list is empty so the layout
+ * doesn't reserve space before zones load. APP-61.
+ */
+export function ZoneFilterChipStrip({ zones, selectedZoneId, onSelect }: ZoneFilterChipStripProps) {
+    if (zones.length === 0) return null;
+
+    return (
+        <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.strip}
+            accessibilityLabel='Zone filter'
+        >
+            <Chip
+                label='All zones'
+                accessibilityLabel='Show all zones'
+                selected={selectedZoneId === undefined}
+                onPress={() => onSelect(undefined)}
+            />
+            {zones.map(zone => (
+                <Chip
+                    key={zone.id}
+                    label={zone.name}
+                    accessibilityLabel={`Filter to ${zone.name}`}
+                    selected={selectedZoneId === zone.id}
+                    onPress={() => onSelect(zone.id)}
+                />
+            ))}
+        </ScrollView>
+    );
+}
+
+function Chip({
+    label,
+    accessibilityLabel,
+    selected,
+    onPress,
+}: {
+    label: string;
+    accessibilityLabel: string;
+    selected: boolean;
+    onPress: () => void;
+}) {
+    return (
+        <Pressable
+            onPress={onPress}
+            accessibilityRole='button'
+            accessibilityLabel={accessibilityLabel}
+            accessibilityState={{ selected }}
+            style={[styles.chip, selected ? styles.chipSelected : styles.chipUnselected]}
+        >
+            <Text style={[styles.label, selected ? styles.labelSelected : styles.labelUnselected]}>
+                {label}
+            </Text>
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create({
+    strip: {
+        gap: 8,
+        paddingHorizontal: 20,
+    },
+    chip: {
+        height: 28,
+        paddingHorizontal: 12,
+        borderWidth: 1,
+        borderRadius: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    chipSelected: {
+        backgroundColor: colors['accent-tint'],
+        borderColor: colors['accent-border'],
+    },
+    chipUnselected: {
+        backgroundColor: colors.surface,
+        borderColor: colors.border,
+    },
+    label: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 12,
+        lineHeight: 14,
+    },
+    labelSelected: {
+        color: colors.accent,
+    },
+    labelUnselected: {
+        color: colors['fg-soft'],
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-61](http://192.168.2.100:7123/home/browse/APP-61/) — Zone filter on the Activity screen

## Summary

- Added <code>&lt;ZoneFilterChipStrip&gt;</code> at <code>app/components/zone-filter-chip-strip/index.tsx</code> — horizontally-scrollable Pressable chips with an "All zones" lead chip plus one per zone. Selected chip paints with the accent treatment (\`accent-tint\` bg + \`accent-border\` + \`accent\` text); unselected chips sit on the surface tone.
- Wired the strip into <code>&lt;ActivityView&gt;</code>. The view owns a \`selectedZoneId: string | undefined\` state (\`undefined\` = All zones), passes it to <code>useActivity({ zoneId })</code>, and reads <code>useZones()</code> for the chip list. Because <code>keys.activity.list({ zoneId })</code> incorporates the param, React Query treats every filter change as a fresh query and re-fetches the first page automatically.
- The eyebrow now tracks the active filter: \`Chronological · all zones\` by default, \`Chronological · {zone.name}\` once a zone is selected.
- Moved \`paddingHorizontal: 20\` off the ScrollView container onto an \`inset\` style so the chip strip can scroll edge-to-edge while other content stays inset.

## Test plan

- [ ] Open Activity: chip strip renders above the fire log with "All zones" pre-selected.
- [ ] Tap a zone chip → fire log refreshes scoped to that zone; eyebrow updates to \`Chronological · {zone name}\`.
- [ ] Tap "All zones" again → fire log returns to the full list; eyebrow returns to \`all zones\`.
- [ ] \`bun --cwd=./app run test\` passes (511/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)