### PR TITLE
[APP-40] Pull-to-refresh across data-driven screens

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -8,6 +8,12 @@ Shared conventions (typing, shell rules, ticket workflow, git workflow) live in 
 
 Read the exact versioned docs at <https://docs.expo.dev/versions/v54.0.0/> before writing any code that touches Expo APIs.
 
+## Scroll containers
+
+Use `RefreshableScrollView` (from `@/components/refreshable-scroll-view`) instead of RN's bare `ScrollView` for any **screen-level, data-driven** scroll container — i.e. the outermost scrolling element on a route that renders content backed by React Query. The wrapper owns a `RefreshControl` whose `onRefresh` invalidates every active query on the mounted screen (APP-40), so the screen recovers from transient API failures without per-screen refresh wiring.
+
+Stick with bare `ScrollView` for **presentation-only** scrollers that aren't a route surface (e.g. the horizontal chip strip in `zone-filter-chip-strip` — it scrolls a static row of chips, not a data view). When in doubt: if the screen would benefit from pull-to-refresh, use `RefreshableScrollView`.
+
 ## Scripts
 
 Always invoke via `bun --cwd=./app run <script>`. Never the bare `bun --cwd=./app <script>` form — see the root `CLAUDE.md` "Running package.json scripts" section. In particular, **`bun --cwd=./app test` is broken** for this project: it triggers Bun's native test runner, which can't parse React Native's flow type syntax and dies on the first import of `react-native`. Use `bun --cwd=./app run test` so Bun dispatches to the `test` script and Jest takes over.

--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { RefreshControl } from 'react-native';
 
 jest.mock('react-native-safe-area-context', () => ({
     useSafeAreaInsets: () => ({ top: 44, bottom: 0, left: 0, right: 0 }),
@@ -276,6 +277,15 @@ describe('ActivityView', () => {
             expect(lastCall).toBeDefined();
             expect(lastCall?.searchParams.has('zoneId')).toBe(false);
         });
+    });
+
+    it('mounts a RefreshControl so pull-to-refresh stays wired in (APP-40).', () => {
+        const { wrapper } = buildApiWrapper();
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        render(<ActivityView />, { wrapper });
+
+        expect(screen.UNSAFE_getByType(RefreshControl)).toBeTruthy();
     });
 
     it('updates the eyebrow suffix to the zone name when a zone is selected (APP-61).', async () => {

--- a/app/components/activity-view/index.tsx
+++ b/app/components/activity-view/index.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { FireLog } from '@/components/fire-log';
+import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
 import { ZoneFilterChipStrip } from '@/components/zone-filter-chip-strip';
 import { FontFamily } from '@/constants/fonts';
 import { useActivity } from '@/hooks/activity';
@@ -42,7 +43,7 @@ export function ActivityView() {
     const eyebrowSuffix = selectedZoneName ?? ALL_ZONES_LABEL;
 
     return (
-        <ScrollView
+        <RefreshableScrollView
             style={styles.scroll}
             contentContainerStyle={[styles.content, { paddingTop: 16, paddingBottom: insets.bottom + 32 }]}
         >
@@ -64,7 +65,7 @@ export function ActivityView() {
                     <PlaceholderCard label='No runs yet.' />
                 :   <FireLog rows={rows} siteTimezone={siteTimezone} />}
             </View>
-        </ScrollView>
+        </RefreshableScrollView>
     );
 }
 

--- a/app/components/home-view/.test.tsx
+++ b/app/components/home-view/.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { RefreshControl } from 'react-native';
 
 jest.mock('expo-router', () => ({
     useRouter: () => ({ push: mockPush }),
@@ -345,6 +346,14 @@ describe('HomeView', () => {
         render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
 
         await waitFor(() => expect(mockHideAsync).toHaveBeenCalledTimes(1));
+    });
+
+    it('mounts a RefreshControl so pull-to-refresh stays wired in (APP-40).', () => {
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
+
+        expect(screen.UNSAFE_getByType(RefreshControl)).toBeTruthy();
     });
 
     it('drops the splash via the 30-second backstop if the API never responds (APP-51).', () => {

--- a/app/components/home-view/index.tsx
+++ b/app/components/home-view/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'expo-router';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -9,6 +9,7 @@ import { ActiveScheduleChip } from '@/components/active-schedule-chip';
 import { DepletionLegend } from '@/components/depletion-legend';
 import { MasterToggle } from '@/components/master-toggle';
 import { NextRunHero } from '@/components/next-run-hero';
+import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
 import { SystemDisabledWrapper } from '@/components/system-disabled-wrapper';
 import { ZoneTile } from '@/components/zone-tile';
 import { FontFamily } from '@/constants/fonts';
@@ -55,7 +56,7 @@ export function HomeView() {
     };
 
     return (
-        <ScrollView
+        <RefreshableScrollView
             style={styles.scroll}
             contentContainerStyle={[styles.content, { paddingTop: 16, paddingBottom: insets.bottom + 32 }]}
         >
@@ -103,7 +104,7 @@ export function HomeView() {
                     )}
                 </View>
             </SystemDisabledWrapper>
-        </ScrollView>
+        </RefreshableScrollView>
     );
 }
 

--- a/app/components/refreshable-scroll-view/.test.tsx
+++ b/app/components/refreshable-scroll-view/.test.tsx
@@ -1,0 +1,112 @@
+import { act, render, screen } from '@testing-library/react-native';
+import { RefreshControl, ScrollView, Text } from 'react-native';
+
+import { buildApiWrapper } from '@/api/test-utils';
+import { RefreshableScrollView } from '.';
+
+describe('RefreshableScrollView', () => {
+    it('renders its children inside the underlying ScrollView.', () => {
+        const { wrapper } = buildApiWrapper();
+        render(
+            <RefreshableScrollView>
+                <Text>child-marker</Text>
+            </RefreshableScrollView>,
+            { wrapper },
+        );
+
+        expect(screen.getByText('child-marker')).toBeOnTheScreen();
+        expect(screen.UNSAFE_getByType(ScrollView)).toBeTruthy();
+    });
+
+    it('mounts a RefreshControl on the ScrollView whose initial `refreshing` flag is false.', () => {
+        const { wrapper } = buildApiWrapper();
+        render(
+            <RefreshableScrollView>
+                <Text>x</Text>
+            </RefreshableScrollView>,
+            { wrapper },
+        );
+
+        const refreshControl = screen.UNSAFE_getByType(RefreshControl);
+        expect(refreshControl.props.refreshing).toBe(false);
+    });
+
+    it('invokes queryClient.invalidateQueries() exactly once per pull.', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+
+        render(
+            <RefreshableScrollView>
+                <Text>x</Text>
+            </RefreshableScrollView>,
+            { wrapper },
+        );
+
+        const refreshControl = screen.UNSAFE_getByType(RefreshControl);
+        await act(async () => {
+            await refreshControl.props.onRefresh();
+        });
+
+        expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('flips `refreshing` to true while the invalidate promise is in flight.', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        let resolveInvalidate: (() => void) | null = null;
+        jest.spyOn(client, 'invalidateQueries').mockImplementation(
+            () => new Promise<void>(resolve => { resolveInvalidate = resolve; }),
+        );
+
+        render(
+            <RefreshableScrollView>
+                <Text>x</Text>
+            </RefreshableScrollView>,
+            { wrapper },
+        );
+
+        const refreshControl = screen.UNSAFE_getByType(RefreshControl);
+
+        let onRefreshPromise: Promise<void> | undefined;
+        await act(async () => {
+            onRefreshPromise = refreshControl.props.onRefresh();
+        });
+
+        expect(screen.UNSAFE_getByType(RefreshControl).props.refreshing).toBe(true);
+
+        await act(async () => {
+            resolveInvalidate?.();
+            await onRefreshPromise;
+        });
+    });
+
+    it('flips `refreshing` back to false once the invalidate promise resolves.', async () => {
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <RefreshableScrollView>
+                <Text>x</Text>
+            </RefreshableScrollView>,
+            { wrapper },
+        );
+
+        const refreshControl = screen.UNSAFE_getByType(RefreshControl);
+        await act(async () => {
+            await refreshControl.props.onRefresh();
+        });
+
+        expect(screen.UNSAFE_getByType(RefreshControl).props.refreshing).toBe(false);
+    });
+
+    it('forwards arbitrary ScrollView props through to the underlying ScrollView.', () => {
+        const { wrapper } = buildApiWrapper();
+        render(
+            <RefreshableScrollView contentContainerStyle={{ padding: 24 }}>
+                <Text>x</Text>
+            </RefreshableScrollView>,
+            { wrapper },
+        );
+
+        const scrollView = screen.UNSAFE_getByType(ScrollView);
+        expect(scrollView.props.contentContainerStyle).toEqual({ padding: 24 });
+    });
+});

--- a/app/components/refreshable-scroll-view/index.tsx
+++ b/app/components/refreshable-scroll-view/index.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useState, type ComponentProps } from 'react';
+import { RefreshControl, ScrollView } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
+
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for {@link RefreshableScrollView}. Inherits every `ScrollView` prop
+ * except `refreshControl`, which the wrapper owns.
+ */
+export type RefreshableScrollViewProps = Omit<ComponentProps<typeof ScrollView>, 'refreshControl'>;
+
+/**
+ * Pull-to-refresh scroll container. Drop-in replacement for RN's
+ * `ScrollView` on any data-driven screen.
+ *
+ * Owns a local `refreshing` state and a `RefreshControl` whose `onRefresh`
+ * fires `queryClient.invalidateQueries()` with no key — that flags every
+ * cached query stale and refetches each active subscriber on the mounted
+ * screen. The hook returns a promise that settles once the refetches
+ * complete, so the spinner stays visible until the data has actually
+ * updated. APP-40.
+ *
+ * Trade-off: invalidating all queries on every pull is mildly noisier than
+ * targeted per-screen invalidation, but the home-LAN API is cheap and
+ * keeps each screen blissfully ignorant of which queries it depends on.
+ */
+export function RefreshableScrollView({ children, ...rest }: RefreshableScrollViewProps) {
+    const queryClient = useQueryClient();
+    const [refreshing, setRefreshing] = useState<boolean>(false);
+
+    const onRefresh = useCallback(async () => {
+        setRefreshing(true);
+        try {
+            await queryClient.invalidateQueries();
+        } finally {
+            setRefreshing(false);
+        }
+    }, [queryClient]);
+
+    return (
+        <ScrollView
+            {...rest}
+            refreshControl={(
+                <RefreshControl
+                    refreshing={refreshing}
+                    onRefresh={onRefresh}
+                    tintColor={colors.accent}
+                    colors={[colors.accent]}
+                    progressBackgroundColor={colors.elevated}
+                />
+            )}
+        >
+            {children}
+        </ScrollView>
+    );
+}


### PR DESCRIPTION
## Ticket

[APP-40](http://192.168.2.100:7123/home/browse/APP-40/) Pull-to-refresh across all data-driven screens.

## Summary

- Add `RefreshableScrollView` — a transparent `ScrollView` wrapper that owns a `refreshing` state and dispatches `queryClient.invalidateQueries()` on pull, so each screen stays ignorant of which queries it depends on.
- Adopt the primitive in `HomeView` and `ActivityView` (the two data-driven scroll containers in the active route tree).
- Recovery path for transient API failures no longer requires killing and relaunching the app — pull to refetch.

## Test plan

- [x] Full app suite green (550 tests across 72 suites).
- [x] `RefreshableScrollView` unit tests assert children, initial state, invalidate count, in-flight `refreshing=true`, post-resolve `refreshing=false`, and prop pass-through.
- [x] Home and Activity views each have a regression test that asserts a `RefreshControl` remains in the tree.
- [ ] Manual: stop the api container, pull on Home → error placeholders appear; restart the api container, pull again → placeholders clear once the queries succeed.