### PR TITLE
[APP-66] Add the app-load error view

### DIFF
--- a/app/components/error-view/.test.tsx
+++ b/app/components/error-view/.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { ErrorView } from '.';
+
+const BASE_PROPS = {
+    eyebrow: 'Connection lost',
+    title: 'Controller unreachable',
+    sub: 'No response from Home Assistant since 14:02. Planner paused, no zone can fire.',
+    onRetry: () => {},
+    state: 'idle' as const,
+};
+
+describe('ErrorView', () => {
+    it('renders the eyebrow, title, and sub-line strings supplied via props.', () => {
+        render(<ErrorView {...BASE_PROPS} />);
+
+        expect(screen.getByText('Connection lost')).toBeOnTheScreen();
+        expect(screen.getByText('Controller unreachable')).toBeOnTheScreen();
+        expect(
+            screen.getByText('No response from Home Assistant since 14:02. Planner paused, no zone can fire.'),
+        ).toBeOnTheScreen();
+    });
+
+    it('renders the Irrigo wordmark in the brand row.', () => {
+        render(<ErrorView {...BASE_PROPS} />);
+
+        expect(screen.getByText('Irrigo')).toBeOnTheScreen();
+    });
+
+    it('renders every stack-trace line when an array is supplied.', () => {
+        const stack = [
+            'Error: connect ECONNREFUSED 192.168.1.42:8123',
+            '    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1611:16)',
+            '    at HAClient.connect (planner/ha.js:142:23)',
+        ];
+
+        render(<ErrorView {...BASE_PROPS} stack={stack} />);
+
+        for (const line of stack) {
+            expect(screen.getByText(line)).toBeOnTheScreen();
+        }
+    });
+
+    it('omits the stack-trace block when no stack is supplied.', () => {
+        render(<ErrorView {...BASE_PROPS} />);
+
+        expect(screen.queryByText(/ECONNREFUSED/)).toBeNull();
+    });
+
+    it('omits the stack-trace block when an empty array is supplied.', () => {
+        render(<ErrorView {...BASE_PROPS} stack={[]} />);
+
+        expect(screen.queryByText(/ECONNREFUSED/)).toBeNull();
+    });
+
+    it('shows the "Retry connection" button label when idle.', () => {
+        render(<ErrorView {...BASE_PROPS} state='idle' />);
+
+        expect(screen.getByText('Retry connection')).toBeOnTheScreen();
+        expect(screen.queryByText('Cancel attempt')).toBeNull();
+    });
+
+    it('shows the "Cancel attempt" button label when retrying.', () => {
+        render(<ErrorView {...BASE_PROPS} state='retrying' />);
+
+        expect(screen.getByText('Cancel attempt')).toBeOnTheScreen();
+        expect(screen.queryByText('Retry connection')).toBeNull();
+    });
+
+    it('renders the "Contacting…" status line only when retrying.', () => {
+        const idle = render(<ErrorView {...BASE_PROPS} state='idle' />);
+        expect(screen.queryByText('Contacting…')).toBeNull();
+        idle.unmount();
+
+        render(<ErrorView {...BASE_PROPS} state='retrying' />);
+        expect(screen.getByText('Contacting…')).toBeOnTheScreen();
+    });
+
+    it('calls onRetry once when the primary button is pressed while idle.', () => {
+        const onRetry = jest.fn();
+
+        render(<ErrorView {...BASE_PROPS} state='idle' onRetry={onRetry} />);
+        fireEvent.press(screen.getByText('Retry connection'));
+
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onRetry once when the primary button is pressed while retrying (acts as cancel).', () => {
+        const onRetry = jest.fn();
+
+        render(<ErrorView {...BASE_PROPS} state='retrying' onRetry={onRetry} />);
+        fireEvent.press(screen.getByText('Cancel attempt'));
+
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/components/error-view/index.tsx
+++ b/app/components/error-view/index.tsx
@@ -1,0 +1,218 @@
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { BrandGlyph } from '@/components/brand-glyph';
+import { Button } from '@/components/button';
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the app-load error view.
+ */
+export type ErrorViewProps = {
+    /** Required. Short uppercase status label rendered above the headline (e.g. 'Connection lost'). */
+    eyebrow: string;
+
+    /** Required. Display headline (e.g. 'Controller unreachable'). */
+    title: string;
+
+    /** Required. Factual sub-line explaining the failure. */
+    sub: string;
+
+    /** Optional. Stack-trace lines rendered in the mono block; the block is omitted when undefined or empty. */
+    stack?: readonly string[];
+
+    /** Required. Drives the primary button label and the optional 'Contacting…' status line. */
+    state: 'idle' | 'retrying';
+
+    /** Required. Press handler for the primary button — serves as both retry and cancel-attempt. */
+    onRetry: () => void;
+};
+
+/**
+ * Full-screen error view shown by the app-load reachability gate when the
+ * API can't be reached. Mirrors `app/design/ui_kit/Error.jsx`: desaturated
+ * brand row at the top, hero block (eyebrow + display headline + factual
+ * sub-line + optional mono stack trace), and a primary retry button pinned
+ * to the bottom of the scroll content.
+ *
+ * Voice (per the mock's header comment): loud, terse, actionable. No
+ * apology copy. Manual retry only — the operator decides when to try
+ * again.
+ *
+ * The mock paints two soft radial `danger-tint` vignettes in the corners
+ * for a "system looks wrong" cue. RN has no radial-gradient primitive and
+ * the eyebrow dot + glow already carries that intent, so the wash is
+ * intentionally omitted here.
+ */
+export function ErrorView({ eyebrow, title, sub, stack, state, onRetry }: ErrorViewProps) {
+    const hasStack = stack !== undefined && stack.length > 0;
+    const isRetrying = state === 'retrying';
+
+    return (
+        <View style={styles.root}>
+            <View style={styles.statusBarSpacer} />
+
+            <View style={styles.brandRow}>
+                <View style={styles.brandInner}>
+                    <BrandGlyph size={22} />
+                    <Text style={styles.brandWordmark}>Irrigo</Text>
+                </View>
+            </View>
+
+            <View style={styles.body}>
+                <View style={styles.hero}>
+                    <View style={styles.eyebrowRow}>
+                        <View style={styles.eyebrowDot} />
+                        <Text style={styles.eyebrowText}>{eyebrow}</Text>
+                    </View>
+
+                    <Text style={styles.title}>{title}</Text>
+
+                    <Text style={styles.sub}>{sub}</Text>
+
+                    {hasStack ? (
+                        <View style={styles.stackContainer}>
+                            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                                <View>
+                                    {stack.map((line, i) => (
+                                        <Text
+                                            key={i}
+                                            style={i === 0 ? styles.stackLineFirst : styles.stackLine}
+                                        >
+                                            {line}
+                                        </Text>
+                                    ))}
+                                </View>
+                            </ScrollView>
+                        </View>
+                    ) : null}
+                </View>
+
+                <View style={styles.actions}>
+                    {isRetrying ? (
+                        <View style={styles.retryingRow} accessibilityLabel='Contacting'>
+                            <ActivityIndicator size='small' color={colors.accent} />
+                            <Text style={styles.retryingText}>Contacting…</Text>
+                        </View>
+                    ) : null}
+
+                    <Button variant='primary' size='lg' onPress={onRetry}>
+                        {isRetrying ? 'Cancel attempt' : 'Retry connection'}
+                    </Button>
+                </View>
+            </View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    root: {
+        flex: 1,
+        backgroundColor: colors.bg,
+    },
+    statusBarSpacer: {
+        height: 60,
+    },
+    brandRow: {
+        paddingTop: 4,
+        paddingBottom: 14,
+        paddingHorizontal: 20,
+    },
+    brandInner: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        opacity: 0.4,
+    },
+    brandWordmark: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 15,
+        lineHeight: 15,
+        letterSpacing: -0.3,
+        color: colors.fg,
+    },
+    body: {
+        flex: 1,
+        paddingTop: 6,
+        paddingBottom: 22,
+        paddingHorizontal: 20,
+    },
+    hero: {
+        marginTop: 12,
+    },
+    eyebrowRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    eyebrowDot: {
+        width: 5,
+        height: 5,
+        backgroundColor: colors.danger,
+        boxShadow: `0 0 8px ${colors.danger}`,
+    },
+    eyebrowText: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        letterSpacing: 1.98,
+        textTransform: 'uppercase',
+        color: colors.danger,
+    },
+    title: {
+        marginTop: 12,
+        fontFamily: FontFamily.displayBold,
+        fontSize: 32,
+        lineHeight: 33,
+        letterSpacing: -0.8,
+        color: colors.fg,
+    },
+    sub: {
+        marginTop: 10,
+        fontFamily: FontFamily.sans,
+        fontSize: 14,
+        lineHeight: 21,
+        color: colors['fg-soft'],
+    },
+    stackContainer: {
+        marginTop: 16,
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 4,
+    },
+    stackLine: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 10.5,
+        lineHeight: 16,
+        color: colors['fg-dim'],
+    },
+    stackLineFirst: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 10.5,
+        lineHeight: 16,
+        color: colors.danger,
+    },
+    actions: {
+        marginTop: 'auto',
+        paddingTop: 4,
+        gap: 12,
+    },
+    retryingRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        minHeight: 16,
+    },
+    retryingText: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        color: colors.accent,
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-66](http://192.168.2.100:7123/home/browse/APP-66/) — Build the app-load error view per `Error.jsx` mock.

## Summary

- Adds `ErrorView` at `app/components/error-view/index.tsx` — full-screen presentational component for the app-load reachability gate (APP-59).
- Mirrors `app/design/ui_kit/Error.jsx`: desaturated brand row, hero block (eyebrow dot + uppercased label, display headline, factual sub-line, optional mono stack trace), and a primary button pinned to the bottom of scroll content.
- Idle state shows "Retry connection"; retrying state shows "Cancel attempt" with a small `ActivityIndicator` + "Contacting…" status line above the button.
- Props: `eyebrow`, `title`, `sub`, `stack?`, `state` (`'idle' | 'retrying'`), `onRetry`.
- The mock's two radial `danger-tint` vignettes are intentionally omitted (RN has no radial-gradient primitive; the eyebrow dot + glow carries the "looks wrong" cue).
- 10 behavior tests covering visible text, button labels per state, stack rendering (populated / undefined / empty array), and `onRetry` wiring.

Out of scope here (lands in APP-59): the reachability probe itself and the `_layout.tsx` wiring.