### PR TITLE
[APP-53] Configure branded splash on canvas-dark

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -34,10 +34,7 @@
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
-          "backgroundColor": "#ffffff",
-          "dark": {
-            "backgroundColor": "#06090A"
-          }
+          "backgroundColor": "#06090A"
         }
       ]
     ],

--- a/app/app.test.ts
+++ b/app/app.test.ts
@@ -58,3 +58,23 @@ describe('app.json icon configuration', () => {
         }
     });
 });
+
+describe('app.json splash configuration', () => {
+    it('paints the splash on the canvas-dark token in every appearance state (APP-53).', () => {
+        // Setting `backgroundColor` to the dark token at the top level (no
+        // `dark` override) ensures the iOS launchscreen never momentarily
+        // flashes white before the OS settles on dark mode.
+        expect(findSplashPlugin().backgroundColor).toBe('#06090A');
+    });
+
+    it('omits the light/dark override now that the base colour is dark (APP-53).', () => {
+        expect(findSplashPlugin().dark).toBeUndefined();
+    });
+
+    it('renders the radar-mark splash image at 200dp via contain resize.', () => {
+        const plugin = findSplashPlugin();
+        expect(plugin.image).toBe('./assets/images/splash-icon.png');
+        expect(plugin.imageWidth).toBe(200);
+        expect(plugin.resizeMode).toBe('contain');
+    });
+});


### PR DESCRIPTION
## Ticket

[APP-53](http://192.168.2.100:7123/home/browse/APP-53/) — Configure branded splash screen

## Summary

- Flattened the \`expo-splash-screen\` plugin in \`app.json\`: \`backgroundColor\` is now \`#06090A\` (canvas-dark) in every appearance state, and the \`dark\` override is gone. The pre-existing \`#ffffff\` light-mode entry was the likely source of the brief white flash before iOS settled on dark.
- Kept \`image: ./assets/images/splash-icon.png\` (the radar mark on transparent that APP-38 produced), \`imageWidth: 200\`, \`resizeMode: 'contain'\`. The mark stays the focal point; no artwork changes needed for this ticket.
- Added 3 new \`app.test.ts\` assertions: backgroundColor pins to \`#06090A\`, no \`dark\` override, splash asset path / width / resize mode are wired correctly.

## Test plan

- [ ] iOS simulator: launch the app cold; the splash should paint solid \`#06090A\` from frame zero through to the React Native root, with no white flash.
- [ ] Android emulator: same check.
- [ ] \`bun --cwd=./app run test\` passes (526/0).

## Out of scope

- Wordmark + spinner from the design mock — the ticket scope is \"logo mark centred\". Wordmark would require embedding Bricolage Grotesque outlines; spinner is APP-51 (hold-until-loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)