### PR TITLE
[API-79] Two-tick depletion reconciliation from HA + observed weather

### DIFF
--- a/api/alerts/index.ts
+++ b/api/alerts/index.ts
@@ -5,11 +5,10 @@ import type { Notifier } from '@/notifications';
 
 /**
  * Operator-facing failure classes recorded by the daemon. The set is closed:
- * the schema has a `check (class in ('weather-stale', 'ha-call-failed',
- * 'missed-close'))` constraint, so widening the union requires both a code
- * change here and a new migration.
+ * the schema has a `check` constraint on `alerts.class`, so widening the
+ * union requires both a code change here and a new migration.
  */
-export type AlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close';
+export type AlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close' | 'actuation-stale';
 
 /**
  * Visual severity used by the mobile app to colour the alert row. `warn`

--- a/api/data/home-assistant/.test.ts
+++ b/api/data/home-assistant/.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { createTestZone } from '@/mock/zone';
-import { closeZone, getZoneState, openZone } from '.';
+import { closeZone, getZoneActuationHistory, getZoneState, openZone, pairOnOffTransitions } from '.';
 import { HttpResponseError, computeBackoffMs, retry } from './retry';
 
 const mockFetch = mock(() => Promise.resolve({} as Response));
@@ -321,6 +321,212 @@ describe('Home Assistant client', () => {
             expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${HA_TOKEN}`);
             expect(init.body).toBeUndefined();
         });
+    });
+
+    describe('getZoneActuationHistory', () => {
+        const SINCE = new Date('2026-05-24T04:00:00.000Z');
+        const UNTIL = new Date('2026-05-24T08:00:00.000Z');
+
+        const historyResponse = (entries: ReadonlyArray<{ state: string; last_changed: string }>) => ({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => [entries],
+        }) as unknown as Response;
+
+        it('GETs /api/history/period/<since> with filter_entity_id, end_time, and minimal_response', async () => {
+            mockFetch.mockResolvedValueOnce(historyResponse([]));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await getZoneActuationHistory(zone, SINCE, UNTIL);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            const [calledUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+            const parsed = new URL(calledUrl);
+            expect(parsed.pathname).toBe(`/api/history/period/${SINCE.toISOString()}`);
+            expect(parsed.searchParams.get('filter_entity_id')).toBe(ENTITY_ID);
+            expect(parsed.searchParams.get('end_time')).toBe(UNTIL.toISOString());
+            expect(parsed.searchParams.has('minimal_response')).toBe(true);
+            expect(init.method).toBe('GET');
+            expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${HA_TOKEN}`);
+        });
+
+        it('returns an empty array when zone has no homeAssistantEntityId and does not call fetch', async () => {
+            const zone = createTestZone({ homeAssistantEntityId: undefined });
+
+            const result = await getZoneActuationHistory(zone, SINCE, UNTIL);
+
+            expect(result).toEqual([]);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it('returns an empty array on 404 (entity unknown to HA) without throwing', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: 'Not Found',
+            } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const result = await getZoneActuationHistory(zone, SINCE, UNTIL);
+
+            expect(result).toEqual([]);
+        });
+
+        it('throws after retry exhaustion on persistent 5xx', async () => {
+            mockFetch.mockResolvedValue({
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable',
+            } as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            await expect(getZoneActuationHistory(zone, SINCE, UNTIL))
+                .rejects.toThrow(/history_period on switch\.sonoff_4chpro_relay_1 failed: 503/);
+        });
+
+        it('parses a clean on→off pair from the HA response', async () => {
+            mockFetch.mockResolvedValueOnce(historyResponse([
+                { state: 'on', last_changed: '2026-05-24T04:30:00.000Z' },
+                { state: 'off', last_changed: '2026-05-24T04:45:00.000Z' },
+            ]));
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const result = await getZoneActuationHistory(zone, SINCE, UNTIL);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T04:30:00.000Z');
+            expect(result[0]?.offAt.toISOString()).toBe('2026-05-24T04:45:00.000Z');
+        });
+
+        it('drops malformed rows (missing state or last_changed)', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                json: async () => [[
+                    { state: 'on', last_changed: '2026-05-24T04:30:00.000Z' },
+                    { last_changed: '2026-05-24T04:35:00.000Z' }, // missing state
+                    { state: 'off' }, // missing last_changed
+                    { state: 'off', last_changed: '2026-05-24T04:45:00.000Z' },
+                ]],
+            } as unknown as Response);
+            const zone = createTestZone({ homeAssistantEntityId: ENTITY_ID });
+
+            const result = await getZoneActuationHistory(zone, SINCE, UNTIL);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T04:30:00.000Z');
+            expect(result[0]?.offAt.toISOString()).toBe('2026-05-24T04:45:00.000Z');
+        });
+    });
+});
+
+describe('pairOnOffTransitions', () => {
+    const WINDOW_START = new Date('2026-05-24T04:00:00.000Z');
+    const WINDOW_END = new Date('2026-05-24T08:00:00.000Z');
+
+    it('returns an empty array for empty input', () => {
+        const result = pairOnOffTransitions([], WINDOW_START, WINDOW_END);
+        expect(result).toEqual([]);
+    });
+
+    it('pairs clean on→off transitions', () => {
+        const states = [
+            { state: 'on', lastChanged: new Date('2026-05-24T04:30:00.000Z') },
+            { state: 'off', lastChanged: new Date('2026-05-24T04:45:00.000Z') },
+            { state: 'on', lastChanged: new Date('2026-05-24T05:30:00.000Z') },
+            { state: 'off', lastChanged: new Date('2026-05-24T05:45:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T04:30:00.000Z');
+        expect(result[0]?.offAt.toISOString()).toBe('2026-05-24T04:45:00.000Z');
+        expect(result[1]?.onAt.toISOString()).toBe('2026-05-24T05:30:00.000Z');
+        expect(result[1]?.offAt.toISOString()).toBe('2026-05-24T05:45:00.000Z');
+    });
+
+    it('filters unavailable, unknown, and other non-binary states', () => {
+        const states = [
+            { state: 'on', lastChanged: new Date('2026-05-24T04:30:00.000Z') },
+            { state: 'unavailable', lastChanged: new Date('2026-05-24T04:35:00.000Z') },
+            { state: 'on', lastChanged: new Date('2026-05-24T04:40:00.000Z') },
+            { state: 'off', lastChanged: new Date('2026-05-24T04:45:00.000Z') },
+            { state: 'unknown', lastChanged: new Date('2026-05-24T04:46:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        // unavailable/unknown filtered; consecutive `on` rows deduped to the first.
+        expect(result).toHaveLength(1);
+        expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T04:30:00.000Z');
+        expect(result[0]?.offAt.toISOString()).toBe('2026-05-24T04:45:00.000Z');
+    });
+
+    it('closes a trailing on with no following off at windowEnd', () => {
+        const states = [
+            { state: 'on', lastChanged: new Date('2026-05-24T07:30:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T07:30:00.000Z');
+        expect(result[0]?.offAt).toEqual(WINDOW_END);
+    });
+
+    it('clamps a leading on whose lastChanged predates windowStart', () => {
+        const states = [
+            // Entity went on before the window started; HA returns the prior
+            // transition as the first row.
+            { state: 'on', lastChanged: new Date('2026-05-24T03:55:00.000Z') },
+            { state: 'off', lastChanged: new Date('2026-05-24T04:30:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.onAt).toEqual(WINDOW_START);
+        expect(result[0]?.offAt.toISOString()).toBe('2026-05-24T04:30:00.000Z');
+    });
+
+    it('clamps an off whose lastChanged exceeds windowEnd', () => {
+        const states = [
+            { state: 'on', lastChanged: new Date('2026-05-24T07:30:00.000Z') },
+            { state: 'off', lastChanged: new Date('2026-05-24T09:00:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T07:30:00.000Z');
+        expect(result[0]?.offAt).toEqual(WINDOW_END);
+    });
+
+    it('ignores a leading off with no preceding on (entity was off when window opened)', () => {
+        const states = [
+            { state: 'off', lastChanged: new Date('2026-05-24T04:30:00.000Z') },
+            { state: 'on', lastChanged: new Date('2026-05-24T05:00:00.000Z') },
+            { state: 'off', lastChanged: new Date('2026-05-24T05:15:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.onAt.toISOString()).toBe('2026-05-24T05:00:00.000Z');
+        expect(result[0]?.offAt.toISOString()).toBe('2026-05-24T05:15:00.000Z');
+    });
+
+    it('returns no pairs when the entity is off throughout the window', () => {
+        const states = [
+            { state: 'off', lastChanged: new Date('2026-05-24T03:30:00.000Z') },
+        ];
+
+        const result = pairOnOffTransitions(states, WINDOW_START, WINDOW_END);
+
+        expect(result).toEqual([]);
     });
 });
 

--- a/api/data/home-assistant/index.ts
+++ b/api/data/home-assistant/index.ts
@@ -86,6 +86,156 @@ export async function getZoneState(zone: Zone): Promise<ZoneRelayState> {
     );
 }
 
+/**
+ * One `[onAt, offAt]` interval reconstructed from HA history. `onAt` is the
+ * moment the relay went `on` (clamped to `windowStart` if the on-transition
+ * predates the window). `offAt` is the moment the relay went `off` (clamped
+ * to `windowEnd` if the relay is still on at the window's end). The morning
+ * reconciler sums `(offAt − onAt)` across these pairs and multiplies by the
+ * zone's precipitation rate to compute applied depth.
+ */
+export type ZoneActuationInterval = {
+    onAt: Date;
+    offAt: Date;
+};
+
+type HistoryStateRecord = {
+    state: string;
+    lastChanged: Date;
+};
+
+/**
+ * Reads the zone's HA switch history over `[since, until)` and returns the
+ * set of on→off intervals during which the relay was actually energized.
+ * Throws if the HA env vars are missing or the history endpoint returns a
+ * 5xx after retry exhaustion; 404 (entity unknown to HA) returns `[]`. The
+ * caller is responsible for fallback behavior on failure.
+ *
+ * @param zone - Zone whose actuation history should be queried.
+ * @param since - Inclusive window start; on-transitions before this are clamped to `since`.
+ * @param until - Exclusive window end; relays still on at this instant are paired with `until`.
+ * @returns Clean on→off intervals, sorted by `onAt`.
+ * @throws Error when configuration is missing or HA returns a non-2xx response after retries.
+ */
+export async function getZoneActuationHistory(
+    zone: Zone,
+    since: Date,
+    until: Date,
+): Promise<ZoneActuationInterval[]> {
+    if (!zone.homeAssistantEntityId) {
+        console.warn(`home-assistant: zone ${zone.id} (${zone.name}) has no homeAssistantEntityId; returning empty actuation history.`);
+        return [];
+    }
+
+    const { url, token } = readConfig();
+    const entityId = zone.homeAssistantEntityId;
+    const endpoint = buildHistoryUrl(url, entityId, since, until);
+
+    console.log(`home-assistant: reading actuation history for zone ${zone.id} (${zone.name}) via ${entityId} from ${since.toISOString()} to ${until.toISOString()}.`);
+
+    const retryConfig = readRetryConfig();
+    const states = await retry(
+        () => sendHistoryRequest(endpoint, token, entityId),
+        {
+            maxAttempts: retryConfig.maxAttempts,
+            baseMs: retryConfig.baseMs,
+            operation: 'history_period',
+            entityId,
+        },
+    );
+
+    return pairOnOffTransitions(states, since, until);
+}
+
+/**
+ * Pure helper. Walks a chronological list of HA state changes and emits the
+ * `on→off` intervals during which the entity was energized within the window
+ * `[windowStart, windowEnd]`.
+ *
+ * - `unavailable`, `unknown`, and any non-`on`/`off` state are filtered out.
+ * - Consecutive same-state rows are deduped (subsequent `on`s after an `on`
+ *   are no-ops; same for `off`s).
+ * - An `on` row whose `lastChanged` precedes `windowStart` is clamped to
+ *   `windowStart` (the entity was already on when the window opened).
+ * - An `off` row whose `lastChanged` exceeds `windowEnd` is clamped to
+ *   `windowEnd` (the off transition was outside the window).
+ * - A trailing `on` with no following `off` pairs with `windowEnd`.
+ * - A leading `off` with no preceding `on` is ignored — the entity was off
+ *   when the window opened and had no on period inside it yet.
+ *
+ * Exported for unit-testing without going through `fetch`.
+ */
+export function pairOnOffTransitions(
+    states: ReadonlyArray<HistoryStateRecord>,
+    windowStart: Date,
+    windowEnd: Date,
+): ZoneActuationInterval[] {
+    const filtered = states.filter(s => s.state === 'on' || s.state === 'off');
+    if (filtered.length === 0) return [];
+
+    const deduped: HistoryStateRecord[] = [];
+    for (const s of filtered) {
+        const last = deduped[deduped.length - 1];
+        if (!last || last.state !== s.state) deduped.push(s);
+    }
+
+    const pairs: ZoneActuationInterval[] = [];
+    let pendingOn: Date | null = null;
+    for (const s of deduped) {
+        if (s.state === 'on') {
+            pendingOn = s.lastChanged.getTime() < windowStart.getTime() ? windowStart : s.lastChanged;
+        } else if (pendingOn !== null) {
+            const offAt = s.lastChanged.getTime() > windowEnd.getTime() ? windowEnd : s.lastChanged;
+            pairs.push({ onAt: pendingOn, offAt });
+            pendingOn = null;
+        }
+    }
+
+    if (pendingOn !== null) {
+        pairs.push({ onAt: pendingOn, offAt: windowEnd });
+    }
+
+    return pairs;
+}
+
+async function sendHistoryRequest(endpoint: string, token: string, entityId: string): Promise<HistoryStateRecord[]> {
+    let response: Response;
+    try {
+        response = await fetch(endpoint, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+    } catch (err) {
+        console.error(`home-assistant: fetch failed while reading history for ${entityId}.`, err);
+        throw err;
+    }
+
+    if (response.status === 404) {
+        console.warn(`home-assistant: entity ${entityId} returned 404 from history endpoint; treating as no actuations.`);
+        return [];
+    }
+
+    if (!response.ok) {
+        const message = `home-assistant: history_period on ${entityId} failed: ${response.status} ${response.statusText}`;
+        console.error(message);
+        throw new HttpResponseError(response.status, response.statusText, message);
+    }
+
+    const body = await response.json() as Array<Array<{ state?: unknown; last_changed?: unknown }>>;
+    const rows = body[0] ?? [];
+    const parsed: HistoryStateRecord[] = [];
+    for (const row of rows) {
+        if (typeof row.state !== 'string') continue;
+        if (typeof row.last_changed !== 'string') continue;
+        const lastChanged = new Date(row.last_changed);
+        if (Number.isNaN(lastChanged.getTime())) continue;
+        parsed.push({ state: row.state, lastChanged });
+    }
+    return parsed;
+}
+
 async function sendStateRequest(endpoint: string, token: string, entityId: string): Promise<ZoneRelayState> {
     let response: Response;
     try {
@@ -200,4 +350,13 @@ function buildServiceUrl(baseUrl: string, service: SwitchService): string {
 function buildStateUrl(baseUrl: string, entityId: string): string {
     const trimmed = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
     return `${trimmed}/api/states/${encodeURIComponent(entityId)}`;
+}
+
+function buildHistoryUrl(baseUrl: string, entityId: string, since: Date, until: Date): string {
+    const trimmed = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const url = new URL(`${trimmed}/api/history/period/${since.toISOString()}`);
+    url.searchParams.set('filter_entity_id', entityId);
+    url.searchParams.set('end_time', until.toISOString());
+    url.searchParams.set('minimal_response', '');
+    return url.toString();
 }

--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { __resetWeatherCacheForTests, fetchWithRetry, getWeatherData } from '.';
+import dayjs from 'dayjs';
+import { __resetWeatherCacheForTests, fetchWithRetry, getWeatherData, sumHourlyWeatherBetween } from '.';
+import type { HourlyWeather } from '@/models';
 
 // Production defaults wait 500 ms then 1500 ms between attempts; tests
 // short-circuit both via `minTimeout: 0` so the retry loop runs without
@@ -34,6 +36,11 @@ describe('Weather Data', () => {
             sunset: ['2025-10-20T18:10', '2025-10-21T18:08', '2025-10-22T18:06'],
             rain_sum: [0.2, 0.5, 0.0],
             et0_fao_evapotranspiration: [1.63, 1.62, 1.04],
+        },
+        hourly: {
+            time: ['2025-10-20T00:00', '2025-10-20T01:00', '2025-10-20T02:00'],
+            precipitation: [0.0, 0.1, 0.2],
+            et0_fao_evapotranspiration: [0.02, 0.03, 0.05],
         },
     };
 
@@ -72,7 +79,9 @@ describe('Weather Data', () => {
         expect(calledUrl.searchParams.get('latitude')).toBe('52.52');
         expect(calledUrl.searchParams.get('longitude')).toBe('13.41');
         expect(calledUrl.searchParams.get('forecast_days')).toBe('7');
+        expect(calledUrl.searchParams.get('past_days')).toBe('1');
         expect(calledUrl.searchParams.get('daily')).toBe('sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
+        expect(calledUrl.searchParams.get('hourly')).toBe('precipitation,et0_fao_evapotranspiration');
         expect(calledUrl.searchParams.get('timezone')).toBeNull();
     });
 
@@ -91,40 +100,48 @@ describe('Weather Data', () => {
         expect(calledUrl.searchParams.get('forecast_days')).toBe('7');
     });
 
-    it('should transform API response into DailyWeather array', async () => {
+    it('should transform API response into daily and hourly arrays', async () => {
         mockFetch.mockResolvedValueOnce({
             ok: true,
             json: async () => mockWeatherResponse,
         } as Response);
 
-        const result = await getWeatherData({
+        const { daily, hourly } = await getWeatherData({
             latitude: 52.52,
             longitude: 13.41,
         });
 
-        // Verify array length.
-        expect(result.length).toBe(3);
+        // Verify daily array length.
+        expect(daily.length).toBe(3);
 
         // Verify first day's data.
-        expect(result[0]!.date.format('YYYY-MM-DD')).toBe('2025-10-20');
-        expect(result[0]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T05:41');
-        expect(result[0]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T18:10');
-        expect(result[0]!.rainfallMm).toBe(0.2);
-        expect(result[0]!.evapotranspirationMmPerDay).toBe(1.63);
+        expect(daily[0]!.date.format('YYYY-MM-DD')).toBe('2025-10-20');
+        expect(daily[0]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T05:41');
+        expect(daily[0]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T18:10');
+        expect(daily[0]!.rainfallMm).toBe(0.2);
+        expect(daily[0]!.evapotranspirationMmPerDay).toBe(1.63);
 
         // Verify second day's data.
-        expect(result[1]!.date.format('YYYY-MM-DD')).toBe('2025-10-21');
-        expect(result[1]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-21T05:43');
-        expect(result[1]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-21T18:08');
-        expect(result[1]!.rainfallMm).toBe(0.5);
-        expect(result[1]!.evapotranspirationMmPerDay).toBe(1.62);
+        expect(daily[1]!.date.format('YYYY-MM-DD')).toBe('2025-10-21');
+        expect(daily[1]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-21T05:43');
+        expect(daily[1]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-21T18:08');
+        expect(daily[1]!.rainfallMm).toBe(0.5);
+        expect(daily[1]!.evapotranspirationMmPerDay).toBe(1.62);
 
         // Verify third day's data.
-        expect(result[2]!.date.format('YYYY-MM-DD')).toBe('2025-10-22');
-        expect(result[2]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-22T05:45');
-        expect(result[2]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-22T18:06');
-        expect(result[2]!.rainfallMm).toBe(0.0);
-        expect(result[2]!.evapotranspirationMmPerDay).toBe(1.04);
+        expect(daily[2]!.date.format('YYYY-MM-DD')).toBe('2025-10-22');
+        expect(daily[2]!.sunrise?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-22T05:45');
+        expect(daily[2]!.sunset?.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-22T18:06');
+        expect(daily[2]!.rainfallMm).toBe(0.0);
+        expect(daily[2]!.evapotranspirationMmPerDay).toBe(1.04);
+
+        // Verify hourly array.
+        expect(hourly.length).toBe(3);
+        expect(hourly[0]!.time.format('YYYY-MM-DDTHH:mm')).toBe('2025-10-20T00:00');
+        expect(hourly[0]!.precipitationMm).toBe(0.0);
+        expect(hourly[0]!.evapotranspirationMm).toBe(0.02);
+        expect(hourly[2]!.precipitationMm).toBe(0.2);
+        expect(hourly[2]!.evapotranspirationMm).toBe(0.05);
     });
 
     it('should throw immediately on a 4xx response without retrying', async () => {
@@ -171,7 +188,7 @@ describe('Weather Data', () => {
             json: async () => mockWeatherResponse,
         } as Response);
 
-        const result = await getWeatherData({
+        const { daily } = await getWeatherData({
             latitude: 52.52,
             longitude: 13.41,
             timezone: 'America/Edmonton',
@@ -179,9 +196,9 @@ describe('Weather Data', () => {
 
         // '2025-10-20T05:41' interpreted as 5:41am America/Edmonton (MDT=UTC-6 in Oct).
         // In UTC that's 11:41am. utcOffset() for an America/Edmonton dayjs is -360 (MDT).
-        expect(result[0]!.sunrise).toBeDefined();
+        expect(daily[0]!.sunrise).toBeDefined();
         // Verify the offset matches the specified timezone (MDT = -360 min in Oct 2025).
-        expect(result[0]!.sunrise!.utcOffset()).toBe(-360);
+        expect(daily[0]!.sunrise!.utcOffset()).toBe(-360);
     });
 
     it('should handle empty response arrays', async () => {
@@ -193,6 +210,11 @@ describe('Weather Data', () => {
                 rain_sum: [],
                 et0_fao_evapotranspiration: [],
             },
+            hourly: {
+                time: [],
+                precipitation: [],
+                et0_fao_evapotranspiration: [],
+            },
         };
 
         mockFetch.mockResolvedValueOnce({
@@ -200,12 +222,13 @@ describe('Weather Data', () => {
             json: async () => emptyResponse,
         } as Response);
 
-        const result = await getWeatherData({
+        const { daily, hourly } = await getWeatherData({
             latitude: 52.52,
             longitude: 13.41,
         });
 
-        expect(result.length).toBe(0);
+        expect(daily.length).toBe(0);
+        expect(hourly.length).toBe(0);
     });
 
     it('should throw error when API response is malformed', async () => {
@@ -340,6 +363,11 @@ describe('Weather caching', () => {
             rain_sum: [0, 0],
             et0_fao_evapotranspiration: [4.0, 4.0],
         },
+        hourly: {
+            time: ['2026-05-24T00:00', '2026-05-24T01:00'],
+            precipitation: [0, 0],
+            et0_fao_evapotranspiration: [0.1, 0.1],
+        },
     };
 
     const stubSuccess = () => mockFetch.mockResolvedValueOnce({
@@ -368,7 +396,7 @@ describe('Weather caching', () => {
         const second = await getWeatherData(params, { now: fixedNow });
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(second).toBe(first); // reference-equal — same cached array
+        expect(second).toBe(first); // reference-equal — same cached object
     });
 
     it('refetches after the TTL has expired', async () => {
@@ -386,20 +414,22 @@ describe('Weather caching', () => {
         expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it('keys the cache by (latitude, longitude, forecastDays, timezone) so each variant misses independently', async () => {
+    it('keys the cache by (latitude, longitude, forecastDays, pastDays, timezone) so each variant misses independently', async () => {
+        stubSuccess();
         stubSuccess();
         stubSuccess();
         stubSuccess();
         stubSuccess();
         const fixedNow = () => 1_700_000_000_000;
-        const base = { latitude: 51.0, longitude: -114.0, forecastDays: 7, timezone: 'America/Edmonton' };
+        const base = { latitude: 51.0, longitude: -114.0, forecastDays: 7, pastDays: 1, timezone: 'America/Edmonton' };
 
         await getWeatherData(base, { now: fixedNow });
         await getWeatherData({ ...base, latitude: 51.1 }, { now: fixedNow });
         await getWeatherData({ ...base, forecastDays: 14 }, { now: fixedNow });
+        await getWeatherData({ ...base, pastDays: 2 }, { now: fixedNow });
         await getWeatherData({ ...base, timezone: 'UTC' }, { now: fixedNow });
 
-        expect(mockFetch).toHaveBeenCalledTimes(4);
+        expect(mockFetch).toHaveBeenCalledTimes(5);
     });
 
     it('does not populate the cache when the upstream call fails', async () => {
@@ -518,5 +548,88 @@ describe('fetchWithRetry', () => {
             fetchWithRetry('https://example.test/', { ...FAST_RETRY_OPTS, retries: 1 }),
         ).rejects.toThrow('Open-Meteo API request failed: 500 Internal Server Error');
         expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('sumHourlyWeatherBetween', () => {
+    function mkRow(timeIso: string, precipitationMm: number, evapotranspirationMm: number): HourlyWeather {
+        return { time: dayjs(timeIso), precipitationMm, evapotranspirationMm };
+    }
+
+    it('sums rows whose time falls inside [since, until)', async () => {
+        const rows = [
+            mkRow('2026-05-24T05:00:00Z', 0.1, 0.05),
+            mkRow('2026-05-24T06:00:00Z', 0.2, 0.06),
+            mkRow('2026-05-24T07:00:00Z', 0.3, 0.07),
+        ];
+
+        const result = sumHourlyWeatherBetween(
+            rows,
+            new Date('2026-05-24T05:00:00Z'),
+            new Date('2026-05-24T07:00:00Z'),
+        );
+
+        // The 07:00 row is excluded because `until` is exclusive.
+        expect(result.rainMm).toBeCloseTo(0.3, 6);
+        expect(result.etMm).toBeCloseTo(0.11, 6);
+    });
+
+    it('returns zero when the window is empty (since >= until)', async () => {
+        const rows = [
+            mkRow('2026-05-24T05:00:00Z', 1, 1),
+            mkRow('2026-05-24T06:00:00Z', 1, 1),
+        ];
+
+        const result = sumHourlyWeatherBetween(
+            rows,
+            new Date('2026-05-24T06:00:00Z'),
+            new Date('2026-05-24T06:00:00Z'),
+        );
+
+        expect(result).toEqual({ rainMm: 0, etMm: 0 });
+    });
+
+    it('returns zero when no rows fall in the window', async () => {
+        const rows = [
+            mkRow('2026-05-24T05:00:00Z', 1, 1),
+            mkRow('2026-05-24T06:00:00Z', 1, 1),
+        ];
+
+        const result = sumHourlyWeatherBetween(
+            rows,
+            new Date('2026-05-25T00:00:00Z'),
+            new Date('2026-05-25T03:00:00Z'),
+        );
+
+        expect(result).toEqual({ rainMm: 0, etMm: 0 });
+    });
+
+    it('handles an empty hourly array', async () => {
+        const result = sumHourlyWeatherBetween(
+            [],
+            new Date('2026-05-24T05:00:00Z'),
+            new Date('2026-05-24T07:00:00Z'),
+        );
+
+        expect(result).toEqual({ rainMm: 0, etMm: 0 });
+    });
+
+    it('spans day boundaries correctly', async () => {
+        const rows = [
+            mkRow('2026-05-24T22:00:00Z', 0.5, 0.05),
+            mkRow('2026-05-24T23:00:00Z', 0.6, 0.04),
+            mkRow('2026-05-25T00:00:00Z', 0.7, 0.03),
+            mkRow('2026-05-25T01:00:00Z', 0.8, 0.02),
+        ];
+
+        const result = sumHourlyWeatherBetween(
+            rows,
+            new Date('2026-05-24T23:00:00Z'),
+            new Date('2026-05-25T01:00:00Z'),
+        );
+
+        // 23:00 + 00:00 included; 01:00 excluded.
+        expect(result.rainMm).toBeCloseTo(1.3, 6);
+        expect(result.etMm).toBeCloseTo(0.07, 6);
     });
 });

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -1,4 +1,4 @@
-import type { DailyWeather } from "@/models";
+import type { DailyWeather, HourlyWeather, WeatherData } from "@/models";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import tzPlugin from "dayjs/plugin/timezone";
@@ -29,6 +29,11 @@ type OpenMeteoResponse = {
         rain_sum: number[];
         et0_fao_evapotranspiration: number[];
     };
+    hourly: {
+        time: string[];
+        precipitation: number[];
+        et0_fao_evapotranspiration: number[];
+    };
 };
 
 export type WeatherDataParams = {
@@ -40,6 +45,13 @@ export type WeatherDataParams = {
 
     /** Optional. Number of days to forecast (default: 7). */
     forecastDays?: number;
+
+    /**
+     * Optional. Number of days of past observations to include (default: 1).
+     * The morning/evening reconcilers need yesterday's hourly observations to
+     * sum ET and precipitation between the last reconciliation and now.
+     */
+    pastDays?: number;
 
     /**
      * Optional. IANA timezone string (e.g. `America/Edmonton`). When provided,
@@ -70,11 +82,11 @@ export type WeatherDataOptions = {
  * window, ET₀ adjustments); without caching, two back-to-back re-plans can
  * produce different schedules from the same site state. See API-70.
  *
- * Keyed by `${latitude}|${longitude}|${forecastDays}|${timezone ?? ''}` — the
- * full set of request parameters that vary between callers. `apiKey` is
+ * Keyed by `${latitude}|${longitude}|${forecastDays}|${pastDays}|${timezone ?? ''}`
+ * — the full set of request parameters that vary between callers. `apiKey` is
  * deliberately omitted; it's a process-wide constant, not a request input.
  */
-type WeatherCacheEntry = { value: DailyWeather[]; expiresAt: number };
+type WeatherCacheEntry = { value: WeatherData; expiresAt: number };
 const cache = new Map<string, WeatherCacheEntry>();
 
 /** 10 minutes — long enough to dedupe rapid re-plan storms, short enough that a "stale" forecast can't drift far from reality (Open-Meteo's model refreshes hourly). */
@@ -171,16 +183,16 @@ export async function fetchWithRetry(url: string, retryOptions: PRetryOptions = 
 export async function getWeatherData(
     params: WeatherDataParams,
     options?: WeatherDataOptions,
-): Promise<DailyWeather[]> {
+): Promise<WeatherData> {
     if (process.env.OPEN_METEO_ENABLED === 'false') {
         throw new Error('Weather integration is disabled (OPEN_METEO_ENABLED=false).');
     }
 
-    const { latitude, longitude, forecastDays = 7, timezone } = params;
+    const { latitude, longitude, forecastDays = 7, pastDays = 1, timezone } = params;
     const ttlMs = options?.ttlMs ?? WEATHER_CACHE_TTL_MS;
     const now = options?.now ?? Date.now;
 
-    const cacheKey = `${latitude}|${longitude}|${forecastDays}|${timezone ?? ''}`;
+    const cacheKey = `${latitude}|${longitude}|${forecastDays}|${pastDays}|${timezone ?? ''}`;
     const cached = cache.get(cacheKey);
     if (cached !== undefined && cached.expiresAt > now()) {
         console.log(`weather: cache hit for ${cacheKey}.`);
@@ -196,7 +208,9 @@ export async function getWeatherData(
     url.searchParams.set('latitude', latitude.toString());
     url.searchParams.set('longitude', longitude.toString());
     url.searchParams.set('daily', 'sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
+    url.searchParams.set('hourly', 'precipitation,et0_fao_evapotranspiration');
     url.searchParams.set('forecast_days', forecastDays.toString());
+    url.searchParams.set('past_days', pastDays.toString());
     if (timezone) {
         url.searchParams.set('timezone', timezone);
     }
@@ -212,17 +226,25 @@ export async function getWeatherData(
     const parseTime = (t: string): dayjs.Dayjs =>
         timezone ? dayjs.tz(t, timezone) : dayjs(t);
 
-    let parsed: DailyWeather[];
+    let parsed: WeatherData;
     try {
         const data = await response.json() as OpenMeteoResponse;
 
-        parsed = data.daily.time.map((time, index) => ({
+        const daily: DailyWeather[] = data.daily.time.map((time, index) => ({
             date: parseTime(time),
             sunrise: parseTime(data.daily.sunrise[index]!),
             sunset: parseTime(data.daily.sunset[index]!),
             rainfallMm: data.daily.rain_sum[index],
             evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
         }));
+
+        const hourly: HourlyWeather[] = data.hourly.time.map((time, index) => ({
+            time: parseTime(time),
+            precipitationMm: data.hourly.precipitation[index] ?? 0,
+            evapotranspirationMm: data.hourly.et0_fao_evapotranspiration[index] ?? 0,
+        }));
+
+        parsed = { daily, hourly };
     } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         console.error(`weather: Open-Meteo response could not be parsed: ${detail}`);
@@ -233,4 +255,34 @@ export async function getWeatherData(
     // above without polluting the cache.
     cache.set(cacheKey, { value: parsed, expiresAt: now() + ttlMs });
     return parsed;
+}
+
+/**
+ * Pure helper. Returns the sum of `precipitationMm` and `evapotranspirationMm`
+ * across hourly observations whose `time` falls in the half-open window
+ * `[since, until)`. Open-Meteo emits one hourly row per hour-start, so each
+ * row contributes fully if its hour-start is inside the window; partial hours
+ * at the edges are *not* pro-rated (the reconciler's window boundaries are
+ * always at tick times, ~12 hours apart, so the per-hour rounding error is
+ * negligible compared to the 24+ rows summed).
+ *
+ * Used by the morning/evening reconcilers in api/service/daemon to compute
+ * the depletion delta over the gap since the last reconciliation.
+ */
+export function sumHourlyWeatherBetween(
+    hourly: ReadonlyArray<HourlyWeather>,
+    since: Date,
+    until: Date,
+): { rainMm: number; etMm: number } {
+    const sinceMs = since.getTime();
+    const untilMs = until.getTime();
+    let rainMm = 0;
+    let etMm = 0;
+    for (const row of hourly) {
+        const t = row.time.valueOf();
+        if (t < sinceMs || t >= untilMs) continue;
+        rainMm += row.precipitationMm;
+        etMm += row.evapotranspirationMm;
+    }
+    return { rainMm, etMm };
 }

--- a/api/db/schema/alerts.ts
+++ b/api/db/schema/alerts.ts
@@ -26,6 +26,6 @@ export const alerts = pgTable('alerts', {
     ack: boolean('ack').notNull().default(false),
     ...auditColumns,
 }, (table) => [
-    check('alerts_class_check', sql`${table.class} in ('weather-stale', 'ha-call-failed', 'missed-close')`),
+    check('alerts_class_check', sql`${table.class} in ('weather-stale', 'ha-call-failed', 'missed-close', 'actuation-stale')`),
     check('alerts_tone_check', sql`${table.tone} in ('warn', 'danger')`),
 ]);

--- a/api/db/schema/zones.ts
+++ b/api/db/schema/zones.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { boolean, check, doublePrecision, pgTable, real, text, uuid } from 'drizzle-orm/pg-core';
+import { boolean, check, doublePrecision, pgTable, real, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { auditColumns } from './audit-columns';
 import { grassTypes } from './grass-types';
 import { sites } from './sites';
@@ -19,6 +19,7 @@ export const zones = pgTable('zones', {
     areaM2: real('area_m2').notNull(),
     precipitationRateMmPerHr: real('precipitation_rate_mm_per_hr'),
     currentDepletionMm: real('current_depletion_mm').notNull().default(0),
+    currentDepletionReconciledAt: timestamp('current_depletion_reconciled_at', { withTimezone: true }),
     isEnabled: boolean('is_enabled').notNull().default(true),
     latitude: doublePrecision('latitude'),
     longitude: doublePrecision('longitude'),

--- a/api/drizzle/0015_woozy_wolfsbane.sql
+++ b/api/drizzle/0015_woozy_wolfsbane.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "alerts" DROP CONSTRAINT "alerts_class_check";--> statement-breakpoint
+ALTER TABLE "zones" ADD COLUMN "current_depletion_reconciled_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "zones" SET "current_depletion_reconciled_at" = now() WHERE "current_depletion_reconciled_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "alerts" ADD CONSTRAINT "alerts_class_check" CHECK ("alerts"."class" in ('weather-stale', 'ha-call-failed', 'missed-close', 'actuation-stale'));

--- a/api/drizzle/meta/0015_snapshot.json
+++ b/api/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1015 @@
+{
+  "id": "477f4bd9-634d-4b4f-ba9f-a42a8ebe5e83",
+  "prevId": "84c28411-9b46-47d4-a0b9-435c714d5ce8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_at": {
+          "name": "when_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack": {
+          "name": "ack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_zone_id_zones_id_fk": {
+          "name": "alerts_zone_id_zones_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alerts_class_check": {
+          "name": "alerts_class_check",
+          "value": "\"alerts\".\"class\" in ('weather-stale', 'ha-call-failed', 'missed-close', 'actuation-stale')"
+        },
+        "alerts_tone_check": {
+          "name": "alerts_tone_check",
+          "value": "\"alerts\".\"tone\" in ('warn', 'danger')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_token_unique": {
+          "name": "push_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "sunrise_at": {
+          "name": "sunrise_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_night_date": {
+          "name": "skipped_night_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_state": {
+      "name": "system_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "irrigation_enabled": {
+          "name": "irrigation_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_state": {
+      "name": "weather_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_fetch_at": {
+          "name": "last_successful_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_depletion_reconciled_at": {
+          "name": "current_depletion_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1748131200000,
       "tag": "0014_drop_sunset_at",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1779852772092,
+      "tag": "0015_woozy_wolfsbane",
+      "breakpoints": true
     }
   ]
 }

--- a/api/models.ts
+++ b/api/models.ts
@@ -90,6 +90,9 @@ export type Zone = {
     /** Required. The current soil moisture deficit (0 = full). */
     currentDepletionMm: number;
 
+    /** Optional. Timestamp of the last reconciliation write to `currentDepletionMm`. Anchors the [since, now) window used by the morning/evening reconcilers to sum weather and actuation history. Null for freshly-seeded zones; the first reconciler tick stamps it and skips the math. */
+    currentDepletionReconciledAt?: Date;
+
     /** Required. The ID of the site this zone belongs to. */
     siteId: string;
 

--- a/api/models.ts
+++ b/api/models.ts
@@ -17,6 +17,34 @@ export type DailyWeather = {
     sunset?: dayjs.Dayjs;
 }
 
+/**
+ * One hour of observed/forecast weather. Open-Meteo emits one row per hour
+ * over the requested past + forecast window. `time` is the start instant of
+ * the hour, anchored to the requested timezone. The reconciler sums
+ * `precipitationMm` and `evapotranspirationMm` over the window between the
+ * last reconciled-at timestamp and now to advance depletion against reality.
+ */
+export type HourlyWeather = {
+    /** Required. Start of the hour, anchored to the request timezone. */
+    time: dayjs.Dayjs;
+
+    /** Required. Total precipitation during the hour. */
+    precipitationMm: number;
+
+    /** Required. Reference evapotranspiration (ET₀) during the hour. */
+    evapotranspirationMm: number;
+}
+
+/**
+ * Composite weather response returned by `getWeatherData`. `daily` continues
+ * to feed the planner's multi-day forecast; `hourly` is consumed by the
+ * morning/evening depletion reconcilers for sub-daily window math.
+ */
+export type WeatherData = {
+    daily: DailyWeather[];
+    hourly: HourlyWeather[];
+}
+
 export type GrassType = {
     /** Required. The name of the grass. */
     name: string;

--- a/api/models/alert.ts
+++ b/api/models/alert.ts
@@ -4,7 +4,7 @@
  * 'missed-close'))` constraint, so widening the union requires both a code
  * change here and a new migration.
  */
-export type AlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close';
+export type AlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close' | 'actuation-stale';
 
 /**
  * Visual severity used by the mobile app to colour the alert row. `warn`

--- a/api/models/push-token.ts
+++ b/api/models/push-token.ts
@@ -21,7 +21,7 @@ export type PushRegistration = {
  * `@/alerts` and `@/service/push-tokens` (the dispatcher lives in the push
  * service, which is itself wired into the alerter).
  */
-export type PushAlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close';
+export type PushAlertClass = 'weather-stale' | 'ha-call-failed' | 'missed-close' | 'actuation-stale';
 
 /**
  * Visual severity carried alongside the push. `danger` maps to Expo

--- a/api/repositories/alerts/.test.ts
+++ b/api/repositories/alerts/.test.ts
@@ -285,6 +285,27 @@ describe('createAlertsRepository.insertAlert', () => {
             zoneId: null,
         });
     });
+
+    it('accepts the actuation-stale class for HA-history fetch failures', async () => {
+        const { db, inserts } = createStub([]);
+        const repo = createAlertsRepository(db);
+
+        await repo.insertAlert({
+            class: 'actuation-stale',
+            tone: 'warn',
+            title: 'HA actuation history stale',
+            sub: 'North · ECONNREFUSED',
+            zoneId: 'zone-001',
+        });
+
+        expect(inserts[0]?.values).toEqual({
+            class: 'actuation-stale',
+            tone: 'warn',
+            title: 'HA actuation history stale',
+            sub: 'North · ECONNREFUSED',
+            zoneId: 'zone-001',
+        });
+    });
 });
 
 describe('createAlertsRepository.updateAlert', () => {

--- a/api/repositories/zones/.test.ts
+++ b/api/repositories/zones/.test.ts
@@ -455,27 +455,33 @@ function stubUpdateDb(): { db: Database; updateCalls: Array<{ table: unknown; va
 }
 
 describe('createZonesRepository.advanceDepletion', () => {
-    it('issues a single UPDATE on zones with the supplied depletionMm value', async () => {
+    it('issues a single UPDATE on zones with the supplied depletionMm and reconciledAt values', async () => {
         const { db, updateCalls } = stubUpdateDb();
         const repo = createZonesRepository(db);
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
 
-        await repo.advanceDepletion('zone-001', 7.5);
+        await repo.advanceDepletion('zone-001', 7.5, reconciledAt);
 
         expect(updateCalls).toHaveLength(1);
         expect(updateCalls[0]?.table).toBe(zones);
-        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 7.5 });
+        expect(updateCalls[0]?.values).toEqual({
+            currentDepletionMm: 7.5,
+            currentDepletionReconciledAt: reconciledAt,
+        });
     });
 
     it('issues a separate UPDATE for each call (two zones produce two updates)', async () => {
         const { db, updateCalls } = stubUpdateDb();
         const repo = createZonesRepository(db);
+        const t1 = new Date('2026-05-04T08:00:00.000Z');
+        const t2 = new Date('2026-05-04T20:00:00.000Z');
 
-        await repo.advanceDepletion('zone-A', 3.2);
-        await repo.advanceDepletion('zone-B', 0);
+        await repo.advanceDepletion('zone-A', 3.2, t1);
+        await repo.advanceDepletion('zone-B', 0, t2);
 
         expect(updateCalls).toHaveLength(2);
-        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 3.2 });
-        expect(updateCalls[1]?.values).toEqual({ currentDepletionMm: 0 });
+        expect(updateCalls[0]?.values).toEqual({ currentDepletionMm: 3.2, currentDepletionReconciledAt: t1 });
+        expect(updateCalls[1]?.values).toEqual({ currentDepletionMm: 0, currentDepletionReconciledAt: t2 });
     });
 });
 

--- a/api/repositories/zones/index.ts
+++ b/api/repositories/zones/index.ts
@@ -63,12 +63,13 @@ export interface ZonesRepository {
     loadLatestFires(): Promise<LatestZoneFire[]>;
 
     /**
-     * Writes `current_depletion_mm` for the zone. Called by the daemon on two
-     * paths: (1) the nightly scheduled re-plan, which persists
-     * `projectedNextDepletionMm` as the next morning's starting depletion; and
-     * (2) `runClose`, which resets depletion to 0 after irrigation actually fires.
+     * Writes `current_depletion_mm` for the zone alongside the reconciliation
+     * timestamp that anchors the [since, now) window used by the next
+     * morning/evening reconciler tick. Callers should pass `clock.now()` (or
+     * an equivalent) so the window math stays accurate across daemon
+     * restarts.
      */
-    advanceDepletion(zoneId: string, depletionMm: number): Promise<void>;
+    advanceDepletion(zoneId: string, depletionMm: number, reconciledAt: Date): Promise<void>;
 }
 
 /**
@@ -161,9 +162,11 @@ export function createZonesRepository(db: Database): ZonesRepository {
             }));
         },
 
-        advanceDepletion: async (zoneId, depletionMm) => {
-            await db.update(zones).set({ currentDepletionMm: depletionMm }).where(eq(zones.id, zoneId));
-            console.log(`zones: advanced current_depletion_mm=${depletionMm} for zone ${zoneId}.`);
+        advanceDepletion: async (zoneId, depletionMm, reconciledAt) => {
+            await db.update(zones)
+                .set({ currentDepletionMm: depletionMm, currentDepletionReconciledAt: reconciledAt })
+                .where(eq(zones.id, zoneId));
+            console.log(`zones: advanced current_depletion_mm=${depletionMm} reconciled_at=${reconciledAt.toISOString()} for zone ${zoneId}.`);
         },
     };
 }
@@ -204,6 +207,7 @@ export function joinedRowToZone(row: ZoneJoinedRow): Zone {
         areaM2: row.zone.areaM2,
         precipitationRateMmPerHr: row.zone.precipitationRateMmPerHr ?? undefined,
         currentDepletionMm: row.zone.currentDepletionMm,
+        currentDepletionReconciledAt: row.zone.currentDepletionReconciledAt ?? undefined,
         siteId: row.zone.siteId,
         siteTimezone: row.site.timezone,
         isEnabled: row.zone.isEnabled,

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -30,6 +30,11 @@ const stubWeatherResponse = {
         rain_sum: [0, 0, 0, 0],
         et0_fao_evapotranspiration: [4.0, 4.0, 4.0, 4.0],
     },
+    hourly: {
+        time: ['2025-10-20T00:00', '2025-10-20T01:00'],
+        precipitation: [0, 0],
+        et0_fao_evapotranspiration: [0.1, 0.1],
+    },
 };
 
 const stubSuccess = () => mockFetch.mockResolvedValueOnce({
@@ -206,6 +211,11 @@ describe('runScheduleForZone', () => {
                     time: [],
                     sunrise: [],
                     rain_sum: [],
+                    et0_fao_evapotranspiration: [],
+                },
+                hourly: {
+                    time: [],
+                    precipitation: [],
                     et0_fao_evapotranspiration: [],
                 },
             }),

--- a/api/schedules/index.ts
+++ b/api/schedules/index.ts
@@ -54,7 +54,7 @@ export async function runScheduleForZone(
 
     console.log(`runScheduleForZone: planning zone ${zone.id} at (${zone.location.lat}, ${zone.location.lon}) over ${forecastDays} day(s).`);
 
-    const weather = await getWeatherData({
+    const { daily } = await getWeatherData({
         latitude: zone.location.lat,
         longitude: zone.location.lon,
         forecastDays,
@@ -66,5 +66,5 @@ export async function runScheduleForZone(
         end: dayjs(w.end),
     }));
 
-    return planZoneSchedule(zone, weather, busyWindows, options?.restrictions, options?.overrides);
+    return planZoneSchedule(zone, daily, busyWindows, options?.restrictions, options?.overrides);
 }

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { AlertEvent, Alerter, AlertsDb } from '@/alerts';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import { grassTypes, irrigationCycles, scheduleEntries, schedules, sites, soilTypes, weatherState, zones } from '@/db/schema';
+import { __resetWeatherCacheForTests } from '@/data/weather';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -22,6 +23,29 @@ import { bootDaemonService, computeNextRePlanAt, start } from '.';
 import type { Clock, TimerHandle } from './runtime';
 
 const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+// Empty-weather response stubbed onto the global `fetch` so the daemon's
+// per-zone `getWeather` call doesn't reach the network. Individual tests that
+// care about hourly weather pass an explicit `getWeather` stub to `start()`.
+const emptyOpenMeteoResponse = {
+    latitude: 51.0,
+    longitude: -114.0,
+    generationtime_ms: 0,
+    utc_offset_seconds: 0,
+    timezone: 'GMT',
+    timezone_abbreviation: 'GMT',
+    elevation: 0,
+    daily_units: { time: 'iso8601', sunrise: 'iso8601', sunset: 'iso8601', rain_sum: 'mm', et0_fao_evapotranspiration: 'mm' },
+    daily: { time: [], sunrise: [], sunset: [], rain_sum: [], et0_fao_evapotranspiration: [] },
+    hourly: { time: [], precipitation: [], et0_fao_evapotranspiration: [] },
+};
+const mockFetch = mock(() => Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => emptyOpenMeteoResponse,
+} as Response));
+(global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
 
 type RecordedNotification = { event: NotificationEvent; context: NotificationContext | undefined };
 
@@ -462,6 +486,8 @@ describe('start', () => {
                 upsertSingleton: async () => {},
             },
         });
+        mockFetch.mockClear();
+        __resetWeatherCacheForTests();
     });
 
     it('arms each future cycle returned by the DB so it fires at its start_time', async () => {
@@ -826,11 +852,21 @@ describe('start', () => {
     });
 
     it('nightly tick advances currentDepletionMm; public rePlan() is idempotent (no depletion write)', async () => {
-        // API-71: operator replans must not mutate zone depletion; only the
-        // nightly scheduled tick (isScheduledTick=true) should call advanceDepletion.
-        // NOW = 2026-05-04T12:00:00Z; with rePlanHourLocal=20 + UTC the tick fires
-        // 8h later at 2026-05-04T20:00:00Z.
-        const enabledRow = buildJoinedRow({ zone: { id: 'zone-001', currentDepletionMm: 0 } });
+        // API-71 + API-79: operator replans must not mutate zone depletion;
+        // only the nightly scheduled tick advances depletion against observed
+        // hourly weather. NOW = 2026-05-04T12:00:00Z; with rePlanHourLocal=20
+        // + UTC the tick fires 8h later at 2026-05-04T20:00:00Z. The zone
+        // starts with depletion=5 and a reconciledAt 12h before the tick; a
+        // weather stub reports 2 mm ET and 0 mm rain over that window, so
+        // the advance lands at 7.
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                currentDepletionMm: 5,
+                currentDepletionReconciledAt: reconciledAt,
+            },
+        });
         const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
         bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
         const { clock, advanceTo } = createFakeClock(NOW);
@@ -839,7 +875,16 @@ describe('start', () => {
             clock,
             rePlanHourLocal: 20,
             siteTimezone: 'UTC',
-            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 7.5 }),
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 999 }),
+            getWeather: async () => ({
+                daily: [],
+                hourly: [
+                    { time: dayjs('2026-05-04T10:00:00Z'), precipitationMm: 0, evapotranspirationMm: 1 },
+                    { time: dayjs('2026-05-04T15:00:00Z'), precipitationMm: 0, evapotranspirationMm: 1 },
+                    // Outside the window — must be ignored.
+                    { time: dayjs('2026-05-04T06:00:00Z'), precipitationMm: 99, evapotranspirationMm: 99 },
+                ],
+            }),
             openZone: async () => {},
             closeZone: async () => {},
         });
@@ -849,8 +894,81 @@ describe('start', () => {
 
         expect(stub.depletionAdvances).toHaveLength(1);
         expect(stub.depletionAdvances[0]?.zoneId).toBe('zone-001');
-        expect(stub.depletionAdvances[0]?.depletionMm).toBe(7.5);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBeCloseTo(7, 6);
         expect(stub.depletionAdvances[0]?.reconciledAt).toBeInstanceOf(Date);
+    });
+
+    it('on first tick with null currentDepletionReconciledAt, stamps the timestamp without changing depletion (API-79)', async () => {
+        // Fresh-seed zone — no prior anchor for the window. The tick should
+        // write the same depletion value plus a reconciledAt timestamp; the
+        // next tick will use that anchor for actual math.
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                currentDepletionMm: 12.4,
+                currentDepletionReconciledAt: null,
+            },
+        });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 999 }),
+            // Even with heavy rain in the hourly stub, the null reconciledAt
+            // path skips the math.
+            getWeather: async () => ({
+                daily: [],
+                hourly: [
+                    { time: dayjs('2026-05-04T15:00:00Z'), precipitationMm: 50, evapotranspirationMm: 0 },
+                ],
+            }),
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await advanceTo(new Date('2026-05-04T20:00:01.000Z'));
+
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBeCloseTo(12.4, 6);
+        expect(stub.depletionAdvances[0]?.reconciledAt).toBeInstanceOf(Date);
+    });
+
+    it('clamps depletion to zero when rain exceeds the deficit (API-79)', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                currentDepletionMm: 3,
+                currentDepletionReconciledAt: reconciledAt,
+            },
+        });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 999 }),
+            getWeather: async () => ({
+                daily: [],
+                hourly: [
+                    { time: dayjs('2026-05-04T15:00:00Z'), precipitationMm: 25, evapotranspirationMm: 1 },
+                ],
+            }),
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await advanceTo(new Date('2026-05-04T20:00:01.000Z'));
+
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBe(0);
     });
 
     it('two consecutive operator rePlan() calls produce no depletionAdvances (API-71 regression)', async () => {

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -19,7 +19,7 @@ import { joinedRowToZone } from '@/repositories/zones';
 import { planZoneSchedule } from '@/schedules/dynamic';
 import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
 import { bootSystemService } from '@/service/system';
-import { bootDaemonService, computeNextRePlanAt, start } from '.';
+import { bootDaemonService, computeNextMorningAt, computeNextRePlanAt, start } from '.';
 import type { Clock, TimerHandle } from './runtime';
 
 const NOW = new Date('2026-05-04T12:00:00.000Z');
@@ -476,6 +476,38 @@ describe('computeNextRePlanAt', () => {
     });
 });
 
+describe('computeNextMorningAt', () => {
+    it('returns sunrise + offset minutes when that instant is in the future', () => {
+        const now = new Date('2026-05-24T04:00:00.000Z');
+        const sunrise = new Date('2026-05-24T11:41:00.000Z');
+        const next = computeNextMorningAt(now, sunrise, 60);
+
+        expect(next?.toISOString()).toBe('2026-05-24T12:41:00.000Z');
+    });
+
+    it('returns null when sunrise is null (no anchor known yet)', () => {
+        const next = computeNextMorningAt(new Date('2026-05-24T04:00:00.000Z'), null, 60);
+
+        expect(next).toBeNull();
+    });
+
+    it('returns null when sunrise + offset is already in the past', () => {
+        const now = new Date('2026-05-24T18:00:00.000Z');
+        const sunrise = new Date('2026-05-24T11:41:00.000Z');
+        const next = computeNextMorningAt(now, sunrise, 60);
+
+        expect(next).toBeNull();
+    });
+
+    it('respects a non-default offset', () => {
+        const now = new Date('2026-05-24T04:00:00.000Z');
+        const sunrise = new Date('2026-05-24T11:41:00.000Z');
+        const next = computeNextMorningAt(now, sunrise, 30);
+
+        expect(next?.toISOString()).toBe('2026-05-24T12:11:00.000Z');
+    });
+});
+
 describe('start', () => {
     // Default the system kill-switch to enabled for every test. Kill-switch
     // tests below override this with their own bootSystemService call.
@@ -650,7 +682,7 @@ describe('start', () => {
         expect(stub.alertTableUpdates[0]!.set).toEqual({ ack: true });
     });
 
-    it('rePlan() records a weather-stale alert when the planner throws and no recent fetch is on record', async () => {
+    it('rePlan() records a weather-stale alert when getWeather throws and no recent fetch is on record', async () => {
         const enabledRows = [buildJoinedRow({ zone: { id: 'zone-bad', name: 'North' } })];
         const stub = createDaemonReposStub({ enabledZones: enabledRows });
         bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
@@ -660,7 +692,8 @@ describe('start', () => {
         const control = await start({
             clock,
             rePlanHourLocal: 4,
-            runPlan: async () => { throw new Error('weather: Open-Meteo network error'); },
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+            getWeather: async () => { throw new Error('weather: Open-Meteo network error'); },
             getZoneState: async () => 'off',
             openZone: async () => {},
             closeZone: async () => {},
@@ -688,7 +721,8 @@ describe('start', () => {
         const control = await start({
             clock,
             rePlanHourLocal: 4,
-            runPlan: async () => { throw new Error('transient error'); },
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
+            getWeather: async () => { throw new Error('transient error'); },
             getZoneState: async () => 'off',
             openZone: async () => {},
             closeZone: async () => {},
@@ -969,6 +1003,203 @@ describe('start', () => {
 
         expect(stub.depletionAdvances).toHaveLength(1);
         expect(stub.depletionAdvances[0]?.depletionMm).toBe(0);
+    });
+
+    it('morning tick reconciles depletion against HA actuation history including applied depth (API-79)', async () => {
+        // Sunrise at 11:41 UTC; next morning tick fires at sunrise+60min =
+        // 12:41 UTC. The morning weather fetch reports today's sunrise, the
+        // hourly array sums to 1 mm ET / 0 mm rain over the window, and HA
+        // history shows two 30-minute cycles at 9 mm/hr = 9 mm applied.
+        // 10 + 1 - 0 - 9 = 2 mm
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const sunrise = dayjs('2026-05-04T11:41:00Z');
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                currentDepletionMm: 10,
+                currentDepletionReconciledAt: reconciledAt,
+                precipitationRateMmPerHr: 9,
+            },
+        });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            morningTickMinutesAfterSunrise: 60,
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 999 }),
+            getWeather: async () => ({
+                daily: [{ date: sunrise, sunrise }],
+                hourly: [
+                    { time: dayjs('2026-05-04T10:00:00Z'), precipitationMm: 0, evapotranspirationMm: 1 },
+                ],
+            }),
+            getZoneActuationHistory: async () => ([
+                { onAt: new Date('2026-05-04T09:00:00Z'), offAt: new Date('2026-05-04T09:30:00Z') },
+                { onAt: new Date('2026-05-04T10:00:00Z'), offAt: new Date('2026-05-04T10:30:00Z') },
+            ]),
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        // Boot fetches weather → sunrise observed → morning tick scheduled
+        // at 12:41 UTC. Advance just past that.
+        await advanceTo(new Date('2026-05-04T12:41:01.000Z'));
+
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBeCloseTo(2, 6);
+    });
+
+    it('morning tick falls back to weather-only advance and raises actuation-stale when HA history fetch fails (API-79)', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const sunrise = dayjs('2026-05-04T11:41:00Z');
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                name: 'North',
+                currentDepletionMm: 5,
+                currentDepletionReconciledAt: reconciledAt,
+            },
+        });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        const { alerter, calls: alertCalls } = recordingAlerter();
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            morningTickMinutesAfterSunrise: 60,
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 999 }),
+            getWeather: async () => ({
+                daily: [{ date: sunrise, sunrise }],
+                hourly: [
+                    { time: dayjs('2026-05-04T10:00:00Z'), precipitationMm: 0, evapotranspirationMm: 2 },
+                ],
+            }),
+            getZoneActuationHistory: async () => { throw new Error('HA history fetch ECONNREFUSED'); },
+            openZone: async () => {},
+            closeZone: async () => {},
+            alerter,
+        });
+
+        await advanceTo(new Date('2026-05-04T12:41:01.000Z'));
+
+        // HA-down path: depletion still advances by weather only (5 + 2 = 7).
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBeCloseTo(7, 6);
+        // actuation-stale alert raised, pinned to the zone.
+        const stale = alertCalls.filter(a => a.class === 'actuation-stale');
+        expect(stale).toHaveLength(1);
+        expect(stale[0]).toMatchObject({ class: 'actuation-stale', tone: 'warn', zoneId: 'zone-001', zoneName: 'North' });
+    });
+
+    it('morning tick reconciles depletion even when irrigation is disabled, but skips planning (API-79)', async () => {
+        // Kill switch off: depletion math + write should still happen; no
+        // cycles should arm.
+        bootSystemService({
+            repo: {
+                findSingleton: async () => ({ irrigationEnabled: false, since: new Date('2026-05-04T08:00:00.000Z') }),
+                upsertSingleton: async () => {},
+            },
+        });
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const sunrise = dayjs('2026-05-04T11:41:00Z');
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                currentDepletionMm: 4,
+                currentDepletionReconciledAt: reconciledAt,
+                precipitationRateMmPerHr: 9,
+            },
+        });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        let runPlanCalls = 0;
+        const opens: string[] = [];
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            morningTickMinutesAfterSunrise: 60,
+            runPlan: async () => {
+                runPlanCalls += 1;
+                return { entries: [], projectedNextDepletionMm: 999 };
+            },
+            getWeather: async () => ({
+                daily: [{ date: sunrise, sunrise }],
+                hourly: [
+                    { time: dayjs('2026-05-04T10:00:00Z'), precipitationMm: 0, evapotranspirationMm: 1 },
+                ],
+            }),
+            getZoneActuationHistory: async () => ([
+                { onAt: new Date('2026-05-04T09:00:00Z'), offAt: new Date('2026-05-04T09:20:00Z') }, // 3 mm
+            ]),
+            openZone: async (z) => { opens.push(z.id); },
+            closeZone: async () => {},
+        });
+
+        await advanceTo(new Date('2026-05-04T12:41:01.000Z'));
+
+        // 4 + 1 - 0 - 3 = 2 mm. Reconciliation ran despite kill switch.
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBeCloseTo(2, 6);
+        // Planning + arming suppressed.
+        expect(runPlanCalls).toBe(0);
+        expect(opens).toEqual([]);
+    });
+
+    it('morning tick advances depletion with weather only when zone has no homeAssistantEntityId (API-79)', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const sunrise = dayjs('2026-05-04T11:41:00Z');
+        const enabledRow = buildJoinedRow({
+            zone: {
+                id: 'zone-001',
+                currentDepletionMm: 8,
+                currentDepletionReconciledAt: reconciledAt,
+                homeAssistantEntityId: null,
+            },
+        });
+        const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
+        bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
+        const { clock, advanceTo } = createFakeClock(NOW);
+        let actuationFetchCalled = false;
+
+        await start({
+            clock,
+            rePlanHourLocal: 20,
+            siteTimezone: 'UTC',
+            morningTickMinutesAfterSunrise: 60,
+            runPlan: async () => ({ entries: [], projectedNextDepletionMm: 999 }),
+            getWeather: async () => ({
+                daily: [{ date: sunrise, sunrise }],
+                hourly: [
+                    { time: dayjs('2026-05-04T10:00:00Z'), precipitationMm: 0, evapotranspirationMm: 2 },
+                ],
+            }),
+            getZoneActuationHistory: async (zone) => {
+                actuationFetchCalled = true;
+                // Real impl returns [] when no entity id; we mirror that.
+                return zone.homeAssistantEntityId ? [] : [];
+            },
+            openZone: async () => {},
+            closeZone: async () => {},
+        });
+
+        await advanceTo(new Date('2026-05-04T12:41:01.000Z'));
+
+        // Weather-only advance: 8 + 2 = 10.
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.depletionMm).toBeCloseTo(10, 6);
+        // The HA call is still issued; the real implementation returns []
+        // when the zone has no entityId, which the reconciler handles.
+        expect(actuationFetchCalled).toBe(true);
     });
 
     it('two consecutive operator rePlan() calls produce no depletionAdvances (API-71 regression)', async () => {

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -223,7 +223,7 @@ type DaemonStubInputs = {
 
 function createDaemonReposStub(inputs?: DaemonStubInputs) {
     const cycleUpdates: CycleUpdate[] = [];
-    const depletionAdvances: Array<{ zoneId: string; depletionMm: number }> = [];
+    const depletionAdvances: Array<{ zoneId: string; depletionMm: number; reconciledAt: Date }> = [];
     const inserts: InsertCall[] = [];
     const deletes: Array<{ table: unknown }> = [];
     const weatherStateUpserts: Array<Record<string, unknown>> = [];
@@ -269,10 +269,13 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
         count: async () => counts,
         loadJoinedRowsForSummary: async () => [],
         loadLatestFires: async () => [],
-        advanceDepletion: async (zoneId, depletionMm) => {
-            depletionAdvances.push({ zoneId, depletionMm });
+        advanceDepletion: async (zoneId, depletionMm, reconciledAt) => {
+            depletionAdvances.push({ zoneId, depletionMm, reconciledAt });
             for (const row of enabledZoneRows) {
-                if (row.zone.id === zoneId) row.zone.currentDepletionMm = depletionMm;
+                if (row.zone.id === zoneId) {
+                    row.zone.currentDepletionMm = depletionMm;
+                    row.zone.currentDepletionReconciledAt = reconciledAt;
+                }
             }
         },
     };
@@ -844,9 +847,10 @@ describe('start', () => {
         // Advance past the nightly re-plan tick (20:00 UTC, 8h from NOW=12:00).
         await advanceTo(new Date('2026-05-04T20:00:01.000Z'));
 
-        expect(stub.depletionAdvances).toEqual([
-            { zoneId: 'zone-001', depletionMm: 7.5 },
-        ]);
+        expect(stub.depletionAdvances).toHaveLength(1);
+        expect(stub.depletionAdvances[0]?.zoneId).toBe('zone-001');
+        expect(stub.depletionAdvances[0]?.depletionMm).toBe(7.5);
+        expect(stub.depletionAdvances[0]?.reconciledAt).toBeInstanceOf(Date);
     });
 
     it('two consecutive operator rePlan() calls produce no depletionAdvances (API-71 regression)', async () => {

--- a/api/service/daemon/depletion/.test.ts
+++ b/api/service/daemon/depletion/.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'bun:test';
+import { advanceFromObservedWeather, reconcileFromActuationHistory } from '.';
+
+describe('reconcileFromActuationHistory', () => {
+    it('subtracts applied depth (on-time × precipitation rate) from previous depletion plus net weather', () => {
+        // Two 30-minute cycles at 9 mm/hr = 1 hour total = 9 mm applied.
+        // Weather adds 2 mm ET, subtracts 0 mm rain.
+        // 22.5 + 2 - 0 - 9 = 15.5 mm
+        const result = reconcileFromActuationHistory({
+            previousDepletionMm: 22.5,
+            weatherDelta: { rainMm: 0, etMm: 2 },
+            history: [
+                { onAt: new Date('2026-05-24T04:00:00Z'), offAt: new Date('2026-05-24T04:30:00Z') },
+                { onAt: new Date('2026-05-24T05:00:00Z'), offAt: new Date('2026-05-24T05:30:00Z') },
+            ],
+            precipitationRateMmPerHr: 9,
+        });
+
+        expect(result.appliedDepthMm).toBeCloseTo(9, 6);
+        expect(result.newDepletionMm).toBeCloseTo(15.5, 6);
+    });
+
+    it('subtracts rain alongside applied depth', () => {
+        // 1 hour at 9 mm/hr = 9 mm applied; 3 mm rain on top.
+        // 25 + 1 - 3 - 9 = 14 mm
+        const result = reconcileFromActuationHistory({
+            previousDepletionMm: 25,
+            weatherDelta: { rainMm: 3, etMm: 1 },
+            history: [
+                { onAt: new Date('2026-05-24T04:00:00Z'), offAt: new Date('2026-05-24T05:00:00Z') },
+            ],
+            precipitationRateMmPerHr: 9,
+        });
+
+        expect(result.newDepletionMm).toBeCloseTo(14, 6);
+    });
+
+    it('clamps to zero when rain + applied depth exceed previous depletion + ET', () => {
+        // 50 mm rain swamps the deficit. Soil cannot go below 0.
+        const result = reconcileFromActuationHistory({
+            previousDepletionMm: 5,
+            weatherDelta: { rainMm: 50, etMm: 2 },
+            history: [],
+            precipitationRateMmPerHr: 9,
+        });
+
+        expect(result.newDepletionMm).toBe(0);
+        expect(result.appliedDepthMm).toBe(0);
+    });
+
+    it('treats an empty history as zero applied depth (equivalent to advanceFromObservedWeather)', () => {
+        const result = reconcileFromActuationHistory({
+            previousDepletionMm: 10,
+            weatherDelta: { rainMm: 2, etMm: 4 },
+            history: [],
+            precipitationRateMmPerHr: 9,
+        });
+
+        const weatherOnly = advanceFromObservedWeather({
+            previousDepletionMm: 10,
+            weatherDelta: { rainMm: 2, etMm: 4 },
+        });
+
+        expect(result.newDepletionMm).toBe(weatherOnly);
+        expect(result.appliedDepthMm).toBe(0);
+    });
+
+    it('skips the actuation term when precipitationRateMmPerHr is undefined', () => {
+        // History present but no calibrated precipitation rate → applied = 0.
+        const result = reconcileFromActuationHistory({
+            previousDepletionMm: 12,
+            weatherDelta: { rainMm: 0, etMm: 3 },
+            history: [
+                { onAt: new Date('2026-05-24T04:00:00Z'), offAt: new Date('2026-05-24T05:00:00Z') },
+            ],
+            precipitationRateMmPerHr: undefined,
+        });
+
+        expect(result.appliedDepthMm).toBe(0);
+        expect(result.newDepletionMm).toBe(15);
+    });
+
+    it('ignores zero-duration or inverted intervals defensively', () => {
+        // A bad row where offAt < onAt should not add negative on-time.
+        const result = reconcileFromActuationHistory({
+            previousDepletionMm: 10,
+            weatherDelta: { rainMm: 0, etMm: 0 },
+            history: [
+                { onAt: new Date('2026-05-24T05:00:00Z'), offAt: new Date('2026-05-24T05:00:00Z') }, // zero
+                { onAt: new Date('2026-05-24T06:00:00Z'), offAt: new Date('2026-05-24T05:30:00Z') }, // inverted
+            ],
+            precipitationRateMmPerHr: 9,
+        });
+
+        expect(result.appliedDepthMm).toBe(0);
+        expect(result.newDepletionMm).toBe(10);
+    });
+});
+
+describe('advanceFromObservedWeather', () => {
+    it('grows depletion by net (ET − rain)', () => {
+        const result = advanceFromObservedWeather({
+            previousDepletionMm: 10,
+            weatherDelta: { rainMm: 0, etMm: 4 },
+        });
+
+        expect(result).toBe(14);
+    });
+
+    it('shrinks depletion when rain exceeds ET', () => {
+        const result = advanceFromObservedWeather({
+            previousDepletionMm: 10,
+            weatherDelta: { rainMm: 5, etMm: 2 },
+        });
+
+        expect(result).toBe(7);
+    });
+
+    it('clamps to zero when rain swamps the deficit', () => {
+        const result = advanceFromObservedWeather({
+            previousDepletionMm: 3,
+            weatherDelta: { rainMm: 20, etMm: 1 },
+        });
+
+        expect(result).toBe(0);
+    });
+
+    it('returns the previous value unchanged when weather delta is zero', () => {
+        const result = advanceFromObservedWeather({
+            previousDepletionMm: 12.4,
+            weatherDelta: { rainMm: 0, etMm: 0 },
+        });
+
+        expect(result).toBe(12.4);
+    });
+});

--- a/api/service/daemon/depletion/index.ts
+++ b/api/service/daemon/depletion/index.ts
@@ -1,0 +1,92 @@
+import type { ZoneActuationInterval } from '@/data/home-assistant';
+
+/**
+ * Sum of rain and reference ET over a window, as produced by
+ * `sumHourlyWeatherBetween` (api/data/weather). Both fields are millimetres
+ * accumulated across the window's hours.
+ */
+export type WeatherDelta = {
+    rainMm: number;
+    etMm: number;
+};
+
+/**
+ * Inputs to `reconcileFromActuationHistory` — the morning tick's math.
+ * Captures the soil state before reconciliation, the weather observed since
+ * that state was written, the relay's actual on→off intervals during the
+ * same window, and the zone calibration needed to convert run-time into
+ * applied depth.
+ */
+export type ReconcileInput = {
+    previousDepletionMm: number;
+    weatherDelta: WeatherDelta;
+    history: ReadonlyArray<ZoneActuationInterval>;
+    /**
+     * Zone's measured precipitation rate in mm/hour. The reconciler skips the
+     * actuation term when this is undefined — the math degrades gracefully to
+     * an evening-tick-style weather-only advance.
+     */
+    precipitationRateMmPerHr: number | undefined;
+};
+
+/**
+ * Inputs to `advanceFromObservedWeather` — the evening tick's math. Same
+ * shape minus the actuation history and precipitation rate, since the evening
+ * tick assumes no irrigation has fired since the morning reconciler ran.
+ */
+export type AdvanceInput = {
+    previousDepletionMm: number;
+    weatherDelta: WeatherDelta;
+};
+
+/**
+ * Result of a reconciliation. `appliedDepthMm` is the gross depth credited to
+ * irrigation over the window — surfaced separately for logging and future
+ * observability (e.g. comparing planned vs. actual applied depth per night).
+ */
+export type ReconcileResult = {
+    newDepletionMm: number;
+    appliedDepthMm: number;
+};
+
+/**
+ * Morning-tick math: advance depletion from its last reconciled value through
+ * the weather observed since (ET adds, rain subtracts) and the actuation
+ * actually applied (subtracts). Result is clamped to non-negative — soil
+ * cannot be "more than full."
+ *
+ * When `precipitationRateMmPerHr` is undefined (zone has no calibrated
+ * precipitation rate), the actuation term is zero — depletion advances by
+ * weather alone, equivalent to `advanceFromObservedWeather`.
+ */
+export function reconcileFromActuationHistory(input: ReconcileInput): ReconcileResult {
+    const { previousDepletionMm, weatherDelta, history, precipitationRateMmPerHr } = input;
+
+    let totalOnHours = 0;
+    for (const interval of history) {
+        const durationMs = interval.offAt.getTime() - interval.onAt.getTime();
+        if (durationMs > 0) totalOnHours += durationMs / 3_600_000;
+    }
+
+    const appliedDepthMm = precipitationRateMmPerHr === undefined
+        ? 0
+        : totalOnHours * precipitationRateMmPerHr;
+
+    const newDepletionMm = Math.max(
+        0,
+        previousDepletionMm + weatherDelta.etMm - weatherDelta.rainMm - appliedDepthMm,
+    );
+
+    return { newDepletionMm, appliedDepthMm };
+}
+
+/**
+ * Evening-tick math: advance depletion through observed weather only. No
+ * actuation term — the evening tick runs *before* tonight's cycles fire, so
+ * the only soil-moisture changes since the morning reconciler are weather.
+ * Result is clamped to non-negative.
+ */
+export function advanceFromObservedWeather(input: AdvanceInput): number {
+    const { previousDepletionMm, weatherDelta } = input;
+    return Math.max(0, previousDepletionMm + weatherDelta.etMm - weatherDelta.rainMm);
+}

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -4,18 +4,20 @@ import timezone from 'dayjs/plugin/timezone';
 import { clearAlertsByClass, noopAlerter, type Alerter } from '@/alerts';
 import {
     closeZone as defaultCloseZone,
+    getZoneActuationHistory as defaultGetZoneActuationHistory,
     getZoneState as defaultGetZoneState,
     openZone as defaultOpenZone,
+    type ZoneActuationInterval,
     type ZoneRelayState,
 } from '@/data/home-assistant';
 import { getWeatherData, sumHourlyWeatherBetween } from '@/data/weather';
-import type { WeatherData, Zone } from '@/models';
+import type { IrrigationScheduleEntry, WeatherData, Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { getSystemState } from '@/service/system';
-import { advanceFromObservedWeather } from './depletion';
+import { advanceFromObservedWeather, reconcileFromActuationHistory } from './depletion';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
 import {
     armCloseOnly,
@@ -69,6 +71,8 @@ export function bootDaemonService(input: BootDaemonServiceInput): void {
  */
 export type DaemonOptions = {
     rePlanHourLocal?: number;
+    /** Optional. Minutes after sunrise at which the morning reconciliation tick fires. Default 60. */
+    morningTickMinutesAfterSunrise?: number;
     runPlan?: (zone: Zone, options?: RunScheduleForZoneOptions) => Promise<PlanZoneScheduleResult>;
     /**
      * Reads weather (daily + hourly) for a zone. Defaulted to the real
@@ -77,6 +81,13 @@ export type DaemonOptions = {
      * having to plumb the hourly array through `PlanZoneScheduleResult`.
      */
     getWeather?: (zone: Zone) => Promise<WeatherData>;
+    /**
+     * Reads the on/off intervals during which `zone.homeAssistantEntityId`
+     * was energized in `[since, until)`. Defaulted to the real HA call.
+     * Used by the morning tick to ground depletion advance in actual relay
+     * runtime rather than the planner's projection.
+     */
+    getZoneActuationHistory?: (zone: Zone, since: Date, until: Date) => Promise<ZoneActuationInterval[]>;
     openZone?: (zone: Zone) => Promise<void>;
     closeZone?: (zone: Zone) => Promise<void>;
     getZoneState?: (zone: Zone) => Promise<ZoneRelayState>;
@@ -85,6 +96,16 @@ export type DaemonOptions = {
     notifier?: Notifier;
     alerter?: Alerter;
 };
+
+/**
+ * Distinguishes the daemon's two scheduled ticks. The morning tick
+ * (~sunrise+60min) reconciles depletion against actual HA actuation history
+ * for the prior night; the evening tick (20:00 local) advances depletion
+ * through the day's observed weather and forward-plans tonight's cycles.
+ */
+type TickKind = 'morning' | 'evening';
+
+const DEFAULT_MORNING_TICK_MINUTES_AFTER_SUNRISE = 60;
 
 /**
  * Snapshot of the daemon's runtime state for the HTTP `/health` endpoint.
@@ -119,6 +140,7 @@ export type { DaemonServiceRepos };
 export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     const clock = options?.clock ?? realClock;
     const rePlanHourLocal = options?.rePlanHourLocal ?? DEFAULT_REPLAN_HOUR_LOCAL;
+    const morningTickMinutesAfterSunrise = options?.morningTickMinutesAfterSunrise ?? DEFAULT_MORNING_TICK_MINUTES_AFTER_SUNRISE;
     const runPlan = options?.runPlan ?? ((zone, opts) => runScheduleForZone(zone, opts));
     const getWeather = options?.getWeather ?? (async (zone: Zone): Promise<WeatherData> => {
         if (!zone.location) throw new Error(`daemon: zone ${zone.id} has no location; cannot fetch weather.`);
@@ -128,6 +150,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
             timezone: zone.siteTimezone,
         });
     });
+    const getZoneActuationHistory = options?.getZoneActuationHistory ?? defaultGetZoneActuationHistory;
     const openZone = options?.openZone ?? defaultOpenZone;
     const closeZone = options?.closeZone ?? defaultCloseZone;
     const getZoneState = options?.getZoneState ?? defaultGetZoneState;
@@ -178,12 +201,51 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         console.warn('daemon: all zones are disabled. Daemon is idle until at least one zone is enabled.');
     }
 
-    const scheduleNextRePlan = (): void => {
-        const next = computeNextRePlanAt(clock.now(), rePlanHourLocal, siteTimezone);
-        const delay = Math.max(0, next.getTime() - clock.now().getTime());
-        console.log(`daemon: next re-plan scheduled at ${next.toISOString()} (${delay}ms from now).`);
+    // Most-recently-observed sunrise instant in the site's timezone. Seeded
+    // by a boot-time weather fetch (cache-friendly — the first per-zone
+    // _rePlan call shares the cache) so the first scheduleNextTick can pick
+    // between morning and evening. Updated inside _rePlan on every
+    // subsequent successful weather fetch.
+    let latestKnownSunrise: Date | null = null;
+
+    // Picks the soonest sunrise from a `daily` array whose `sunrise+offset`
+    // is still in the future relative to `at`. Returns null if no entry
+    // qualifies (e.g. the last day of the horizon already morning-ticked).
+    const pickUpcomingSunrise = (daily: ReadonlyArray<{ sunrise?: dayjs.Dayjs }>, at: Date): Date | null => {
+        const thresholdMs = at.getTime() - morningTickMinutesAfterSunrise * 60_000;
+        for (const day of daily) {
+            const candidate = day.sunrise?.toDate();
+            if (candidate && candidate.getTime() > thresholdMs) return candidate;
+        }
+        return null;
+    };
+
+    // Boot weather fetch — seeds latestKnownSunrise so the first
+    // scheduleNextTick can pick a morning tick. Fire-and-forget tolerance:
+    // if the fetch fails, the daemon still boots and schedules an evening
+    // tick; the next successful fetch (per-zone, inside _rePlan) repopulates
+    // the anchor.
+    const bootSeedZone = enabledZonesAtBoot.find(z => z.location !== undefined);
+    if (bootSeedZone) {
+        try {
+            const bootWeather = await getWeather(bootSeedZone);
+            latestKnownSunrise = pickUpcomingSunrise(bootWeather.daily, clock.now());
+            console.log(`daemon: boot weather fetch ok — latestKnownSunrise=${latestKnownSunrise?.toISOString() ?? 'null'}.`);
+        } catch (err) {
+            console.warn(`daemon: boot weather fetch failed; morning tick will be scheduled after the first successful in-tick fetch.`, err);
+        }
+    }
+
+    const scheduleNextTick = (): void => {
+        const now = clock.now();
+        const nextEvening = computeNextRePlanAt(now, rePlanHourLocal, siteTimezone);
+        const nextMorning = computeNextMorningAt(now, latestKnownSunrise, morningTickMinutesAfterSunrise);
+        const next = nextMorning !== null && nextMorning.getTime() < nextEvening.getTime() ? nextMorning : nextEvening;
+        const kind: TickKind = next === nextMorning ? 'morning' : 'evening';
+        const delay = Math.max(0, next.getTime() - now.getTime());
+        console.log(`daemon: next tick (${kind}) scheduled at ${next.toISOString()} (${delay}ms from now).`);
         const handle = clock.setTimeout(() => {
-            _rePlan(true).catch(err => {
+            _rePlan(kind, true).catch(err => {
                 console.error('daemon: unhandled error in scheduled re-plan.', err);
             });
         }, delay);
@@ -191,20 +253,18 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     };
 
     // Private implementation. `isScheduledTick` distinguishes the nightly
-    // daemon-scheduled re-plan (which advances depletion from observed hourly
-    // weather since the last reconciliation, see API-79) from
-    // operator-triggered replans (which must be idempotent and must not
-    // mutate zone state). See API-71.
-    const _rePlan = async (isScheduledTick: boolean): Promise<void> => {
-        console.log(`daemon: re-plan starting (scheduled=${isScheduledTick}).`);
+    // daemon-scheduled re-plan (which writes a reality-derived depletion via
+    // the morning HA-history or evening observed-weather path, see API-79)
+    // from operator-triggered replans (idempotent, no zone mutation; see
+    // API-71). `tickKind` selects morning vs. evening math.
+    const _rePlan = async (tickKind: TickKind, isScheduledTick: boolean): Promise<void> => {
+        console.log(`daemon: re-plan starting (kind=${tickKind}, scheduled=${isScheduledTick}).`);
         registry.cancelOpenTimers(clock);
 
         const system = await getSystemState();
-        if (!system.irrigationEnabled) {
-            console.warn(`daemon: re-plan skipped — system irrigation is disabled (since ${system.since}). All armed cycles cancelled; no new cycles will arm until re-enabled.`);
-            lastRePlanAt = clock.now();
-            scheduleNextRePlan();
-            return;
+        const irrigationEnabled = system.irrigationEnabled;
+        if (!irrigationEnabled) {
+            console.warn(`daemon: planning suppressed — system irrigation is disabled (since ${system.since}). Depletion reconciliation still runs so the model stays accurate while watering is paused.`);
         }
 
         // Resolve `today` against the site's IANA timezone so the date cutoff
@@ -227,12 +287,86 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
 
         for (const zone of enabledZones) {
             const activeSchedule = activeSchedulesBySite.get(zone.siteId);
-            if (!activeSchedule) {
-                console.warn(`daemon: no active schedule for site ${zone.siteId} — skipping zone ${zone.id} (${zone.name}).`);
-                continue;
-            }
 
             try {
+                // Reality-derived depletion advance. Morning ticks reconcile
+                // against actual HA actuation history (subtracts applied
+                // depth); evening ticks advance through observed weather only
+                // (no irrigation has fired since the morning anchor). A null
+                // reconciledAt (fresh seed) is stamped without math — first
+                // tick calibrates the clock, subsequent ticks roll forward.
+                // See API-79.
+                const tickNow = clock.now();
+                const weather = await getWeather(zone);
+                // Refresh the morning-tick anchor with the soonest upcoming
+                // sunrise still inside the offset window.
+                const upcoming = pickUpcomingSunrise(weather.daily, tickNow);
+                if (upcoming) latestKnownSunrise = upcoming;
+
+                let newDepletionMm = zone.currentDepletionMm;
+                if (isScheduledTick) {
+                    if (zone.currentDepletionReconciledAt) {
+                        const weatherDelta = sumHourlyWeatherBetween(
+                            weather.hourly, zone.currentDepletionReconciledAt, tickNow,
+                        );
+                        if (tickKind === 'morning') {
+                            let history: ZoneActuationInterval[] = [];
+                            try {
+                                history = await getZoneActuationHistory(zone, zone.currentDepletionReconciledAt, tickNow);
+                            } catch (err) {
+                                const reason = err instanceof Error ? err.message : String(err);
+                                console.error(`daemon: HA actuation history fetch failed for zone ${zone.id}; falling through to weather-only advance.`, err);
+                                await alerter({
+                                    class: 'actuation-stale',
+                                    tone: 'warn',
+                                    title: 'HA actuation history stale',
+                                    sub: `Depletion advanced from weather only. Last fetch error: ${reason}.`,
+                                    zoneId: zone.id,
+                                    zoneName: zone.name,
+                                });
+                            }
+                            const result = reconcileFromActuationHistory({
+                                previousDepletionMm: zone.currentDepletionMm,
+                                weatherDelta,
+                                history,
+                                precipitationRateMmPerHr: zone.precipitationRateMmPerHr,
+                            });
+                            newDepletionMm = result.newDepletionMm;
+                            console.log(`daemon: zone ${zone.id} morning reconcile — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, applied=${result.appliedDepthMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
+                        } else {
+                            newDepletionMm = advanceFromObservedWeather({
+                                previousDepletionMm: zone.currentDepletionMm,
+                                weatherDelta,
+                            });
+                            console.log(`daemon: zone ${zone.id} evening weather advance — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
+                        }
+                    } else {
+                        console.log(`daemon: zone ${zone.id} has null currentDepletionReconciledAt — stamping ${tickNow.toISOString()} without advancing depletion.`);
+                    }
+                    // Persist the reality-derived depletion + the new anchor
+                    // immediately. Planning runs afterward; if it skips (kill
+                    // switch off, no active schedule), the reconciliation
+                    // still landed.
+                    await zonesRepo.advanceDepletion(zone.id, newDepletionMm, tickNow);
+                }
+
+                // Successful weather fetch — refresh the staleness timestamp
+                // and clear any lingering unacked weather-stale alert.
+                const alertsDb = getAlertsDb();
+                await Promise.all([
+                    weatherStateRepo.markFetchSuccessful(clock.now()),
+                    alertsDb ? clearAlertsByClass(alertsDb, 'weather-stale') : Promise.resolve(),
+                ]);
+
+                // Planning + arming portion. Skipped when irrigation is
+                // disabled (kill switch off) or the zone's site has no
+                // active schedule.
+                if (!irrigationEnabled) continue;
+                if (!activeSchedule) {
+                    console.warn(`daemon: no active schedule for site ${zone.siteId} — skipping plan/arm of zone ${zone.id} (${zone.name}).`);
+                    continue;
+                }
+
                 const restrictions = {
                     allowedDays: activeSchedule.allowedDays,
                     allowedTimeWindows: activeSchedule.allowedTimeWindows,
@@ -243,33 +377,9 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                     rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,
                     allowableDepletionFraction: activeSchedule.allowableDepletionFractionOverride ?? undefined,
                 };
-                // Reality-derived depletion advance: sum hourly weather since
-                // the last reconciliation and apply (ET adds, rain subtracts).
-                // A null reconciledAt (fresh seed) is stamped without math —
-                // we have no anchor for the prior window, so the first tick
-                // calibrates the clock and subsequent ticks roll forward
-                // against a known boundary. See API-79.
-                const tickNow = clock.now();
-                const weather = await getWeather(zone);
-                let newDepletionMm = zone.currentDepletionMm;
-                let planningZone = zone;
-                if (isScheduledTick) {
-                    if (zone.currentDepletionReconciledAt) {
-                        const weatherDelta = sumHourlyWeatherBetween(
-                            weather.hourly, zone.currentDepletionReconciledAt, tickNow,
-                        );
-                        newDepletionMm = advanceFromObservedWeather({
-                            previousDepletionMm: zone.currentDepletionMm,
-                            weatherDelta,
-                        });
-                        console.log(`daemon: zone ${zone.id} weather advance — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
-                    } else {
-                        console.log(`daemon: zone ${zone.id} has null currentDepletionReconciledAt — stamping ${tickNow.toISOString()} without advancing depletion.`);
-                    }
-                    // Hand the planner the advanced depletion so it plans
-                    // from the same value we're about to persist.
-                    planningZone = { ...zone, currentDepletionMm: newDepletionMm, currentDepletionReconciledAt: tickNow };
-                }
+                const planningZone = isScheduledTick
+                    ? { ...zone, currentDepletionMm: newDepletionMm, currentDepletionReconciledAt: tickNow }
+                    : zone;
                 const { entries } = await runPlan(planningZone, {
                     busyWindows: [pastWindow, ...busyWindows],
                     restrictions,
@@ -279,13 +389,6 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                 const { cycles } = await scheduleEntriesRepo.replaceForZone(
                     zone.id, entries, today, activeSchedule.id,
                 );
-                // Operator replans (isScheduledTick=false) are intentionally
-                // idempotent — they plan against current state without
-                // mutating it. The scheduled tick writes the reality-derived
-                // depletion alongside the new reconciledAt anchor.
-                if (isScheduledTick) {
-                    await zonesRepo.advanceDepletion(zone.id, newDepletionMm, tickNow);
-                }
                 for (const cycle of cycles) {
                     const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);
                     const overlaps = busyWindows.some(w => cycle.startTime < w.end && cycleEnd > w.start);
@@ -296,14 +399,6 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                     cyclesToArm.push({ zone, cycle });
                     busyWindows.push({ start: cycle.startTime, end: cycleEnd });
                 }
-                // Successful runPlan implies a successful weather fetch — refresh
-                // the staleness timestamp and clear any lingering unacked
-                // weather-stale alert so the UI region collapses on recovery.
-                const alertsDb = getAlertsDb();
-                await Promise.all([
-                    weatherStateRepo.markFetchSuccessful(clock.now()),
-                    alertsDb ? clearAlertsByClass(alertsDb, 'weather-stale') : Promise.resolve(),
-                ]);
             } catch (err) {
                 const reason = err instanceof Error ? err.message : String(err);
                 console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
@@ -324,11 +419,15 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         });
 
         lastRePlanAt = clock.now();
-        scheduleNextRePlan();
+        scheduleNextTick();
         console.log('daemon: re-plan complete.');
     };
 
-    const rePlan = (): Promise<void> => _rePlan(false);
+    // Operator rePlan() invokes the evening forward-plan path. The morning
+    // tick is purely a daemon-scheduled reconciliation; there's no operator
+    // affordance to trigger it manually (it has no useful idempotent
+    // semantics — actuation history is whatever HA reports).
+    const rePlan = (): Promise<void> => _rePlan('evening', false);
 
     const shutdown = async (): Promise<void> => {
         console.log('daemon: shutdown starting.');
@@ -337,7 +436,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         console.log('daemon: shutdown complete.');
     };
 
-    scheduleNextRePlan();
+    scheduleNextTick();
     started = true;
 
     const getStatus = (): DaemonStatus => ({
@@ -359,6 +458,21 @@ export function computeNextRePlanAt(now: Date, hourLocal: number, tz: string): D
     const todayAtHour = ref.hour(hourLocal).minute(0).second(0).millisecond(0);
     const next = todayAtHour.isAfter(ref) ? todayAtHour : todayAtHour.add(1, 'day');
     return next.toDate();
+}
+
+/**
+ * Returns `sunrise + offsetMinutes` if that instant is still in the future
+ * relative to `now`; otherwise `null`. Used by `scheduleNextTick` to pick
+ * between the morning reconciliation tick and the evening forward-plan tick.
+ * When the latest known sunrise has already passed (or no sunrise has been
+ * observed yet), the daemon falls back to scheduling the evening tick only,
+ * and the next successful weather fetch refreshes the morning anchor.
+ */
+export function computeNextMorningAt(now: Date, sunrise: Date | null, offsetMinutes: number): Date | null {
+    if (sunrise === null) return null;
+    const candidate = new Date(sunrise.getTime() + offsetMinutes * 60_000);
+    if (candidate.getTime() <= now.getTime()) return null;
+    return candidate;
 }
 
 /**

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -238,7 +238,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                 // Operator replans (isScheduledTick=false) are intentionally
                 // idempotent — they plan against current state without mutating it.
                 if (isScheduledTick) {
-                    await zonesRepo.advanceDepletion(zone.id, projectedNextDepletionMm);
+                    await zonesRepo.advanceDepletion(zone.id, projectedNextDepletionMm, clock.now());
                 }
                 for (const cycle of cycles) {
                     const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -8,12 +8,14 @@ import {
     openZone as defaultOpenZone,
     type ZoneRelayState,
 } from '@/data/home-assistant';
-import type { Zone } from '@/models';
+import { getWeatherData, sumHourlyWeatherBetween } from '@/data/weather';
+import type { WeatherData, Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { getSystemState } from '@/service/system';
+import { advanceFromObservedWeather } from './depletion';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
 import {
     armCloseOnly,
@@ -68,6 +70,13 @@ export function bootDaemonService(input: BootDaemonServiceInput): void {
 export type DaemonOptions = {
     rePlanHourLocal?: number;
     runPlan?: (zone: Zone, options?: RunScheduleForZoneOptions) => Promise<PlanZoneScheduleResult>;
+    /**
+     * Reads weather (daily + hourly) for a zone. Defaulted to the real
+     * `getWeatherData`. Injected separately from `runPlan` so the daemon can
+     * advance depletion against observed hourly weather without the planner
+     * having to plumb the hourly array through `PlanZoneScheduleResult`.
+     */
+    getWeather?: (zone: Zone) => Promise<WeatherData>;
     openZone?: (zone: Zone) => Promise<void>;
     closeZone?: (zone: Zone) => Promise<void>;
     getZoneState?: (zone: Zone) => Promise<ZoneRelayState>;
@@ -111,6 +120,14 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     const clock = options?.clock ?? realClock;
     const rePlanHourLocal = options?.rePlanHourLocal ?? DEFAULT_REPLAN_HOUR_LOCAL;
     const runPlan = options?.runPlan ?? ((zone, opts) => runScheduleForZone(zone, opts));
+    const getWeather = options?.getWeather ?? (async (zone: Zone): Promise<WeatherData> => {
+        if (!zone.location) throw new Error(`daemon: zone ${zone.id} has no location; cannot fetch weather.`);
+        return getWeatherData({
+            latitude: zone.location.lat,
+            longitude: zone.location.lon,
+            timezone: zone.siteTimezone,
+        });
+    });
     const openZone = options?.openZone ?? defaultOpenZone;
     const closeZone = options?.closeZone ?? defaultCloseZone;
     const getZoneState = options?.getZoneState ?? defaultGetZoneState;
@@ -174,9 +191,10 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     };
 
     // Private implementation. `isScheduledTick` distinguishes the nightly
-    // daemon-scheduled re-plan (which should persist projectedNextDepletionMm
-    // so tomorrow's plan starts honest) from operator-triggered replans (which
-    // must be idempotent and must not mutate zone state). See API-71.
+    // daemon-scheduled re-plan (which advances depletion from observed hourly
+    // weather since the last reconciliation, see API-79) from
+    // operator-triggered replans (which must be idempotent and must not
+    // mutate zone state). See API-71.
     const _rePlan = async (isScheduledTick: boolean): Promise<void> => {
         console.log(`daemon: re-plan starting (scheduled=${isScheduledTick}).`);
         registry.cancelOpenTimers(clock);
@@ -225,7 +243,34 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                     rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,
                     allowableDepletionFraction: activeSchedule.allowableDepletionFractionOverride ?? undefined,
                 };
-                const { entries, projectedNextDepletionMm } = await runPlan(zone, {
+                // Reality-derived depletion advance: sum hourly weather since
+                // the last reconciliation and apply (ET adds, rain subtracts).
+                // A null reconciledAt (fresh seed) is stamped without math —
+                // we have no anchor for the prior window, so the first tick
+                // calibrates the clock and subsequent ticks roll forward
+                // against a known boundary. See API-79.
+                const tickNow = clock.now();
+                const weather = await getWeather(zone);
+                let newDepletionMm = zone.currentDepletionMm;
+                let planningZone = zone;
+                if (isScheduledTick) {
+                    if (zone.currentDepletionReconciledAt) {
+                        const weatherDelta = sumHourlyWeatherBetween(
+                            weather.hourly, zone.currentDepletionReconciledAt, tickNow,
+                        );
+                        newDepletionMm = advanceFromObservedWeather({
+                            previousDepletionMm: zone.currentDepletionMm,
+                            weatherDelta,
+                        });
+                        console.log(`daemon: zone ${zone.id} weather advance — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
+                    } else {
+                        console.log(`daemon: zone ${zone.id} has null currentDepletionReconciledAt — stamping ${tickNow.toISOString()} without advancing depletion.`);
+                    }
+                    // Hand the planner the advanced depletion so it plans
+                    // from the same value we're about to persist.
+                    planningZone = { ...zone, currentDepletionMm: newDepletionMm, currentDepletionReconciledAt: tickNow };
+                }
+                const { entries } = await runPlan(planningZone, {
                     busyWindows: [pastWindow, ...busyWindows],
                     restrictions,
                     overrides,
@@ -234,11 +279,12 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                 const { cycles } = await scheduleEntriesRepo.replaceForZone(
                     zone.id, entries, today, activeSchedule.id,
                 );
-                // Only the nightly scheduled tick advances currentDepletionMm.
                 // Operator replans (isScheduledTick=false) are intentionally
-                // idempotent — they plan against current state without mutating it.
+                // idempotent — they plan against current state without
+                // mutating it. The scheduled tick writes the reality-derived
+                // depletion alongside the new reconciledAt anchor.
                 if (isScheduledTick) {
-                    await zonesRepo.advanceDepletion(zone.id, projectedNextDepletionMm, clock.now());
+                    await zonesRepo.advanceDepletion(zone.id, newDepletionMm, tickNow);
                 }
                 for (const cycle of cycles) {
                     const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -112,7 +112,7 @@ function recordingScheduleEntriesRepo(): { repo: ScheduleEntriesRepository; upda
     return { repo, updates };
 }
 
-function defaultRepos(scheduleEntries: ScheduleEntriesRepository, onAdvanceDepletion?: (zoneId: string, mm: number) => void): DaemonServiceRepos {
+function defaultRepos(scheduleEntries: ScheduleEntriesRepository, onAdvanceDepletion?: (zoneId: string, mm: number, reconciledAt: Date) => void): DaemonServiceRepos {
     return {
         zones: {
             loadEnabled: async () => [],
@@ -120,7 +120,7 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository, onAdvanceDeple
             count: async () => ({ total: 0, enabled: 0 }),
             loadJoinedRowsForSummary: async () => [],
             loadLatestFires: async () => [],
-            advanceDepletion: async (zoneId, mm) => { onAdvanceDepletion?.(zoneId, mm); },
+            advanceDepletion: async (zoneId, mm, reconciledAt) => { onAdvanceDepletion?.(zoneId, mm, reconciledAt); },
         },
         sites: { loadTimezone: async () => 'UTC' },
         schedules: {
@@ -244,14 +244,14 @@ describe('armCycle', () => {
         expect(calls.some(c => c.event === 'schedule-begun')).toBe(true);
     });
 
-    it('calls advanceDepletion(zone.id, 0) on the zones repo after the relay closes', async () => {
+    it('calls advanceDepletion(zone.id, 0, closedAt) on the zones repo after the relay closes', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
         const registry = new TimerRegistry();
         const { notifier } = recordingNotifier();
         const { alerter } = recordingAlerter();
         const { repo } = recordingScheduleEntriesRepo();
-        const depletionAdvances: Array<{ zoneId: string; mm: number }> = [];
-        setDaemonRepos({ repos: defaultRepos(repo, (zoneId, mm) => depletionAdvances.push({ zoneId, mm })) });
+        const depletionAdvances: Array<{ zoneId: string; mm: number; reconciledAt: Date }> = [];
+        setDaemonRepos({ repos: defaultRepos(repo, (zoneId, mm, reconciledAt) => depletionAdvances.push({ zoneId, mm, reconciledAt })) });
 
         armCycle({
             clock,
@@ -267,7 +267,9 @@ describe('armCycle', () => {
         await advanceTo(new Date('2026-05-04T13:05:01.000Z'));
 
         expect(depletionAdvances).toHaveLength(1);
-        expect(depletionAdvances[0]).toEqual({ zoneId: 'zone-depletion', mm: 0 });
+        expect(depletionAdvances[0]?.zoneId).toBe('zone-depletion');
+        expect(depletionAdvances[0]?.mm).toBe(0);
+        expect(depletionAdvances[0]?.reconciledAt).toBeInstanceOf(Date);
     });
 
     it('records HA open-failure alert and skips firedAt write on openZone error', async () => {

--- a/api/service/daemon/runtime.ts
+++ b/api/service/daemon/runtime.ts
@@ -234,7 +234,7 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
 
     const closedAt = clock.now();
     await getScheduleEntriesRepo().markCycleClosed(cycle.id, closedAt);
-    await getZonesRepo().advanceDepletion(zone.id, 0);
+    await getZonesRepo().advanceDepletion(zone.id, 0, closedAt);
     registry.clearInFlight(cycle.id);
     console.log(`daemon: closed zone ${zone.id} for cycle ${cycle.id} at ${closedAt.toISOString()}.`);
 


### PR DESCRIPTION
## Ticket

[API-79](http://192.168.2.100:7123/home/browse/API-79/) — Reconcile depletion from HA actuation history at sunrise+1, then replan.

## Summary

Replaces the daemon's projection-based depletion write (which assumed every scheduled cycle ran to completion) with two reality-anchored ticks:

- **Morning (sunrise+60min):** read HA actuation history for each zone, sum observed hourly weather since the last reconciliation, write `depletion = previous + ET − rain − applied_depth`. If HA history fetch fails, fall back to weather-only advance and raise an `actuation-stale` alert.
- **Evening (20:00 local):** advance depletion through observed hourly weather since the morning tick, then forward-plan tonight's cycles.

Both ticks write reality-derived depletion; neither writes the planner's projection. The morning tick runs even when irrigation is disabled (kill switch shouldn't suppress depletion accuracy); only the planning portion remains gated.

## Notable changes

- New `zones.current_depletion_reconciled_at` column anchors each tick's `[since, now)` window.
- New `actuation-stale` alert class for HA-history fetch failures.
- Open-Meteo request extended with `hourly=precipitation,et0_fao_evapotranspiration` and `past_days=1`; new `sumHourlyWeatherBetween` helper.
- New `getZoneActuationHistory` HA call with a pure `pairOnOffTransitions` parser (filters `unavailable`, clamps to window).
- Pure depletion math (`reconcileFromActuationHistory`, `advanceFromObservedWeather`) lives in `api/service/daemon/depletion/`.

## Test plan

- [x] `bun --cwd=./api run type-check` clean
- [x] `bun --cwd=./api test` — 876 passing (40 new, 2 rewritten)
- [ ] After deploy, inspect a zone row post-tick: `current_depletion_mm` matches observed-weather math; `current_depletion_reconciled_at` bumps each tick
- [ ] Daemon logs show two ticks per 24h (morning + evening) and the depletion advance values per zone
- [ ] Kill switch off: confirm depletion still advances; no cycles arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)