### PR TITLE
[APP-62] Add alert bell with unread-count badge to header

### DIFF
--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -58,12 +58,15 @@ jest.mock('@/components/splash-gate', () => {
 jest.mock('@/components/header', () => {
     const { Pressable, Text, View } = require('react-native');
     return {
-        Header: (props: { onMenuPress: () => void }) => {
+        Header: (props: { onMenuPress: () => void; onAlertsPress: () => void }) => {
             mockHeaderProps(props);
             return (
                 <View accessibilityLabel='App header'>
                     <Pressable accessibilityLabel='Open menu' onPress={props.onMenuPress}>
                         <Text>menu</Text>
+                    </Pressable>
+                    <Pressable accessibilityLabel='Alerts' onPress={props.onAlertsPress}>
+                        <Text>alerts</Text>
                     </Pressable>
                 </View>
             );

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -83,7 +83,10 @@ function AppShell() {
     return (
         <View style={{ flex: 1 }}>
             <View style={{ paddingTop: insets.top, backgroundColor: '#000000' }}>
-                <Header onMenuPress={() => setDrawerOpen(true)} />
+                <Header
+                    onMenuPress={() => setDrawerOpen(true)}
+                    onAlertsPress={() => console.warn('alerts route not wired yet (APP-62).')}
+                />
             </View>
             <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: '#000000' } }}>
                 <Stack.Screen name='modal' options={{ presentation: 'modal', title: 'Modal' }} />

--- a/app/components/header/.test.tsx
+++ b/app/components/header/.test.tsx
@@ -1,9 +1,12 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 
+import type { AlertDto } from '@/api/types/alerts';
 import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
 import { keys } from '@/api/query-keys';
+import config from '@/tailwind.config';
 import { Header } from '.';
 
+const colors = config.theme.extend.colors;
 const mockFetch = jest.fn();
 
 beforeEach(() => {
@@ -12,25 +15,50 @@ beforeEach(() => {
     process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
 });
 
-describe('Header', () => {
-    it('renders menu, brand, and re-plan controls.', () => {
-        const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+function buildAlert(overrides?: Partial<AlertDto>): AlertDto {
+    return {
+        id: 'a-1',
+        class: 'weather-stale',
+        tone: 'warn',
+        title: 'Weather API stale',
+        sub: null,
+        when: '2026-05-24T11:00:00.000Z',
+        zoneId: null,
+        ack: false,
+        ...overrides,
+    };
+}
 
-        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+function seedSystem(client: ReturnType<typeof buildApiWrapper>['client'], irrigationOn: boolean) {
+    client.setQueryData(keys.system.state(), { irrigationEnabled: irrigationOn, since: 'x' });
+}
+
+function seedAlerts(client: ReturnType<typeof buildApiWrapper>['client'], alerts: ReadonlyArray<AlertDto>) {
+    client.setQueryData(keys.alerts.list(), alerts);
+}
+
+describe('Header', () => {
+    it('renders menu, brand, and bell — refresh is no longer in the tree (APP-62).', () => {
+        const { wrapper, client } = buildApiWrapper();
+        seedSystem(client, true);
+        seedAlerts(client, []);
+
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
 
         expect(screen.getByLabelText('Open menu')).toBeOnTheScreen();
         expect(screen.getByLabelText('Irrigo')).toBeOnTheScreen();
         expect(screen.getByText('Irrigo')).toBeOnTheScreen();
-        expect(screen.getByLabelText('Re-plan')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Alerts, no unread')).toBeOnTheScreen();
+        expect(screen.queryByLabelText('Re-plan')).toBeNull();
     });
 
     it('calls onMenuPress when the user taps the menu button while irrigation is on.', () => {
         const onMenuPress = jest.fn();
         const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+        seedSystem(client, true);
+        seedAlerts(client, []);
 
-        render(<Header onMenuPress={onMenuPress} />, { wrapper });
+        render(<Header onMenuPress={onMenuPress} onAlertsPress={jest.fn()} />, { wrapper });
         fireEvent.press(screen.getByLabelText('Open menu'));
 
         expect(onMenuPress).toHaveBeenCalledTimes(1);
@@ -39,9 +67,10 @@ describe('Header', () => {
     it('disables the menu button and ignores presses when irrigation is off.', () => {
         const onMenuPress = jest.fn();
         const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'x' });
+        seedSystem(client, false);
+        seedAlerts(client, []);
 
-        render(<Header onMenuPress={onMenuPress} />, { wrapper });
+        render(<Header onMenuPress={onMenuPress} onAlertsPress={jest.fn()} />, { wrapper });
         const menu = screen.getByLabelText('Open menu');
         fireEvent.press(menu);
 
@@ -49,85 +78,130 @@ describe('Header', () => {
         expect(menu.props.accessibilityState).toMatchObject({ disabled: true });
     });
 
-    it('posts to /replan when the user taps the refresh button while irrigation is on.', async () => {
-        // First resolved value covers the POST /replan; subsequent
-        // mockResolvedValue covers the background GET /system refetch that
-        // `useReplan.onSuccess` triggers by invalidating the system query.
-        mockFetch.mockResolvedValueOnce(
-            jsonResponse({ status: 'replanned', lastRePlanAt: '2026-05-23T03:00:00.000Z' }),
+    it('shows no badge text when the alerts cache is empty (APP-62).', () => {
+        const { wrapper, client } = buildApiWrapper();
+        seedSystem(client, true);
+        seedAlerts(client, []);
+
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
+
+        expect(screen.getByLabelText('Alerts, no unread')).toBeOnTheScreen();
+        // No digit text rendered for 0.
+        expect(screen.queryByText(/^\d+$/)).toBeNull();
+        expect(screen.queryByText('9+')).toBeNull();
+    });
+
+    it('renders an integer badge with the accent tone for info-only unacked alerts (APP-62).', () => {
+        const { wrapper, client } = buildApiWrapper();
+        seedSystem(client, true);
+        // The wire type only allows tone "warn" | "danger"; "info" isn't in
+        // the union. The fallback severity ('info' → accent colour) is
+        // exercised when the alerts array is non-empty AND has no warn /
+        // danger entries — practically that means the cache holds zero
+        // items but `useAlerts` data is treated as "unknown tone". Cover
+        // that path by injecting a synthetic entry shaped like an AlertDto
+        // with a non-warn/non-danger tone via a cast.
+        const accentAlerts = [
+            buildAlert({ id: 'a-1', tone: 'warn' as never }),
+            buildAlert({ id: 'a-2', tone: 'warn' as never }),
+            buildAlert({ id: 'a-3', tone: 'warn' as never }),
+        ];
+        // Replace the warn tone with a "neutral" string the highest-
+        // severity helper falls through on. Cast back to AlertDto[] so the
+        // cache write typechecks.
+        const neutralAlerts = accentAlerts.map(a => ({ ...a, tone: 'neutral' as unknown as 'warn' }));
+        seedAlerts(client, neutralAlerts as AlertDto[]);
+
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
+
+        expect(screen.getByLabelText('Alerts, 3 unread')).toBeOnTheScreen();
+        expect(screen.getByText('3')).toBeOnTheScreen();
+        const badge = screen.getByLabelText('Unread count 3');
+        expect(badge.props.style).toEqual(
+            expect.arrayContaining([expect.objectContaining({ backgroundColor: colors.accent })]),
         );
-        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: true, since: 'x' }));
-
-        const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
-
-        render(<Header onMenuPress={jest.fn()} />, { wrapper });
-
-        await act(async () => {
-            fireEvent.press(screen.getByLabelText('Re-plan'));
-        });
-
-        await waitFor(() => {
-            const replanCalls = mockFetch.mock.calls.filter(([url]) => String(url).endsWith('/replan'));
-            expect(replanCalls).toHaveLength(1);
-        });
-        const replanCall = mockFetch.mock.calls.find(([url]) => String(url).endsWith('/replan'));
-        expect((replanCall as [string, RequestInit])[1].method).toBe('POST');
     });
 
-    it('disables the refresh button and does not POST /replan when irrigation is off.', () => {
-        // Seed the system cache. The header still mounts `useSystem`, which
-        // will refetch (the seeded entry is immediately stale under the
-        // default `staleTime: 0`), so we cover that background GET too —
-        // the test asserts no `/replan` POST, not zero fetches overall.
-        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: false, since: 'x' }));
-
+    it('caps the badge text at "9+" when there are more than nine unacked alerts (APP-62).', () => {
         const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.system.state(), { irrigationEnabled: false, since: 'x' });
+        seedSystem(client, true);
+        seedAlerts(client, Array.from({ length: 12 }, (_, i) => buildAlert({ id: `a-${i}` })));
 
-        render(<Header onMenuPress={jest.fn()} />, { wrapper });
-        const refresh = screen.getByLabelText('Re-plan');
-        fireEvent.press(refresh);
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
 
-        const replanCalls = mockFetch.mock.calls.filter(([url]) => String(url).endsWith('/replan'));
-        expect(replanCalls).toHaveLength(0);
-        expect(refresh.props.accessibilityState).toMatchObject({ disabled: true });
+        expect(screen.getByText('9+')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Alerts, 12 unread')).toBeOnTheScreen();
     });
 
-    it('keeps the refresh button disabled while a re-plan request is in flight.', async () => {
-        // Hold the POST /replan promise open so the mutation stays pending
-        // long enough to observe the disabled state.
-        let resolveReplan: (response: Response) => void = () => {};
-        const replanPromise = new Promise<Response>(resolve => {
-            resolveReplan = resolve;
-        });
-        mockFetch.mockReturnValueOnce(replanPromise);
-        mockFetch.mockResolvedValue(jsonResponse({ irrigationEnabled: true, since: 'x' }));
-
+    it('uses the warn tint when at least one unacked alert is warn-tone (APP-62).', () => {
         const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.system.state(), { irrigationEnabled: true, since: 'x' });
+        seedSystem(client, true);
+        seedAlerts(client, [
+            buildAlert({ id: 'a-1', tone: 'warn' }),
+            buildAlert({ id: 'a-2', tone: 'warn' }),
+        ]);
 
-        render(<Header onMenuPress={jest.fn()} />, { wrapper });
-        fireEvent.press(screen.getByLabelText('Re-plan'));
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
 
-        await waitFor(() => {
-            expect(screen.getByLabelText('Re-plan').props.accessibilityState).toMatchObject({ disabled: true });
-        });
-
-        // Release the held promise so the mutation settles and React Query
-        // doesn't log "unhandled promise" warnings after the test ends.
-        await act(async () => {
-            resolveReplan(jsonResponse({ status: 'replanned', lastRePlanAt: 'x' }));
-            await replanPromise;
-        });
+        const badge = screen.getByLabelText('Unread count 2');
+        expect(badge.props.style).toEqual(
+            expect.arrayContaining([expect.objectContaining({ backgroundColor: colors.warn })]),
+        );
     });
 
-    it('treats an unresolved system query as off so both icon buttons stay disabled.', () => {
+    it('uses the danger tint when any unacked alert is danger-tone, regardless of others (APP-62).', () => {
+        const { wrapper, client } = buildApiWrapper();
+        seedSystem(client, true);
+        seedAlerts(client, [
+            buildAlert({ id: 'a-1', tone: 'warn' }),
+            buildAlert({ id: 'a-2', tone: 'danger' }),
+            buildAlert({ id: 'a-3', tone: 'warn' }),
+        ]);
+
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
+
+        const badge = screen.getByLabelText('Unread count 3');
+        expect(badge.props.style).toEqual(
+            expect.arrayContaining([expect.objectContaining({ backgroundColor: colors.danger })]),
+        );
+    });
+
+    it('fires onAlertsPress when the user taps the bell while irrigation is on (APP-62).', () => {
+        const onAlertsPress = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        seedSystem(client, true);
+        seedAlerts(client, [buildAlert()]);
+
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={onAlertsPress} />, { wrapper });
+        fireEvent.press(screen.getByLabelText('Alerts, 1 unread'));
+
+        expect(onAlertsPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the bell and does not fire onAlertsPress when irrigation is off (APP-62).', () => {
+        // Stub the fetch the disabled-system render still triggers (useAlerts
+        // polls), so React Query doesn't hit an undefined response object.
+        mockFetch.mockResolvedValue(jsonResponse([]));
+
+        const onAlertsPress = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        seedSystem(client, false);
+        seedAlerts(client, []);
+
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={onAlertsPress} />, { wrapper });
+        const bell = screen.getByLabelText('Alerts, no unread');
+        fireEvent.press(bell);
+
+        expect(onAlertsPress).not.toHaveBeenCalled();
+        expect(bell.props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it('treats an unresolved system query as off so both icon buttons stay disabled (APP-62).', () => {
         const { wrapper } = buildApiWrapper();
 
-        render(<Header onMenuPress={jest.fn()} />, { wrapper });
+        render(<Header onMenuPress={jest.fn()} onAlertsPress={jest.fn()} />, { wrapper });
 
         expect(screen.getByLabelText('Open menu').props.accessibilityState).toMatchObject({ disabled: true });
-        expect(screen.getByLabelText('Re-plan').props.accessibilityState).toMatchObject({ disabled: true });
+        expect(screen.getByLabelText('Alerts, no unread').props.accessibilityState).toMatchObject({ disabled: true });
     });
 });

--- a/app/components/header/index.tsx
+++ b/app/components/header/index.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import type { AlertDto } from '@/api/types/alerts';
 import { BrandGlyph } from '@/components/brand-glyph';
 import { Button } from '@/components/button';
 import { Bell, Menu } from '@/components/icons';
@@ -8,9 +10,14 @@ import { useAlerts } from '@/hooks/alerts';
 import { useSystem } from '@/hooks/system';
 import { SEVERITY_COLOR, highestSeverity } from '@/lib/alert-severity';
 import config from '@/tailwind.config';
-import { useMemo } from 'react';
 
 const colors = config.theme.extend.colors;
+
+// Module-level sentinel used as the fallback when `useAlerts().data` is
+// undefined. Using a stable reference (instead of an inline `?? []`) keeps
+// the downstream `useMemo` cache hot — a fresh `[]` each render busts every
+// dependency array that closes over `alerts`.
+const EMPTY_ALERTS: readonly AlertDto[] = [];
 
 /**
  * Props for the Irrigo app header.
@@ -54,7 +61,7 @@ export function Header({ onMenuPress, onAlertsPress }: HeaderProps) {
     const { data: alertsData } = useAlerts();
     const irrigationOn = system?.irrigationEnabled === true;
 
-    const alerts = alertsData ?? [];
+    const alerts = alertsData ?? EMPTY_ALERTS;
     const count = alerts.length;
     const display = count > 9 ? '9+' : String(count);
     const severity = useMemo(() => highestSeverity(alerts), [alerts]);

--- a/app/components/header/index.tsx
+++ b/app/components/header/index.tsx
@@ -1,12 +1,14 @@
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { BrandGlyph } from '@/components/brand-glyph';
 import { Button } from '@/components/button';
-import { Menu, Refresh } from '@/components/icons';
+import { Bell, Menu } from '@/components/icons';
 import { FontFamily } from '@/constants/fonts';
-import { useReplan } from '@/hooks/replan';
+import { useAlerts } from '@/hooks/alerts';
 import { useSystem } from '@/hooks/system';
+import { SEVERITY_COLOR, highestSeverity } from '@/lib/alert-severity';
 import config from '@/tailwind.config';
+import { useMemo } from 'react';
 
 const colors = config.theme.extend.colors;
 
@@ -16,16 +18,25 @@ const colors = config.theme.extend.colors;
 export type HeaderProps = {
     /**
      * Required. Fired when the hamburger button is tapped (and irrigation is
-     * on). The header itself is drawer-agnostic — APP-23 wires this prop to
-     * the nav drawer's open handler.
+     * on). The header itself is drawer-agnostic — the root layout wires this
+     * prop to the nav drawer's open handler.
      */
     onMenuPress: () => void;
+
+    /**
+     * Required. Fired when the bell button is tapped (and irrigation is on).
+     * The destination screen is owned by the caller — the full alerts view
+     * is a follow-up ticket (APP-62 wires the bell, not the route).
+     */
+    onAlertsPress: () => void;
 };
 
 /**
  * The shared app header — hamburger on the left, `BrandGlyph` + `Irrigo`
- * wordmark in the centre, refresh icon on the right. RN port of the App
- * header block in [`Mobile.jsx:32-68`](app/design/irrigo/project/ui_kit/Mobile.jsx).
+ * wordmark in the centre, alert bell on the right. RN port of the App
+ * header block in [`Alerts.jsx`](app/design/ui_kit/Alerts.jsx) (APP-62 —
+ * the bell replaces the earlier refresh icon; re-plan stays accessible
+ * from the active-schedule hero card).
  *
  * Reads the master irrigation switch via `useSystem`. When the system is off
  * (or the query hasn't resolved yet — sticky-off during cold start), both
@@ -33,15 +44,21 @@ export type HeaderProps = {
  * design source uses `filter: grayscale(1)` to desaturate the brand, but
  * React Native has no CSS filter; opacity is the portable approximation.
  *
- * The refresh button dispatches `useReplan` and stays disabled while a
- * re-plan is in flight so impatient double-taps don't queue duplicate
- * mutations.
+ * The bell pulls the unacked alert count from `useAlerts()`. Badge hides
+ * when the count is zero, displays the integer up to 9, and caps at `9+`.
+ * Badge colour follows the highest-severity unacked tone — danger first,
+ * then warn, then accent.
  */
-export function Header({ onMenuPress }: HeaderProps) {
+export function Header({ onMenuPress, onAlertsPress }: HeaderProps) {
     const { data: system } = useSystem();
-    const replan = useReplan();
+    const { data: alertsData } = useAlerts();
     const irrigationOn = system?.irrigationEnabled === true;
-    const refreshDisabled = !irrigationOn || replan.isPending;
+
+    const alerts = alertsData ?? [];
+    const count = alerts.length;
+    const display = count > 9 ? '9+' : String(count);
+    const severity = useMemo(() => highestSeverity(alerts), [alerts]);
+    const alertsLabel = count === 0 ? 'Alerts, no unread' : `Alerts, ${count} unread`;
 
     return (
         <View className='flex-row items-center justify-between gap-3 px-4 pt-1 pb-[14px]'>
@@ -54,10 +71,7 @@ export function Header({ onMenuPress }: HeaderProps) {
             >
                 <Menu size={18} />
             </Button>
-            <View
-                className='flex-row items-center gap-2'
-                style={{ opacity: irrigationOn ? 1 : 0.45 }}
-            >
+            <View className='flex-row items-center gap-2' style={{ opacity: irrigationOn ? 1 : 0.45 }}>
                 <BrandGlyph size={24} />
                 <Text
                     style={{
@@ -74,12 +88,50 @@ export function Header({ onMenuPress }: HeaderProps) {
             <Button
                 iconOnly
                 variant='ghost'
-                accessibilityLabel='Re-plan'
-                disabled={refreshDisabled}
-                onPress={() => replan.mutate()}
+                accessibilityLabel={alertsLabel}
+                disabled={!irrigationOn}
+                onPress={onAlertsPress}
             >
-                <Refresh size={16} />
+                <View style={styles.bellSlot}>
+                    <Bell size={18} />
+                    {count > 0 && (
+                        <View
+                            accessibilityLabel={`Unread count ${display}`}
+                            style={[styles.badge, { backgroundColor: SEVERITY_COLOR[severity] }]}
+                        >
+                            <Text style={styles.badgeText}>{display}</Text>
+                        </View>
+                    )}
+                </View>
             </Button>
         </View>
     );
 }
+
+const styles = StyleSheet.create({
+    bellSlot: {
+        position: 'relative',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    badge: {
+        position: 'absolute',
+        top: -6,
+        right: -8,
+        minWidth: 14,
+        height: 14,
+        paddingHorizontal: 3,
+        borderRadius: 7,
+        alignItems: 'center',
+        justifyContent: 'center',
+        // Punch-out ring matching the design source: a 2px ring of the
+        // surface colour separates the badge from the icon behind it.
+        boxShadow: `0 0 0 2px ${colors.bg}`,
+    },
+    badgeText: {
+        fontFamily: FontFamily.monoSemibold,
+        fontSize: 9,
+        lineHeight: 12,
+        color: colors['on-accent'],
+    },
+});

--- a/app/lib/alert-severity/.test.ts
+++ b/app/lib/alert-severity/.test.ts
@@ -1,0 +1,47 @@
+import type { AlertDto } from '@/api/types/alerts';
+import config from '@/tailwind.config';
+import { SEVERITY_COLOR, highestSeverity, type AlertSeverity } from '.';
+
+const colors = config.theme.extend.colors;
+
+function alert(tone: 'warn' | 'danger'): AlertDto {
+    return {
+        id: tone,
+        class: 'weather-stale',
+        tone,
+        title: 't',
+        sub: null,
+        when: '2026-05-24T11:00:00.000Z',
+        zoneId: null,
+        ack: false,
+    };
+}
+
+describe('SEVERITY_COLOR', () => {
+    it('maps each severity to the matching design token.', () => {
+        const map: Record<AlertSeverity, string> = SEVERITY_COLOR;
+        expect(map.danger).toBe(colors.danger);
+        expect(map.warn).toBe(colors.warn);
+        expect(map.info).toBe(colors.accent);
+    });
+});
+
+describe('highestSeverity', () => {
+    it(`returns 'info' for an empty alert list (no urgency to surface).`, () => {
+        expect(highestSeverity([])).toBe('info');
+    });
+
+    it(`returns 'warn' when every alert is warn-tone.`, () => {
+        expect(highestSeverity([alert('warn'), alert('warn')])).toBe('warn');
+    });
+
+    it(`returns 'danger' when any alert is danger-tone, even mixed with warn.`, () => {
+        expect(highestSeverity([alert('warn'), alert('danger'), alert('warn')])).toBe('danger');
+    });
+
+    it(`prioritises danger over warn regardless of order.`, () => {
+        expect(highestSeverity([alert('danger')])).toBe('danger');
+        expect(highestSeverity([alert('danger'), alert('warn')])).toBe('danger');
+        expect(highestSeverity([alert('warn'), alert('danger')])).toBe('danger');
+    });
+});

--- a/app/lib/alert-severity/index.ts
+++ b/app/lib/alert-severity/index.ts
@@ -1,0 +1,37 @@
+import type { AlertTone } from '@/api/types/alerts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Severity tones surfaced by aggregate alert UI (currently the header
+ * bell badge — APP-62). `'info'` covers the "alerts present but none
+ * warn / danger" case; unreachable on the wire today (the API only emits
+ * warn / danger) but the value keeps the type honest if the contract
+ * grows to include info-level alerts in the future.
+ */
+export type AlertSeverity = AlertTone | 'info';
+
+/**
+ * Per-severity hex used to tint aggregate alert UI. Source: the
+ * AlertBell mock in `app/design/ui_kit/Alerts.jsx`. Distinct from
+ * `AlertRow`'s per-tone palette, which uses richer `tint + border +
+ * accent + icon` quadruples — aggregate badges only need the dominant
+ * accent colour.
+ */
+export const SEVERITY_COLOR: Readonly<Record<AlertSeverity, string>> = {
+    danger: colors.danger,
+    warn: colors.warn,
+    info: colors.accent,
+};
+
+/**
+ * Returns the highest-priority tone among the supplied alerts:
+ * `danger` > `warn` > `info`. Drives the colour of aggregate alert UI so
+ * the worst unacked condition wins the visual urgency.
+ */
+export function highestSeverity(alerts: ReadonlyArray<{ tone: AlertTone }>): AlertSeverity {
+    if (alerts.some(a => a.tone === 'danger')) return 'danger';
+    if (alerts.some(a => a.tone === 'warn')) return 'warn';
+    return 'info';
+}


### PR DESCRIPTION
## Ticket

[APP-62](http://192.168.2.100:7123/home/browse/APP-62/) — Add notification bell with alert count to header

## Summary

- Swapped the header's refresh icon for a new alert bell (\`Bell\` icon from \`@/components/icons\`), driven by \`useAlerts()\`. Re-plan stays accessible from \`ActiveScheduleHero\`, so no functional loss.
- Badge hides at 0, shows the integer up to 9, caps at \`9+\`.
- Badge colour follows the highest-severity unacked tone: \`danger\` → \`warn\` → \`info\` (info falls through to the accent green per the design mock in \`app/design/ui_kit/Alerts.jsx\`).
- Bell shares the existing \"disabled when system is off / unresolved\" pattern with the menu button.
- \`accessibilityLabel\` reflects the count: \`'Alerts, no unread'\` / \`'Alerts, N unread'\`.
- Extracted the severity→colour palette and \`highestSeverity\` helper into a new shared module at \`app/lib/alert-severity/\` so any future aggregate alert UI can reuse the same source of truth.

## Design decisions confirmed before planning

- **Bell replaces refresh** in the header (vs. alongside) — matches the design source comment in \`Alerts.jsx\` and avoids a second right-side icon. Re-plan remains in the active-schedule hero.
- **Wire-but-no-route**: \`onAlertsPress\` is a placeholder \`console.warn\` in the root layout. The full \`AlertsView\` (grouped list + filter chips per the mock) is a follow-up ticket.

## Test plan

- [ ] Open the app; header shows menu / brand / bell with no badge when there are no unacked alerts.
- [ ] Trigger a warn alert from the API; badge appears amber with the count.
- [ ] Trigger a danger alert; badge flips to red.
- [ ] Trigger more than 9 alerts; badge caps at \`9+\`.
- [ ] Toggle system off; bell + menu both grey out, taps are ignored.
- [ ] \`bun --cwd=./app run test\` passes (542/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)