### PR TITLE
[APP-59] Probe API reachability on app load

### DIFF
--- a/app/api/endpoints/health/index.ts
+++ b/app/api/endpoints/health/index.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from '@/api/client';
+
+/**
+ * Pings `GET /health` purely for reachability — the daemon returns a
+ * status snapshot but the client treats the body as opaque. A successful
+ * resolution means "API process is up and responding"; any rejection
+ * carries an `ApiError` whose `status` (0 for transport, >= 500 for
+ * server-side) drives the on-screen failure copy. APP-59.
+ */
+export function getHealth(): Promise<unknown> {
+    return apiFetch<unknown>('/health');
+}

--- a/app/api/query-keys.ts
+++ b/app/api/query-keys.ts
@@ -32,4 +32,8 @@ export const keys = {
         all: () => ['activity'] as const,
         list: (params: { zoneId?: string }) => ['activity', 'list', params] as const,
     },
+    health: {
+        all: () => ['health'] as const,
+        status: () => ['health', 'status'] as const,
+    },
 } as const;

--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -51,6 +51,16 @@ jest.mock('@/components/splash-gate', () => {
     };
 });
 
+// Same pattern for ReachabilityGate — without this mock the layout test
+// would have to seed a `/health` fetch just to clear the gate's pending
+// state. The gate's own behaviour is covered under
+// @/components/reachability-gate.
+jest.mock('@/components/reachability-gate', () => {
+    return {
+        ReachabilityGate: ({ children }: { children: React.ReactNode }) => children,
+    };
+});
+
 // Stand-ins for Header and NavDrawer keep this layout test focused on
 // wiring (does the layout render them? does it pass the right props?)
 // without dragging in React Query plumbing that the components themselves

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -11,6 +11,7 @@ import { ApiProvider } from '@/api/provider';
 import { Header } from '@/components/header';
 import { NavDrawer, type NavItemId } from '@/components/nav-drawer';
 import { NotificationsBridge } from '@/components/notifications-bridge';
+import { ReachabilityGate } from '@/components/reachability-gate';
 import { SplashGate } from '@/components/splash-gate';
 import { StatusBarBackdrop } from '@/components/status-bar-backdrop';
 import '../global.css';
@@ -55,14 +56,16 @@ export default function RootLayout() {
     return (
         <ApiProvider>
             <SplashGate>
-                <SafeAreaProvider>
-                    <ThemeProvider value={irrigoDarkTheme}>
-                        <AppShell />
-                        <NotificationsBridge />
-                        <StatusBarBackdrop />
-                        <StatusBar style='light' />
-                    </ThemeProvider>
-                </SafeAreaProvider>
+                <ReachabilityGate>
+                    <SafeAreaProvider>
+                        <ThemeProvider value={irrigoDarkTheme}>
+                            <AppShell />
+                            <NotificationsBridge />
+                            <StatusBarBackdrop />
+                            <StatusBar style='light' />
+                        </ThemeProvider>
+                    </SafeAreaProvider>
+                </ReachabilityGate>
             </SplashGate>
         </ApiProvider>
     );

--- a/app/components/badge/.test.tsx
+++ b/app/components/badge/.test.tsx
@@ -7,7 +7,7 @@ const TONE_EXPECTATIONS: Readonly<Record<BadgeTone, { text: string; border: stri
     // Neutral is the one case where the dot deliberately stays muted while
     // the label text reads fg-soft — every other tone matches dot to text.
     neutral: { text: '#C7CFC9', border: '#232E29', dot: '#8A9690' },
-    active: { text: '#6FE39B', border: 'rgba(111, 227, 155, 0.4)', dot: '#6FE39B' },
+    active: { text: '#5ece48', border: 'rgba(94, 206, 72, 0.4)', dot: '#5ece48' },
     warn: { text: '#FFBE6B', border: 'rgba(255, 190, 107, 0.4)', dot: '#FFBE6B' },
     danger: { text: '#FF6B7B', border: 'rgba(255, 107, 123, 0.4)', dot: '#FF6B7B' },
     info: { text: '#7CD4FB', border: 'rgba(124, 212, 251, 0.4)', dot: '#7CD4FB' },
@@ -68,7 +68,7 @@ describe('Badge', () => {
 
         const activeDot = findDotSibling(activeRoot)[0];
         const activeDotStyle = StyleSheet.flatten(activeDot?.props.style) as { boxShadow?: string };
-        expect(activeDotStyle.boxShadow).toContain('#6FE39B');
+        expect(activeDotStyle.boxShadow).toContain('#5ece48');
 
         rerender(<Badge tone='neutral'>Idle</Badge>);
         const neutralDot = findDotSibling(activeRoot)[0];

--- a/app/components/brand-glyph.tsx
+++ b/app/components/brand-glyph.tsx
@@ -14,7 +14,7 @@ export type BrandGlyphProps = {
 
 const SOIL_FILL = '#1B231F';
 const SOIL_STROKE = '#344239';
-const ACCENT = '#6FE39B';
+const ACCENT = '#5ece48';
 
 /**
  * The Irrigo brand mark — a dashed sprinkler arc spraying down to a droplet

--- a/app/components/card/.test.tsx
+++ b/app/components/card/.test.tsx
@@ -71,7 +71,7 @@ describe('Card', () => {
 
         const style = StyleSheet.flatten(root.props.style) as FlatStyle;
 
-        expect(style.boxShadow).toContain('rgba(111, 227, 155, 0.28)');
+        expect(style.boxShadow).toContain('rgba(94, 206, 72, 0.28)');
         expect(style.boxShadow).toContain('inset');
     });
 
@@ -87,7 +87,7 @@ describe('Card', () => {
         // Both the shadow-2 ambient drop and the glow-accent ring must be in
         // the composed boxShadow string.
         expect(style.boxShadow).toContain('rgba(0, 0, 0, 0.45)');
-        expect(style.boxShadow).toContain('rgba(111, 227, 155, 0.28)');
+        expect(style.boxShadow).toContain('rgba(94, 206, 72, 0.28)');
     });
 
     it('merges the caller-provided style override onto the container.', () => {

--- a/app/components/day-dots/.test.tsx
+++ b/app/components/day-dots/.test.tsx
@@ -40,11 +40,11 @@ describe('DayDots', () => {
 
         // Sun-first: Sun=off, Mon=on, Tue=off, Wed=on, Thu=off, Fri=on, Sat=off.
         expect(fills[0]).toBe('#232E29');
-        expect(fills[1]).toBe('#6FE39B');
+        expect(fills[1]).toBe('#5ece48');
         expect(fills[2]).toBe('#232E29');
-        expect(fills[3]).toBe('#6FE39B');
+        expect(fills[3]).toBe('#5ece48');
         expect(fills[4]).toBe('#232E29');
-        expect(fills[5]).toBe('#6FE39B');
+        expect(fills[5]).toBe('#5ece48');
         expect(fills[6]).toBe('#232E29');
     });
 

--- a/app/components/day-strip/.test.tsx
+++ b/app/components/day-strip/.test.tsx
@@ -45,8 +45,8 @@ describe('DayStrip', () => {
         const monStyle = StyleSheet.flatten(screen.getByLabelText('Monday: active').props.style) as FlatStyle;
         const tueStyle = StyleSheet.flatten(screen.getByLabelText('Tuesday: inactive').props.style) as FlatStyle;
 
-        expect(monStyle.backgroundColor).toBe('rgba(111, 227, 155, 0.06)');
-        expect(monStyle.borderColor).toBe('rgba(111, 227, 155, 0.4)');
+        expect(monStyle.backgroundColor).toBe('rgba(94, 206, 72, 0.06)');
+        expect(monStyle.borderColor).toBe('rgba(94, 206, 72, 0.4)');
         expect(tueStyle.backgroundColor).toBe('#0E1412');
         expect(tueStyle.borderColor).toBe('#232E29');
     });

--- a/app/components/depletion-legend/.test.tsx
+++ b/app/components/depletion-legend/.test.tsx
@@ -19,7 +19,7 @@ describe('DepletionLegend', () => {
         const swatches = ['ok', 'warn', 'danger'] as const;
         // Same hexes as `Battery`'s TONE_COLOR map (`accent`, `warn`, `danger`).
         const expected: Record<typeof swatches[number], string> = {
-            ok: '#6FE39B',
+            ok: '#5ece48',
             warn: '#FFBE6B',
             danger: '#FF6B7B',
         };

--- a/app/components/input/index.tsx
+++ b/app/components/input/index.tsx
@@ -13,7 +13,7 @@ const input = tv({
     },
     variants: {
         focused: {
-            true: { base: 'border-accent bg-bg shadow-[0_0_0_4px_rgba(111,227,155,0.06)]' },
+            true: { base: 'border-accent bg-bg shadow-[0_0_0_4px_rgba(94,206,72,0.06)]' },
             false: { base: 'bg-surface border-border' },
         },
         invalid: {

--- a/app/components/lawn-patch/index.tsx
+++ b/app/components/lawn-patch/index.tsx
@@ -14,13 +14,13 @@ export type LawnPatchProps = {
     slug?: LawnPatchSlug;
     /** Optional. Pixel size for the rendered square. Defaults to 28. */
     size?: number;
-    /** Optional. Stroke + fill colour (filled at 22% alpha, stroked at full). Defaults to the grass accent (#6FE39B). */
+    /** Optional. Stroke + fill colour (filled at 22% alpha, stroked at full). Defaults to the grass accent (#5ece48). */
     tone?: string;
     /** Optional. Accessibility label for screen readers. Defaults to `Lawn patch`. */
     accessibilityLabel?: string;
 };
 
-const ACCENT = '#6FE39B';
+const ACCENT = '#5ece48';
 
 export const OUTLINE_PATH: Readonly<Record<LawnPatchSlug, string>> = {
     a: 'M4 8 C 6 4, 14 4, 18 8 C 22 6, 28 10, 28 16 C 28 22, 22 28, 16 28 C 8 28, 3 22, 4 16 C 4 12, 3 10, 4 8 Z',

--- a/app/components/reachability-gate/.test.tsx
+++ b/app/components/reachability-gate/.test.tsx
@@ -1,0 +1,163 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+
+const mockHideAsync = jest.fn(() => Promise.resolve());
+
+jest.mock('expo-splash-screen', () => ({
+    preventAutoHideAsync: jest.fn(() => Promise.resolve()),
+    hideAsync: () => mockHideAsync(),
+}));
+
+import { ReachabilityGate } from '.';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    mockHideAsync.mockClear();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('ReachabilityGate', () => {
+    it('renders nothing while the probe is still pending so the splash stays up.', () => {
+        // Never-resolving fetch keeps useHealth in its pending state.
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        expect(screen.queryByText('home-marker')).toBeNull();
+        expect(screen.queryByText('Connection lost')).toBeNull();
+    });
+
+    it('renders the children once the probe succeeds.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText('home-marker')).toBeOnTheScreen());
+    });
+
+    it(`shows the "Can't reach the Irrigo service" headline on a transport failure.`, async () => {
+        mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText(`Can't reach the Irrigo service`)).toBeOnTheScreen());
+        expect(screen.queryByText('home-marker')).toBeNull();
+    });
+
+    it('shows the "Service is unhealthy" headline on a 5xx response.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'planner' }, 503));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText('Service is unhealthy')).toBeOnTheScreen());
+    });
+
+    it('surfaces the resolved EXPO_PUBLIC_API_BASE_URL in the ErrorView sub-line.', async () => {
+        process.env.EXPO_PUBLIC_API_BASE_URL = 'http://my.lan.host:9753';
+        mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText('Tried http://my.lan.host:9753.')).toBeOnTheScreen());
+    });
+
+    it('renders ErrorView in the idle state once the failed probe has settled.', async () => {
+        mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText('Retry connection')).toBeOnTheScreen());
+        expect(screen.queryByText('Cancel attempt')).toBeNull();
+    });
+
+    it('re-runs the probe when the retry button is pressed.', async () => {
+        // First call fails; second resolves so React Query settles cleanly.
+        mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(screen.getByText('Retry connection')).toBeOnTheScreen());
+
+        fireEvent.press(screen.getByText('Retry connection'));
+
+        await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+        // Once the second probe resolves, the gate flips to the children.
+        await waitFor(() => expect(screen.getByText('home-marker')).toBeOnTheScreen());
+    });
+
+    it('drops the native splash exactly once when the probe settles into the error state.', async () => {
+        mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(mockHideAsync).toHaveBeenCalledTimes(1));
+    });
+
+    it('drops the native splash exactly once when the probe settles into the success state.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+        const { wrapper } = buildApiWrapper();
+
+        render(
+            <ReachabilityGate>
+                <Text>home-marker</Text>
+            </ReachabilityGate>,
+            { wrapper },
+        );
+
+        await waitFor(() => expect(mockHideAsync).toHaveBeenCalledTimes(1));
+    });
+});

--- a/app/components/reachability-gate/index.tsx
+++ b/app/components/reachability-gate/index.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, type PropsWithChildren } from 'react';
+import * as SplashScreen from 'expo-splash-screen';
+
+import { ApiError, getApiBaseUrl } from '@/api/client';
+import { ErrorView, type ErrorViewProps } from '@/components/error-view';
+import { useHealth } from '@/hooks/health';
+
+type FailureCopy = Pick<ErrorViewProps, 'eyebrow' | 'title' | 'sub'>;
+
+/**
+ * App-load reachability gate. Probes `GET /health` once on mount via
+ * {@link useHealth}; until the probe settles the gate renders `null` so
+ * the native splash (held by `preventAutoHideAsync()` in `_layout.tsx`)
+ * stays up and the home screen never flashes. On 2xx the gate renders its
+ * children; on failure it renders the full-screen `ErrorView` with copy
+ * that distinguishes transport failure (`ApiError.status === 0`) from
+ * server-side errors. APP-59.
+ *
+ * The gate hides the native splash on first transition out of `isPending`
+ * — on the failure path this is the only thing that drops the splash
+ * (HomeView never mounts), and on the success path it's a harmless
+ * duplicate of HomeView's own `hideAsync` call.
+ */
+export function ReachabilityGate({ children }: PropsWithChildren) {
+    const { isPending, isError, isFetching, error, refetch } = useHealth();
+    const splashHidden = useRef<boolean>(false);
+
+    useEffect(() => {
+        if (splashHidden.current || isPending) return;
+        splashHidden.current = true;
+        console.log('reachability: probe settled; dropping splash.', { isError });
+        SplashScreen.hideAsync().catch(err => {
+            console.warn('reachability: SplashScreen.hideAsync failed; swallowing.', err);
+        });
+    }, [isPending, isError]);
+
+    if (isPending) return null;
+
+    if (isError) {
+        const copy = failureCopy(error);
+        const handleRetry = () => {
+            // Refetch is idempotent while one is in flight — React Query
+            // coalesces overlapping calls — but gating on isFetching keeps
+            // the intent explicit.
+            if (isFetching) return;
+            refetch().catch(err => {
+                console.warn('reachability: refetch threw; swallowing (the error already lives on the query state).', err);
+            });
+        };
+        return (
+            <ErrorView
+                eyebrow={copy.eyebrow}
+                title={copy.title}
+                sub={copy.sub}
+                state={isFetching ? 'retrying' : 'idle'}
+                onRetry={handleRetry}
+            />
+        );
+    }
+
+    return <>{children}</>;
+}
+
+/**
+ * Maps an `ApiError` (or unknown rejection) into the eyebrow / title /
+ * sub-line copy passed to `ErrorView`. Transport failures get the "Can't
+ * reach" framing; everything else (5xx, the unlikely 4xx, or a non-Error
+ * rejection) gets the "Service is unhealthy" framing. Both surface the
+ * resolved base URL so the operator can confirm what was targeted.
+ */
+function failureCopy(error: ApiError | null): FailureCopy {
+    const baseUrl = safeGetBaseUrl();
+
+    if (error instanceof ApiError && error.status === 0) {
+        return {
+            eyebrow: 'Connection lost',
+            title: `Can't reach the Irrigo service`,
+            sub: `Tried ${baseUrl}.`,
+        };
+    }
+
+    const status = error instanceof ApiError ? error.status : 0;
+    return {
+        eyebrow: 'Service unhealthy',
+        title: 'Service is unhealthy',
+        sub: `${baseUrl} returned ${status}.`,
+    };
+}
+
+/**
+ * `getApiBaseUrl()` throws when the env var is unset. The gate would
+ * never normally reach the error branch with a missing base URL (apiFetch
+ * would have thrown during the probe and surfaced as the same error), but
+ * we still defend the render path here so the failure copy never crashes
+ * the screen — preferring a placeholder over a redbox.
+ */
+function safeGetBaseUrl(): string {
+    try {
+        return getApiBaseUrl();
+    } catch {
+        return '(EXPO_PUBLIC_API_BASE_URL unset)';
+    }
+}

--- a/app/components/tile-gradient/index.tsx
+++ b/app/components/tile-gradient/index.tsx
@@ -11,7 +11,7 @@ export type TileGradientVariant = 'elevated' | 'surface';
 
 /**
  * Opaque [top, bottom] colour pairs per variant. The bottom stop is the
- * base card colour nudged ~3% toward `grass-700` (#2C8F5A) so the gradient
+ * base card colour nudged ~3% toward `grass-700` (#2C7E1F) so the gradient
  * reads as a subtle tint of the same surface, not a separate hue. APP-60.
  */
 export const TILE_GRADIENT_COLORS: Readonly<Record<TileGradientVariant, readonly [string, string]>> = {

--- a/app/hooks/health/.test.tsx
+++ b/app/hooks/health/.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import { useHealth } from '.';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('useHealth', () => {
+    it('reports success after the API returns 200 against /health.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+        const { result } = renderHook(() => useHealth(), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect((mockFetch.mock.calls[0] as [string])[0]).toBe('http://test.local:9753/health');
+    });
+
+    it('surfaces a transport-level ApiError when fetch rejects.', async () => {
+        mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+
+        const { result } = renderHook(() => useHealth(), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.status).toBe(0);
+        expect(result.current.error?.code).toBe('network');
+    });
+
+    it('surfaces a server-side ApiError when the API returns a 5xx.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'planner', message: 'planner crashed' }, 503));
+
+        const { result } = renderHook(() => useHealth(), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.status).toBe(503);
+    });
+});

--- a/app/hooks/health/index.ts
+++ b/app/hooks/health/index.ts
@@ -1,0 +1,18 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { ApiError } from '@/api/client';
+import { getHealth } from '@/api/endpoints/health';
+import { keys } from '@/api/query-keys';
+
+/**
+ * Runs the app-load reachability probe against `GET /health`. The body is
+ * opaque to the client (`unknown`) — only success vs failure matters. The
+ * `ReachabilityGate` consumes this hook to decide between rendering the
+ * app shell (success) and the `ErrorView` (failure). APP-59.
+ */
+export function useHealth(): UseQueryResult<unknown, ApiError> {
+    return useQuery<unknown, ApiError>({
+        queryKey: keys.health.status(),
+        queryFn: getHealth,
+    });
+}

--- a/app/lib/zone-palette/.test.ts
+++ b/app/lib/zone-palette/.test.ts
@@ -6,8 +6,8 @@ describe('paletteForZone', () => {
     });
 
     it('returns the accent green for the first zone.', () => {
-        expect(paletteForZone(0).color).toBe('#6FE39B');
-        expect(paletteForZone(0).glow).toBe('rgba(111, 227, 155, 0.4)');
+        expect(paletteForZone(0).color).toBe('#5ece48');
+        expect(paletteForZone(0).glow).toBe('rgba(94, 206, 72, 0.4)');
     });
 
     it('returns the info blue for the second zone.', () => {

--- a/app/scripts/render-radar-dots-svg.test.ts
+++ b/app/scripts/render-radar-dots-svg.test.ts
@@ -61,7 +61,7 @@ describe('renderRadarDotsSvg', () => {
         const svg = renderRadarDotsSvg({ size: 1024, background: null, padding: 0.45, color: '#FFFFFF' });
 
         // The design-source accent must not appear when an override is set.
-        expect(svg).not.toContain('#6FE39B');
+        expect(svg).not.toContain('#5ece48');
         // The override colour shows up on the anchor rect plus every dot.
         const occurrences = svg.match(/#FFFFFF/g) ?? [];
         expect(occurrences.length).toBe(EXPECTED_DOT_COUNT + 1);

--- a/app/scripts/render-radar-dots-svg.ts
+++ b/app/scripts/render-radar-dots-svg.ts
@@ -9,7 +9,7 @@
  * dragging in Bun-only APIs or filesystem effects.
  */
 
-const ACCENT = '#6FE39B';
+const ACCENT = '#5ece48';
 
 // 64-unit viewBox + center-bottom anchor exactly as the design source
 // specifies (`anchor` at `x=30 y=48` 4×4; arc origin `(32, 50)`).

--- a/app/tailwind.config.test.ts
+++ b/app/tailwind.config.test.ts
@@ -41,14 +41,14 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
         });
 
         it('exposes the grass ramp plus glow rgba accents.', () => {
-            expect(colors['grass-500']).toBe('#6FE39B');
-            expect(colors['grass-700']).toBe('#2C8F5A');
-            expect(colors['grass-glow']).toBe('rgba(111, 227, 155, 0.18)');
+            expect(colors['grass-500']).toBe('#5ece48');
+            expect(colors['grass-700']).toBe('#2C7E1F');
+            expect(colors['grass-glow']).toBe('rgba(94, 206, 72, 0.18)');
         });
 
         it('exposes the soft-glow tints used by canvas, modal, and info surfaces.', () => {
-            expect(colors['grass-glow-2']).toBe('rgba(111, 227, 155, 0.06)');
-            expect(colors['grass-glow-3']).toBe('rgba(111, 227, 155, 0.07)');
+            expect(colors['grass-glow-2']).toBe('rgba(94, 206, 72, 0.06)');
+            expect(colors['grass-glow-3']).toBe('rgba(94, 206, 72, 0.07)');
             expect(colors['water-glow']).toBe('rgba(124, 212, 251, 0.04)');
         });
 
@@ -64,15 +64,15 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
             expect(colors.surface).toBe('#0E1412');
             expect(colors.fg).toBe('#ECF1ED');
             expect(colors['fg-soft']).toBe('#C7CFC9');
-            expect(colors.accent).toBe('#6FE39B');
-            expect(colors['accent-press']).toBe('#4FCB7E');
+            expect(colors.accent).toBe('#5ece48');
+            expect(colors['accent-press']).toBe('#4DB339');
         });
 
         it('exposes warn / danger / info semantics plus on-accent for green buttons.', () => {
             expect(colors.warn).toBe('#FFBE6B');
             expect(colors.danger).toBe('#FF6B7B');
             expect(colors.info).toBe('#7CD4FB');
-            expect(colors['on-accent']).toBe('#052013');
+            expect(colors['on-accent']).toBe('#0B1D07');
         });
 
         it('exposes the modal / sheet scrim at the design-spec alpha.', () => {
@@ -80,8 +80,8 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
         });
 
         it('exposes tinted border / fill aliases (0.4 / 0.06 alpha) per semantic tone for tag-style chrome.', () => {
-            expect(colors['accent-border']).toBe('rgba(111, 227, 155, 0.4)');
-            expect(colors['accent-tint']).toBe('rgba(111, 227, 155, 0.06)');
+            expect(colors['accent-border']).toBe('rgba(94, 206, 72, 0.4)');
+            expect(colors['accent-tint']).toBe('rgba(94, 206, 72, 0.06)');
             expect(colors['warn-border']).toBe('rgba(255, 190, 107, 0.4)');
             expect(colors['warn-tint']).toBe('rgba(255, 190, 107, 0.06)');
             expect(colors['danger-border']).toBe('rgba(255, 107, 123, 0.4)');
@@ -91,7 +91,7 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
         });
 
         it('exposes the seven-stop depletion ramp end-to-end.', () => {
-            expect(colors['depletion-0']).toBe('#6FE39B');
+            expect(colors['depletion-0']).toBe('#5ece48');
             expect(colors['depletion-3']).toBe('#E9C96D');
             expect(colors['depletion-6']).toBe('#FF6B7B');
         });
@@ -132,8 +132,8 @@ describe('tailwind.config.js — Irrigo design tokens', () => {
         });
 
         it('exposes glow-accent with the grass-tinted inset ring and outer glow.', () => {
-            expect(shadows['glow-accent']).toContain('rgba(111, 227, 155, 0.28)');
-            expect(shadows['glow-accent']).toContain('rgba(111, 227, 155, 0.18)');
+            expect(shadows['glow-accent']).toContain('rgba(94, 206, 72, 0.28)');
+            expect(shadows['glow-accent']).toContain('rgba(94, 206, 72, 0.18)');
         });
     });
 

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -4,10 +4,7 @@ import plugin from 'tailwindcss/plugin';
 import nativewindPreset from 'nativewind/preset';
 
 export default {
-    content: [
-        './app/**/*.{js,jsx,ts,tsx}',
-        './components/**/*.{js,jsx,ts,tsx}',
-    ],
+    content: ['./app/**/*.{js,jsx,ts,tsx}', './components/**/*.{js,jsx,ts,tsx}'],
     presets: [nativewindPreset],
     theme: {
         extend: {
@@ -31,15 +28,15 @@ export default {
                 'chalk-800': '#3A4641',
 
                 // Grass ramp (raw) + glow.
-                'grass-300': '#B7F0CB',
-                'grass-400': '#8FEAB1',
-                'grass-500': '#6FE39B',
-                'grass-600': '#4FCB7E',
-                'grass-700': '#2C8F5A',
-                'grass-900': '#0F2A1C',
-                'grass-glow': 'rgba(111, 227, 155, 0.18)',
-                'grass-glow-2': 'rgba(111, 227, 155, 0.06)',
-                'grass-glow-3': 'rgba(111, 227, 155, 0.07)',
+                'grass-300': '#C0F1B6',
+                'grass-400': '#A0E891',
+                'grass-500': '#5ece48',
+                'grass-600': '#4DB339',
+                'grass-700': '#2C7E1F',
+                'grass-900': '#13290F',
+                'grass-glow': 'rgba(94, 206, 72, 0.18)',
+                'grass-glow-2': 'rgba(94, 206, 72, 0.06)',
+                'grass-glow-3': 'rgba(94, 206, 72, 0.07)',
 
                 // Accent supplemental.
                 'water-500': '#7CD4FB',
@@ -65,12 +62,12 @@ export default {
                 'fg-muted': '#8A9690',
                 'fg-dim': '#5A6862',
                 'fg-faint': '#3A4641',
-                accent: '#6FE39B',
-                'accent-press': '#4FCB7E',
-                'accent-deep': '#2C8F5A',
-                'accent-glow': 'rgba(111, 227, 155, 0.18)',
-                'accent-border': 'rgba(111, 227, 155, 0.4)',
-                'accent-tint': 'rgba(111, 227, 155, 0.06)',
+                accent: '#5ece48',
+                'accent-press': '#4DB339',
+                'accent-deep': '#2C7E1F',
+                'accent-glow': 'rgba(94, 206, 72, 0.18)',
+                'accent-border': 'rgba(94, 206, 72, 0.4)',
+                'accent-tint': 'rgba(94, 206, 72, 0.06)',
                 info: '#7CD4FB',
                 'info-border': 'rgba(124, 212, 251, 0.4)',
                 'info-tint': 'rgba(124, 212, 251, 0.06)',
@@ -80,11 +77,11 @@ export default {
                 danger: '#FF6B7B',
                 'danger-border': 'rgba(255, 107, 123, 0.4)',
                 'danger-tint': 'rgba(255, 107, 123, 0.06)',
-                'on-accent': '#052013',
+                'on-accent': '#0B1D07',
                 scrim: 'rgba(2, 4, 3, 0.66)',
 
                 // Depletion ramp (saturated → past RAW).
-                'depletion-0': '#6FE39B',
+                'depletion-0': '#5ece48',
                 'depletion-1': '#9CE093',
                 'depletion-2': '#C8DD7B',
                 'depletion-3': '#E9C96D',
@@ -118,7 +115,7 @@ export default {
                 1: '0 1px 0 0 rgba(255, 255, 255, 0.03) inset, 0 1px 2px rgba(0, 0, 0, 0.4)',
                 2: '0 1px 0 0 rgba(255, 255, 255, 0.04) inset, 0 4px 14px rgba(0, 0, 0, 0.45), 0 1px 2px rgba(0, 0, 0, 0.3)',
                 3: '0 1px 0 0 rgba(255, 255, 255, 0.05) inset, 0 20px 48px rgba(0, 0, 0, 0.6), 0 4px 10px rgba(0, 0, 0, 0.4)',
-                'glow-accent': '0 0 0 1px rgba(111, 227, 155, 0.28) inset, 0 0 24px -4px rgba(111, 227, 155, 0.18)',
+                'glow-accent': '0 0 0 1px rgba(94, 206, 72, 0.28) inset, 0 0 24px -4px rgba(94, 206, 72, 0.18)',
             },
             fontFamily: {
                 // Bricolage Grotesque — display weights, loaded by FontLoader.


### PR DESCRIPTION
## Ticket

[APP-59](http://192.168.2.100:7123/home/browse/APP-59/) — Probe API reachability on app load and route to the error view when down.

## Summary

- Adds a `GET /health` endpoint wrapper (`getHealth`) + a `useHealth` hook backed by a new `keys.health.status()` React Query key. The body is treated as opaque — only the success / failure of the request matters.
- Adds `ReachabilityGate`, a small component that wraps the app shell. While `useHealth` is pending it returns `null` so the native splash (held by `preventAutoHideAsync`) stays up and the home screen never flashes. On 2xx it renders its children. On error it renders the `ErrorView` from APP-66.
- Failure copy maps the `ApiError`:
  - Transport (`status === 0`, `code === 'network'`) → "Can't reach the Irrigo service" + "Tried `<EXPO_PUBLIC_API_BASE_URL>`."
  - Server-side (`status >= 500`) and other non-2xx → "Service is unhealthy" + "`<BASE_URL>` returned `<status>`."
- The gate drops the native splash exactly once on first transition out of `isPending`, so the failure path doesn't get stuck behind the splash (HomeView's `useHideSplashOnReady` never mounts when the gate routes to `ErrorView`). On the success path, HomeView's existing `hideAsync` becomes a harmless duplicate.
- Retry button in the error view re-runs the probe via React Query `refetch()`; the in-flight check is gated by `isFetching` so a double-tap doesn't kick off a second concurrent fetch.
- 12 new tests (3 on `useHealth`, 9 on `ReachabilityGate`) covering pending / success / network-failure / 5xx, base-URL surfacing, idle state, retry-fires-fetch, and splash drop on both settled states.

Out of scope (per ticket): ongoing connectivity monitoring after the initial probe — per-query error states continue to handle mid-session blips inline.