### PR TITLE
[API-80] Modularize service/daemon/index.ts

### DIFF
--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -432,81 +432,10 @@ function createDaemonReposStub(inputs?: DaemonStubInputs) {
 // Tests
 // ============================================================================
 
-describe('computeNextRePlanAt', () => {
-    it('UTC: returns todays hour when the current time is before that hour', () => {
-        const now = new Date('2026-05-04T01:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4, 'UTC');
-
-        expect(next.toISOString()).toBe('2026-05-04T04:00:00.000Z');
-    });
-
-    it('UTC: returns tomorrows hour when the current time is past todays hour', () => {
-        const now = new Date('2026-05-04T18:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4, 'UTC');
-
-        expect(next.toISOString()).toBe('2026-05-05T04:00:00.000Z');
-    });
-
-    it('UTC: returns tomorrows hour when the current time exactly matches todays hour', () => {
-        const now = new Date('2026-05-04T04:00:00.000Z');
-        const next = computeNextRePlanAt(now, 4, 'UTC');
-
-        expect(next.toISOString()).toBe('2026-05-05T04:00:00.000Z');
-    });
-
-    it('Edmonton MDT: maps local 04:00 to the correct UTC instant when now is before it', () => {
-        const now = new Date('2026-05-04T01:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
-
-        expect(next.toISOString()).toBe('2026-05-04T10:00:00.000Z');
-    });
-
-    it('Edmonton MDT: rolls to tomorrow when now is past local 04:00', () => {
-        const now = new Date('2026-05-04T18:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
-
-        expect(next.toISOString()).toBe('2026-05-05T10:00:00.000Z');
-    });
-
-    it('Edmonton MST: maps local 04:00 to the correct UTC instant outside DST', () => {
-        const now = new Date('2026-01-15T18:30:00.000Z');
-        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
-
-        expect(next.toISOString()).toBe('2026-01-16T11:00:00.000Z');
-    });
-});
-
-describe('computeNextMorningAt', () => {
-    it('returns sunrise + offset minutes when that instant is in the future', () => {
-        const now = new Date('2026-05-24T04:00:00.000Z');
-        const sunrise = new Date('2026-05-24T11:41:00.000Z');
-        const next = computeNextMorningAt(now, sunrise, 60);
-
-        expect(next?.toISOString()).toBe('2026-05-24T12:41:00.000Z');
-    });
-
-    it('returns null when sunrise is null (no anchor known yet)', () => {
-        const next = computeNextMorningAt(new Date('2026-05-24T04:00:00.000Z'), null, 60);
-
-        expect(next).toBeNull();
-    });
-
-    it('returns null when sunrise + offset is already in the past', () => {
-        const now = new Date('2026-05-24T18:00:00.000Z');
-        const sunrise = new Date('2026-05-24T11:41:00.000Z');
-        const next = computeNextMorningAt(now, sunrise, 60);
-
-        expect(next).toBeNull();
-    });
-
-    it('respects a non-default offset', () => {
-        const now = new Date('2026-05-24T04:00:00.000Z');
-        const sunrise = new Date('2026-05-24T11:41:00.000Z');
-        const next = computeNextMorningAt(now, sunrise, 30);
-
-        expect(next?.toISOString()).toBe('2026-05-24T12:11:00.000Z');
-    });
-});
+// `computeNextRePlanAt` and `computeNextMorningAt` are now tested in
+// service/daemon/scheduling/.test.ts (API-80). Their tests moved alongside
+// the pure functions; the daemon-level integration tests below exercise
+// them through the scheduler.
 
 describe('start', () => {
     // Default the system kill-switch to enabled for every test. Kill-switch

--- a/api/service/daemon/boot/.test.ts
+++ b/api/service/daemon/boot/.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import dayjs from 'dayjs';
+import type { Alerter, AlertEvent } from '@/alerts';
+import { createTestZone } from '@/mock/zone';
+import type { WeatherData, Zone } from '@/models';
+import type { Notifier } from '@/notifications';
+import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { ZonesRepository } from '@/repositories/zones';
+import { bootSystemService } from '@/service/system';
+import { runBootSequence, type BootDeps } from '.';
+import type { Clock, TimerHandle } from '../runtime';
+import { TimerRegistry } from '../runtime';
+
+const NOW = new Date('2026-05-04T12:00:00.000Z');
+
+function fakeClock(at: Date = NOW): Clock {
+    return {
+        now: () => at,
+        setTimeout: () => 1 as TimerHandle,
+        clearTimeout: () => {},
+    };
+}
+
+function noopNotifier(): Notifier {
+    return async () => {};
+}
+
+function recordingAlerter(): { alerter: Alerter; calls: AlertEvent[] } {
+    const calls: AlertEvent[] = [];
+    return { alerter: async (event) => { calls.push(event); }, calls };
+}
+
+function buildZonesRepo(zones: Zone[] = [], total = zones.length, enabled = zones.length): ZonesRepository {
+    return {
+        loadEnabled: async () => zones,
+        findById: async () => null,
+        count: async () => ({ total, enabled }),
+        loadJoinedRowsForSummary: async () => [],
+        loadLatestFires: async () => [],
+        advanceDepletion: async () => {},
+    };
+}
+
+function buildScheduleEntriesRepo(future: Awaited<ReturnType<ScheduleEntriesRepository['loadFutureCycles']>> = []): ScheduleEntriesRepository {
+    return {
+        loadFutureCycles: async () => future,
+        loadInFlightCycles: async () => [],
+        replaceForZone: async () => ({ cycles: [] }),
+        markCycleFired: async () => {},
+        markCycleClosed: async () => {},
+        findScheduledFromDate: async () => [],
+    };
+}
+
+function buildDeps(overrides: Partial<BootDeps> = {}): BootDeps {
+    return {
+        clock: fakeClock(),
+        registry: new TimerRegistry(),
+        notifier: noopNotifier(),
+        alerter: recordingAlerter().alerter,
+        openZone: async () => {},
+        closeZone: async () => {},
+        getZoneState: async () => 'off',
+        getWeather: async (): Promise<WeatherData> => ({ daily: [], hourly: [] }),
+        zonesRepo: buildZonesRepo(),
+        scheduleEntriesRepo: buildScheduleEntriesRepo(),
+        ...overrides,
+    };
+}
+
+describe('runBootSequence', () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        bootSystemService({
+            repo: {
+                findSingleton: async () => ({ irrigationEnabled: true, since: NOW }),
+                upsertSingleton: async () => {},
+            },
+        });
+        warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('seeds initialSunrise from the first enabled zone\'s weather fetch', async () => {
+        const sunrise = dayjs('2026-05-05T11:41:00Z');
+        const result = await runBootSequence({
+            morningTickMinutesAfterSunrise: 60,
+            deps: buildDeps({
+                zonesRepo: buildZonesRepo([createTestZone({ id: 'zone-001', location: { lat: 51, lon: -114 } })]),
+                getWeather: async () => ({ daily: [{ date: sunrise, sunrise }], hourly: [] }),
+            }),
+        });
+
+        expect(result.initialSunrise?.toISOString()).toBe('2026-05-05T11:41:00.000Z');
+    });
+
+    it('returns initialSunrise = null when the boot weather fetch throws (graceful degrade)', async () => {
+        const result = await runBootSequence({
+            morningTickMinutesAfterSunrise: 60,
+            deps: buildDeps({
+                zonesRepo: buildZonesRepo([createTestZone({ id: 'zone-001', location: { lat: 51, lon: -114 } })]),
+                getWeather: async () => { throw new Error('Open-Meteo down'); },
+            }),
+        });
+
+        expect(result.initialSunrise).toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('boot weather fetch failed'),
+            expect.any(Error),
+        );
+    });
+
+    it('returns initialSunrise = null when no enabled zone has a location', async () => {
+        const result = await runBootSequence({
+            morningTickMinutesAfterSunrise: 60,
+            deps: buildDeps({
+                zonesRepo: buildZonesRepo([createTestZone({ id: 'zone-001', location: undefined })]),
+            }),
+        });
+
+        expect(result.initialSunrise).toBeNull();
+    });
+
+    it('skips arming future cycles when the kill switch is off', async () => {
+        bootSystemService({
+            repo: {
+                findSingleton: async () => ({ irrigationEnabled: false, since: NOW }),
+                upsertSingleton: async () => {},
+            },
+        });
+        const opens: string[] = [];
+        const future = [{
+            cycle: { id: 'cycle-existing', startTime: new Date('2026-05-04T13:00:00.000Z'), durationMin: 60, entryDate: '2026-05-04' },
+            zone: createTestZone({ id: 'zone-001' }),
+        }];
+
+        await runBootSequence({
+            morningTickMinutesAfterSunrise: 60,
+            deps: buildDeps({
+                zonesRepo: buildZonesRepo([createTestZone({ id: 'zone-001' })]),
+                scheduleEntriesRepo: buildScheduleEntriesRepo(future),
+                openZone: async (z) => { opens.push(z.id); },
+            }),
+        });
+
+        expect(opens).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('skipping arm of 1 future cycle(s)'));
+    });
+
+    it('warns when there are zero zones to manage', async () => {
+        await runBootSequence({
+            morningTickMinutesAfterSunrise: 60,
+            deps: buildDeps({
+                zonesRepo: buildZonesRepo([], 0, 0),
+            }),
+        });
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('has no zones to manage'));
+    });
+
+    it('warns when zones exist but none are enabled', async () => {
+        await runBootSequence({
+            morningTickMinutesAfterSunrise: 60,
+            deps: buildDeps({
+                zonesRepo: buildZonesRepo([], 3, 0),
+            }),
+        });
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('all zones are disabled'));
+    });
+});

--- a/api/service/daemon/boot/index.ts
+++ b/api/service/daemon/boot/index.ts
@@ -1,0 +1,108 @@
+import type { Alerter } from '@/alerts';
+import type { ZoneRelayState } from '@/data/home-assistant';
+import type { WeatherData, Zone } from '@/models';
+import type { Notifier } from '@/notifications';
+import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { ZonesRepository } from '@/repositories/zones';
+import { getSystemState } from '@/service/system';
+import { reconcileCycleAndRelayState, type ReconcileSummary } from '../reconcile';
+import { armCloseOnly, armCycle, type Clock, type TimerRegistry } from '../runtime';
+import { pickUpcomingSunrise } from '../scheduling';
+
+/**
+ * Dependencies consumed by `runBootSequence`. Pulled into a single object
+ * so the boot orchestration has one parameter for collaborators.
+ */
+export type BootDeps = {
+    clock: Clock;
+    registry: TimerRegistry;
+    notifier: Notifier;
+    alerter: Alerter;
+    openZone: (zone: Zone) => Promise<void>;
+    closeZone: (zone: Zone) => Promise<void>;
+    getZoneState: (zone: Zone) => Promise<ZoneRelayState>;
+    getWeather: (zone: Zone) => Promise<WeatherData>;
+    zonesRepo: ZonesRepository;
+    scheduleEntriesRepo: ScheduleEntriesRepository;
+};
+
+export type RunBootSequenceInput = {
+    morningTickMinutesAfterSunrise: number;
+    deps: BootDeps;
+};
+
+export type RunBootSequenceResult = {
+    /**
+     * Sunrise instant to seed the morning-tick scheduler with. `null` when
+     * no boot weather fetch succeeded — `scheduleNextTick` will fall back to
+     * evening-only until the first in-tick fetch refreshes the anchor.
+     */
+    initialSunrise: Date | null;
+    enabledZonesAtBoot: Zone[];
+    reconcileSummary: ReconcileSummary;
+};
+
+/**
+ * Runs the daemon's boot sequence: relay/cycle reconciliation, future-cycle
+ * arming (gated by the kill switch), zone-count warnings, and the boot
+ * weather fetch that seeds the morning-tick anchor. Caller-owned mutable
+ * state (`latestKnownSunrise`) is updated from `initialSunrise` after this
+ * returns.
+ *
+ * Each side-effect is the same as the previous inline implementation in
+ * `start()`; this function just packages them so the boot path becomes one
+ * call instead of ~60 lines of imperative setup.
+ */
+export async function runBootSequence(input: RunBootSequenceInput): Promise<RunBootSequenceResult> {
+    const { morningTickMinutesAfterSunrise, deps } = input;
+    const { clock, registry, notifier, alerter, openZone, closeZone, getZoneState, getWeather, zonesRepo, scheduleEntriesRepo } = deps;
+
+    const enabledZonesAtBoot = await zonesRepo.loadEnabled();
+    const reconcileSummary = await reconcileCycleAndRelayState({
+        clock,
+        registry,
+        notifier,
+        alerter,
+        closeZone,
+        getZoneState,
+        armCloseOnly,
+        managedZones: enabledZonesAtBoot.filter(z => z.homeAssistantEntityId !== undefined),
+    });
+    console.log(`daemon: reconcile summary — resumed: ${reconcileSummary.resumed}, forcedClosed: ${reconcileSummary.forcedClosed}, missedClose: ${reconcileSummary.missedClose}, orphansClosed: ${reconcileSummary.orphansClosed}, errors: ${reconcileSummary.errors}.`);
+
+    const futureCycles = await scheduleEntriesRepo.loadFutureCycles(clock.now());
+    const systemAtBoot = await getSystemState();
+    if (!systemAtBoot.irrigationEnabled) {
+        console.warn(`daemon: system irrigation is disabled (since ${systemAtBoot.since}); skipping arm of ${futureCycles.length} future cycle(s).`);
+    } else {
+        for (const { cycle, zone } of futureCycles) {
+            armCycle({ clock, registry, zone, cycle, openZone, closeZone, notifier, alerter });
+        }
+    }
+
+    const { total, enabled } = await zonesRepo.count();
+    if (total === 0) {
+        console.warn('daemon: has no zones to manage. Did you run `bun run seed`? Daemon is idle until zones are added.');
+    } else if (enabled === 0) {
+        console.warn('daemon: all zones are disabled. Daemon is idle until at least one zone is enabled.');
+    }
+
+    // Boot weather fetch — seeds latestKnownSunrise so the first
+    // scheduleNextTick can pick a morning tick. Fire-and-forget tolerance:
+    // if the fetch fails, the daemon still boots and schedules an evening
+    // tick; the next successful fetch (per-zone, inside _rePlan) repopulates
+    // the anchor.
+    let initialSunrise: Date | null = null;
+    const bootSeedZone = enabledZonesAtBoot.find(z => z.location !== undefined);
+    if (bootSeedZone) {
+        try {
+            const bootWeather = await getWeather(bootSeedZone);
+            initialSunrise = pickUpcomingSunrise(bootWeather.daily, clock.now(), morningTickMinutesAfterSunrise);
+            console.log(`daemon: boot weather fetch ok — latestKnownSunrise=${initialSunrise?.toISOString() ?? 'null'}.`);
+        } catch (err) {
+            console.warn(`daemon: boot weather fetch failed; morning tick will be scheduled after the first successful in-tick fetch.`, err);
+        }
+    }
+
+    return { initialSunrise, enabledZonesAtBoot, reconcileSummary };
+}

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -17,12 +17,11 @@ import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { getSystemState } from '@/service/system';
-import { pickNextTick, pickUpcomingSunrise } from './scheduling';
+import { pickNextTick } from './scheduling';
 export { computeNextMorningAt, computeNextRePlanAt, type TickKind } from './scheduling';
 import { runTickForZone } from './tick';
-import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
+import { runBootSequence } from './boot';
 import {
-    armCloseOnly,
     armCycle,
     closeAllInFlight,
     realClock,
@@ -165,58 +164,21 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
 
     console.log(`daemon: starting (re-plan hour: ${rePlanHourLocal}:00 ${siteTimezone}).`);
 
-    const enabledZonesAtBoot = await zonesRepo.loadEnabled();
-    const reconcileSummary: ReconcileSummary = await reconcileCycleAndRelayState({
-        clock,
-        registry,
-        notifier,
-        alerter,
-        closeZone,
-        getZoneState,
-        armCloseOnly,
-        managedZones: enabledZonesAtBoot.filter(z => z.homeAssistantEntityId !== undefined),
+    const { initialSunrise } = await runBootSequence({
+        morningTickMinutesAfterSunrise,
+        deps: {
+            clock, registry, notifier, alerter,
+            openZone, closeZone, getZoneState, getWeather,
+            zonesRepo, scheduleEntriesRepo,
+        },
     });
-    console.log(`daemon: reconcile summary — resumed: ${reconcileSummary.resumed}, forcedClosed: ${reconcileSummary.forcedClosed}, missedClose: ${reconcileSummary.missedClose}, orphansClosed: ${reconcileSummary.orphansClosed}, errors: ${reconcileSummary.errors}.`);
-
-    const futureCycles = await scheduleEntriesRepo.loadFutureCycles(clock.now());
-    const systemAtBoot = await getSystemState();
-    if (!systemAtBoot.irrigationEnabled) {
-        console.warn(`daemon: system irrigation is disabled (since ${systemAtBoot.since}); skipping arm of ${futureCycles.length} future cycle(s).`);
-    } else {
-        for (const { cycle, zone } of futureCycles) {
-            armCycle({ clock, registry, zone, cycle, openZone, closeZone, notifier, alerter });
-        }
-    }
-
-    const { total, enabled } = await zonesRepo.count();
-    if (total === 0) {
-        console.warn('daemon: has no zones to manage. Did you run `bun run seed`? Daemon is idle until zones are added.');
-    } else if (enabled === 0) {
-        console.warn('daemon: all zones are disabled. Daemon is idle until at least one zone is enabled.');
-    }
 
     // Most-recently-observed sunrise instant in the site's timezone. Seeded
-    // by a boot-time weather fetch (cache-friendly — the first per-zone
+    // by the boot weather fetch (cache-friendly — the first per-zone
     // _rePlan call shares the cache) so the first scheduleNextTick can pick
     // between morning and evening. Updated inside _rePlan on every
     // subsequent successful weather fetch.
-    let latestKnownSunrise: Date | null = null;
-
-    // Boot weather fetch — seeds latestKnownSunrise so the first
-    // scheduleNextTick can pick a morning tick. Fire-and-forget tolerance:
-    // if the fetch fails, the daemon still boots and schedules an evening
-    // tick; the next successful fetch (per-zone, inside _rePlan) repopulates
-    // the anchor.
-    const bootSeedZone = enabledZonesAtBoot.find(z => z.location !== undefined);
-    if (bootSeedZone) {
-        try {
-            const bootWeather = await getWeather(bootSeedZone);
-            latestKnownSunrise = pickUpcomingSunrise(bootWeather.daily, clock.now(), morningTickMinutesAfterSunrise);
-            console.log(`daemon: boot weather fetch ok — latestKnownSunrise=${latestKnownSunrise?.toISOString() ?? 'null'}.`);
-        } catch (err) {
-            console.warn(`daemon: boot weather fetch failed; morning tick will be scheduled after the first successful in-tick fetch.`, err);
-        }
-    }
+    let latestKnownSunrise: Date | null = initialSunrise;
 
     const scheduleNextTick = (): void => {
         const { kind, at } = pickNextTick({

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
-import { clearAlertsByClass, noopAlerter, type Alerter } from '@/alerts';
+import { noopAlerter, type Alerter } from '@/alerts';
 import {
     closeZone as defaultCloseZone,
     getZoneActuationHistory as defaultGetZoneActuationHistory,
@@ -10,16 +10,16 @@ import {
     type ZoneActuationInterval,
     type ZoneRelayState,
 } from '@/data/home-assistant';
-import { getWeatherData, sumHourlyWeatherBetween } from '@/data/weather';
-import type { IrrigationScheduleEntry, WeatherData, Zone } from '@/models';
+import { getWeatherData } from '@/data/weather';
+import type { WeatherData, Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import { noopNotifier, type Notifier } from '@/notifications';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { getSystemState } from '@/service/system';
-import { advanceFromObservedWeather, reconcileFromActuationHistory } from './depletion';
-import { pickNextTick, pickUpcomingSunrise, type TickKind } from './scheduling';
+import { pickNextTick, pickUpcomingSunrise } from './scheduling';
 export { computeNextMorningAt, computeNextRePlanAt, type TickKind } from './scheduling';
+import { runTickForZone } from './tick';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
 import {
     armCloseOnly,
@@ -236,12 +236,18 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         registry.setRePlanHandle(handle);
     };
 
+    const tickDeps = {
+        clock, alerter,
+        runPlan, getWeather, getZoneActuationHistory,
+        zonesRepo, scheduleEntriesRepo, weatherStateRepo, getAlertsDb,
+    };
+
     // Private implementation. `isScheduledTick` distinguishes the nightly
     // daemon-scheduled re-plan (which writes a reality-derived depletion via
     // the morning HA-history or evening observed-weather path, see API-79)
     // from operator-triggered replans (idempotent, no zone mutation; see
     // API-71). `tickKind` selects morning vs. evening math.
-    const _rePlan = async (tickKind: TickKind, isScheduledTick: boolean): Promise<void> => {
+    const _rePlan = async (tickKind: 'morning' | 'evening', isScheduledTick: boolean): Promise<void> => {
         console.log(`daemon: re-plan starting (kind=${tickKind}, scheduled=${isScheduledTick}).`);
         registry.cancelOpenTimers(clock);
 
@@ -270,132 +276,21 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         const cyclesToArm: Array<{ zone: Zone; cycle: PersistedCycle }> = [];
 
         for (const zone of enabledZones) {
-            const activeSchedule = activeSchedulesBySite.get(zone.siteId);
-
-            try {
-                // Reality-derived depletion advance. Morning ticks reconcile
-                // against actual HA actuation history (subtracts applied
-                // depth); evening ticks advance through observed weather only
-                // (no irrigation has fired since the morning anchor). A null
-                // reconciledAt (fresh seed) is stamped without math — first
-                // tick calibrates the clock, subsequent ticks roll forward.
-                // See API-79.
-                const tickNow = clock.now();
-                const weather = await getWeather(zone);
-                // Refresh the morning-tick anchor with the soonest upcoming
-                // sunrise still inside the offset window.
-                const upcoming = pickUpcomingSunrise(weather.daily, tickNow, morningTickMinutesAfterSunrise);
-                if (upcoming) latestKnownSunrise = upcoming;
-
-                let newDepletionMm = zone.currentDepletionMm;
-                if (isScheduledTick) {
-                    if (zone.currentDepletionReconciledAt) {
-                        const weatherDelta = sumHourlyWeatherBetween(
-                            weather.hourly, zone.currentDepletionReconciledAt, tickNow,
-                        );
-                        if (tickKind === 'morning') {
-                            let history: ZoneActuationInterval[] = [];
-                            try {
-                                history = await getZoneActuationHistory(zone, zone.currentDepletionReconciledAt, tickNow);
-                            } catch (err) {
-                                const reason = err instanceof Error ? err.message : String(err);
-                                console.error(`daemon: HA actuation history fetch failed for zone ${zone.id}; falling through to weather-only advance.`, err);
-                                await alerter({
-                                    class: 'actuation-stale',
-                                    tone: 'warn',
-                                    title: 'HA actuation history stale',
-                                    sub: `Depletion advanced from weather only. Last fetch error: ${reason}.`,
-                                    zoneId: zone.id,
-                                    zoneName: zone.name,
-                                });
-                            }
-                            const result = reconcileFromActuationHistory({
-                                previousDepletionMm: zone.currentDepletionMm,
-                                weatherDelta,
-                                history,
-                                precipitationRateMmPerHr: zone.precipitationRateMmPerHr,
-                            });
-                            newDepletionMm = result.newDepletionMm;
-                            console.log(`daemon: zone ${zone.id} morning reconcile — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, applied=${result.appliedDepthMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
-                        } else {
-                            newDepletionMm = advanceFromObservedWeather({
-                                previousDepletionMm: zone.currentDepletionMm,
-                                weatherDelta,
-                            });
-                            console.log(`daemon: zone ${zone.id} evening weather advance — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
-                        }
-                    } else {
-                        console.log(`daemon: zone ${zone.id} has null currentDepletionReconciledAt — stamping ${tickNow.toISOString()} without advancing depletion.`);
-                    }
-                    // Persist the reality-derived depletion + the new anchor
-                    // immediately. Planning runs afterward; if it skips (kill
-                    // switch off, no active schedule), the reconciliation
-                    // still landed.
-                    await zonesRepo.advanceDepletion(zone.id, newDepletionMm, tickNow);
-                }
-
-                // Successful weather fetch — refresh the staleness timestamp
-                // and clear any lingering unacked weather-stale alert.
-                const alertsDb = getAlertsDb();
-                await Promise.all([
-                    weatherStateRepo.markFetchSuccessful(clock.now()),
-                    alertsDb ? clearAlertsByClass(alertsDb, 'weather-stale') : Promise.resolve(),
-                ]);
-
-                // Planning + arming portion. Skipped when irrigation is
-                // disabled (kill switch off) or the zone's site has no
-                // active schedule.
-                if (!irrigationEnabled) continue;
-                if (!activeSchedule) {
-                    console.warn(`daemon: no active schedule for site ${zone.siteId} — skipping plan/arm of zone ${zone.id} (${zone.name}).`);
-                    continue;
-                }
-
-                const restrictions = {
-                    allowedDays: activeSchedule.allowedDays,
-                    allowedTimeWindows: activeSchedule.allowedTimeWindows,
-                    endBySunrise: activeSchedule.endBySunrise ?? false,
-                    skippedNightDate: activeSchedule.skippedNightDate ?? null,
-                };
-                const overrides = {
-                    rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,
-                    allowableDepletionFraction: activeSchedule.allowableDepletionFractionOverride ?? undefined,
-                };
-                const planningZone = isScheduledTick
-                    ? { ...zone, currentDepletionMm: newDepletionMm, currentDepletionReconciledAt: tickNow }
-                    : zone;
-                const { entries } = await runPlan(planningZone, {
-                    busyWindows: [pastWindow, ...busyWindows],
-                    restrictions,
-                    overrides,
-                    forecastDays: 14,
-                });
-                const { cycles } = await scheduleEntriesRepo.replaceForZone(
-                    zone.id, entries, today, activeSchedule.id,
-                );
-                for (const cycle of cycles) {
-                    const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);
-                    const overlaps = busyWindows.some(w => cycle.startTime < w.end && cycleEnd > w.start);
-                    if (overlaps) {
-                        console.warn(`daemon: cycle ${cycle.id} for zone ${zone.id} (${zone.name}) overlaps a busy window — not arming.`);
-                        continue;
-                    }
-                    cyclesToArm.push({ zone, cycle });
-                    busyWindows.push({ start: cycle.startTime, end: cycleEnd });
-                }
-            } catch (err) {
-                const reason = err instanceof Error ? err.message : String(err);
-                console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
-                if (await weatherStateRepo.isStale(clock.now())) {
-                    await alerter({
-                        class: 'weather-stale',
-                        tone: 'warn',
-                        title: 'Weather API stale',
-                        sub: `Planner using fallback ET zero. Last fetch error: ${reason}.`,
-                        zoneName: zone.name,
-                    });
-                }
-            }
+            const result = await runTickForZone({
+                zone,
+                activeSchedule: activeSchedulesBySite.get(zone.siteId),
+                today,
+                busyWindows,
+                pastWindow,
+                tickKind,
+                isScheduledTick,
+                irrigationEnabled,
+                morningTickMinutesAfterSunrise,
+                deps: tickDeps,
+            });
+            if (result.observedSunrise) latestKnownSunrise = result.observedSunrise;
+            cyclesToArm.push(...result.cyclesToArm);
+            busyWindows.push(...result.newBusyWindows);
         }
 
         armCyclesWithScheduleMarkers(cyclesToArm, siteTimezone, ({ zone, cycle, scheduleStart, scheduleEnd }) => {

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -18,6 +18,8 @@ import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules'
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { getSystemState } from '@/service/system';
 import { advanceFromObservedWeather, reconcileFromActuationHistory } from './depletion';
+import { pickNextTick, pickUpcomingSunrise, type TickKind } from './scheduling';
+export { computeNextMorningAt, computeNextRePlanAt, type TickKind } from './scheduling';
 import { reconcileCycleAndRelayState, type ReconcileSummary } from './reconcile';
 import {
     armCloseOnly,
@@ -96,14 +98,6 @@ export type DaemonOptions = {
     notifier?: Notifier;
     alerter?: Alerter;
 };
-
-/**
- * Distinguishes the daemon's two scheduled ticks. The morning tick
- * (~sunrise+60min) reconciles depletion against actual HA actuation history
- * for the prior night; the evening tick (20:00 local) advances depletion
- * through the day's observed weather and forward-plans tonight's cycles.
- */
-type TickKind = 'morning' | 'evening';
 
 const DEFAULT_MORNING_TICK_MINUTES_AFTER_SUNRISE = 60;
 
@@ -208,18 +202,6 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     // subsequent successful weather fetch.
     let latestKnownSunrise: Date | null = null;
 
-    // Picks the soonest sunrise from a `daily` array whose `sunrise+offset`
-    // is still in the future relative to `at`. Returns null if no entry
-    // qualifies (e.g. the last day of the horizon already morning-ticked).
-    const pickUpcomingSunrise = (daily: ReadonlyArray<{ sunrise?: dayjs.Dayjs }>, at: Date): Date | null => {
-        const thresholdMs = at.getTime() - morningTickMinutesAfterSunrise * 60_000;
-        for (const day of daily) {
-            const candidate = day.sunrise?.toDate();
-            if (candidate && candidate.getTime() > thresholdMs) return candidate;
-        }
-        return null;
-    };
-
     // Boot weather fetch — seeds latestKnownSunrise so the first
     // scheduleNextTick can pick a morning tick. Fire-and-forget tolerance:
     // if the fetch fails, the daemon still boots and schedules an evening
@@ -229,7 +211,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     if (bootSeedZone) {
         try {
             const bootWeather = await getWeather(bootSeedZone);
-            latestKnownSunrise = pickUpcomingSunrise(bootWeather.daily, clock.now());
+            latestKnownSunrise = pickUpcomingSunrise(bootWeather.daily, clock.now(), morningTickMinutesAfterSunrise);
             console.log(`daemon: boot weather fetch ok — latestKnownSunrise=${latestKnownSunrise?.toISOString() ?? 'null'}.`);
         } catch (err) {
             console.warn(`daemon: boot weather fetch failed; morning tick will be scheduled after the first successful in-tick fetch.`, err);
@@ -237,13 +219,15 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     }
 
     const scheduleNextTick = (): void => {
-        const now = clock.now();
-        const nextEvening = computeNextRePlanAt(now, rePlanHourLocal, siteTimezone);
-        const nextMorning = computeNextMorningAt(now, latestKnownSunrise, morningTickMinutesAfterSunrise);
-        const next = nextMorning !== null && nextMorning.getTime() < nextEvening.getTime() ? nextMorning : nextEvening;
-        const kind: TickKind = next === nextMorning ? 'morning' : 'evening';
-        const delay = Math.max(0, next.getTime() - now.getTime());
-        console.log(`daemon: next tick (${kind}) scheduled at ${next.toISOString()} (${delay}ms from now).`);
+        const { kind, at } = pickNextTick({
+            now: clock.now(),
+            eveningHourLocal: rePlanHourLocal,
+            siteTimezone,
+            latestKnownSunrise,
+            morningOffsetMinutes: morningTickMinutesAfterSunrise,
+        });
+        const delay = Math.max(0, at.getTime() - clock.now().getTime());
+        console.log(`daemon: next tick (${kind}) scheduled at ${at.toISOString()} (${delay}ms from now).`);
         const handle = clock.setTimeout(() => {
             _rePlan(kind, true).catch(err => {
                 console.error('daemon: unhandled error in scheduled re-plan.', err);
@@ -300,7 +284,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
                 const weather = await getWeather(zone);
                 // Refresh the morning-tick anchor with the soonest upcoming
                 // sunrise still inside the offset window.
-                const upcoming = pickUpcomingSunrise(weather.daily, tickNow);
+                const upcoming = pickUpcomingSunrise(weather.daily, tickNow, morningTickMinutesAfterSunrise);
                 if (upcoming) latestKnownSunrise = upcoming;
 
                 let newDepletionMm = zone.currentDepletionMm;
@@ -448,32 +432,6 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     return { rePlan, shutdown, getStatus };
 }
 
-/**
- * Returns the next wall-clock occurrence of `hourLocal:00` after `now`,
- * resolved against the supplied IANA timezone. Pure function exported so the
- * scheduling math is unit-testable directly.
- */
-export function computeNextRePlanAt(now: Date, hourLocal: number, tz: string): Date {
-    const ref = dayjs(now).tz(tz);
-    const todayAtHour = ref.hour(hourLocal).minute(0).second(0).millisecond(0);
-    const next = todayAtHour.isAfter(ref) ? todayAtHour : todayAtHour.add(1, 'day');
-    return next.toDate();
-}
-
-/**
- * Returns `sunrise + offsetMinutes` if that instant is still in the future
- * relative to `now`; otherwise `null`. Used by `scheduleNextTick` to pick
- * between the morning reconciliation tick and the evening forward-plan tick.
- * When the latest known sunrise has already passed (or no sunrise has been
- * observed yet), the daemon falls back to scheduling the evening tick only,
- * and the next successful weather fetch refreshes the morning anchor.
- */
-export function computeNextMorningAt(now: Date, sunrise: Date | null, offsetMinutes: number): Date | null {
-    if (sunrise === null) return null;
-    const candidate = new Date(sunrise.getTime() + offsetMinutes * 60_000);
-    if (candidate.getTime() <= now.getTime()) return null;
-    return candidate;
-}
 
 /**
  * Tagged cycle ready for `armCycle`. Marker fields decide whether the runtime

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -21,14 +21,14 @@ import { pickNextTick } from './scheduling';
 export { computeNextMorningAt, computeNextRePlanAt, type TickKind } from './scheduling';
 import { runTickForZone } from './tick';
 import { runBootSequence } from './boot';
+import { armCyclesWithScheduleMarkers } from './markers';
+export { type ArmableCycle, armCyclesWithScheduleMarkers } from './markers';
 import {
     armCycle,
     closeAllInFlight,
     realClock,
     TimerRegistry,
     type Clock,
-    type ScheduleEndMarker,
-    type ScheduleStartMarker,
 } from './runtime';
 import {
     getAlertsDb,
@@ -287,72 +287,4 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     });
 
     return { rePlan, shutdown, getStatus };
-}
-
-
-/**
- * Tagged cycle ready for `armCycle`. Marker fields decide whether the runtime
- * emits `schedule-begun` / `schedule-ended` after the cycle's open/close.
- */
-export type ArmableCycle = {
-    zone: Zone;
-    cycle: PersistedCycle;
-    scheduleStart?: ScheduleStartMarker;
-    scheduleEnd?: ScheduleEndMarker;
-};
-
-/**
- * Groups cycles by their `entryDate` (one entry-date = one irrigation
- * night), sorts each group by start time, and tags the earliest cycle of
- * each group with `scheduleStart` and the latest with `scheduleEnd`.
- */
-export function armCyclesWithScheduleMarkers(
-    cyclesToArm: ReadonlyArray<{ zone: Zone; cycle: PersistedCycle }>,
-    siteTimezone: string,
-    arm: (input: ArmableCycle) => void,
-): void {
-    if (cyclesToArm.length === 0) return;
-
-    const byNight = new Map<string, Array<{ zone: Zone; cycle: PersistedCycle }>>();
-    for (const c of cyclesToArm) {
-        const group = byNight.get(c.cycle.entryDate) ?? [];
-        group.push(c);
-        byNight.set(c.cycle.entryDate, group);
-    }
-
-    const nights = [...byNight.keys()].sort();
-    for (const group of byNight.values()) {
-        group.sort((a, b) => a.cycle.startTime.getTime() - b.cycle.startTime.getTime());
-    }
-
-    for (let i = 0; i < nights.length; i++) {
-        const night = nights[i]!;
-        const group = byNight.get(night)!;
-        const first = group[0]!;
-        const last = group[group.length - 1]!;
-
-        const perZoneRuntimeMin: Record<string, number> = {};
-        for (const { zone, cycle } of group) {
-            perZoneRuntimeMin[zone.name] = (perZoneRuntimeMin[zone.name] ?? 0) + cycle.durationMin;
-        }
-
-        const nextNight = i + 1 < nights.length ? byNight.get(nights[i + 1]!) : undefined;
-        const nextFirst = nextNight?.[0];
-        const scheduleEnd: ScheduleEndMarker = {
-            scheduleNight: night,
-            perZoneRuntimeMin,
-            siteTimezone,
-            ...(nextFirst ? { nextIrrigation: { zoneName: nextFirst.zone.name, startTime: nextFirst.cycle.startTime } } : {}),
-        };
-        const scheduleStart: ScheduleStartMarker = { scheduleNight: night };
-
-        for (const item of group) {
-            arm({
-                zone: item.zone,
-                cycle: item.cycle,
-                ...(item === first ? { scheduleStart } : {}),
-                ...(item === last ? { scheduleEnd } : {}),
-            });
-        }
-    }
 }

--- a/api/service/daemon/markers/index.ts
+++ b/api/service/daemon/markers/index.ts
@@ -1,0 +1,70 @@
+import type { Zone } from '@/models';
+import type { PersistedCycle } from '@/models/cycle';
+import type { ScheduleEndMarker, ScheduleStartMarker } from '../runtime';
+
+/**
+ * Tagged cycle ready for `armCycle`. Marker fields decide whether the runtime
+ * emits `schedule-begun` / `schedule-ended` after the cycle's open/close.
+ */
+export type ArmableCycle = {
+    zone: Zone;
+    cycle: PersistedCycle;
+    scheduleStart?: ScheduleStartMarker;
+    scheduleEnd?: ScheduleEndMarker;
+};
+
+/**
+ * Groups cycles by their `entryDate` (one entry-date = one irrigation
+ * night), sorts each group by start time, and tags the earliest cycle of
+ * each group with `scheduleStart` and the latest with `scheduleEnd`.
+ */
+export function armCyclesWithScheduleMarkers(
+    cyclesToArm: ReadonlyArray<{ zone: Zone; cycle: PersistedCycle }>,
+    siteTimezone: string,
+    arm: (input: ArmableCycle) => void,
+): void {
+    if (cyclesToArm.length === 0) return;
+
+    const byNight = new Map<string, Array<{ zone: Zone; cycle: PersistedCycle }>>();
+    for (const c of cyclesToArm) {
+        const group = byNight.get(c.cycle.entryDate) ?? [];
+        group.push(c);
+        byNight.set(c.cycle.entryDate, group);
+    }
+
+    const nights = [...byNight.keys()].sort();
+    for (const group of byNight.values()) {
+        group.sort((a, b) => a.cycle.startTime.getTime() - b.cycle.startTime.getTime());
+    }
+
+    for (let i = 0; i < nights.length; i++) {
+        const night = nights[i]!;
+        const group = byNight.get(night)!;
+        const first = group[0]!;
+        const last = group[group.length - 1]!;
+
+        const perZoneRuntimeMin: Record<string, number> = {};
+        for (const { zone, cycle } of group) {
+            perZoneRuntimeMin[zone.name] = (perZoneRuntimeMin[zone.name] ?? 0) + cycle.durationMin;
+        }
+
+        const nextNight = i + 1 < nights.length ? byNight.get(nights[i + 1]!) : undefined;
+        const nextFirst = nextNight?.[0];
+        const scheduleEnd: ScheduleEndMarker = {
+            scheduleNight: night,
+            perZoneRuntimeMin,
+            siteTimezone,
+            ...(nextFirst ? { nextIrrigation: { zoneName: nextFirst.zone.name, startTime: nextFirst.cycle.startTime } } : {}),
+        };
+        const scheduleStart: ScheduleStartMarker = { scheduleNight: night };
+
+        for (const item of group) {
+            arm({
+                zone: item.zone,
+                cycle: item.cycle,
+                ...(item === first ? { scheduleStart } : {}),
+                ...(item === last ? { scheduleEnd } : {}),
+            });
+        }
+    }
+}

--- a/api/service/daemon/scheduling/.test.ts
+++ b/api/service/daemon/scheduling/.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'bun:test';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import { computeNextMorningAt, computeNextRePlanAt, pickNextTick, pickUpcomingSunrise } from '.';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+describe('computeNextRePlanAt', () => {
+    it('UTC: returns todays hour when the current time is before that hour', () => {
+        const now = new Date('2026-05-04T01:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'UTC');
+
+        expect(next.toISOString()).toBe('2026-05-04T04:00:00.000Z');
+    });
+
+    it('UTC: returns tomorrows hour when the current time is past todays hour', () => {
+        const now = new Date('2026-05-04T18:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'UTC');
+
+        expect(next.toISOString()).toBe('2026-05-05T04:00:00.000Z');
+    });
+
+    it('UTC: returns tomorrows hour when the current time exactly matches todays hour', () => {
+        const now = new Date('2026-05-04T04:00:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'UTC');
+
+        expect(next.toISOString()).toBe('2026-05-05T04:00:00.000Z');
+    });
+
+    it('Edmonton MDT: maps local 04:00 to the correct UTC instant when now is before it', () => {
+        const now = new Date('2026-05-04T01:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
+
+        expect(next.toISOString()).toBe('2026-05-04T10:00:00.000Z');
+    });
+
+    it('Edmonton MDT: rolls to tomorrow when now is past local 04:00', () => {
+        const now = new Date('2026-05-04T18:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
+
+        expect(next.toISOString()).toBe('2026-05-05T10:00:00.000Z');
+    });
+
+    it('Edmonton MST: maps local 04:00 to the correct UTC instant outside DST', () => {
+        const now = new Date('2026-01-15T18:30:00.000Z');
+        const next = computeNextRePlanAt(now, 4, 'America/Edmonton');
+
+        expect(next.toISOString()).toBe('2026-01-16T11:00:00.000Z');
+    });
+});
+
+describe('computeNextMorningAt', () => {
+    it('returns sunrise + offset minutes when that instant is in the future', () => {
+        const now = new Date('2026-05-24T04:00:00.000Z');
+        const sunrise = new Date('2026-05-24T11:41:00.000Z');
+        const next = computeNextMorningAt(now, sunrise, 60);
+
+        expect(next?.toISOString()).toBe('2026-05-24T12:41:00.000Z');
+    });
+
+    it('returns null when sunrise is null (no anchor known yet)', () => {
+        const next = computeNextMorningAt(new Date('2026-05-24T04:00:00.000Z'), null, 60);
+
+        expect(next).toBeNull();
+    });
+
+    it('returns null when sunrise + offset is already in the past', () => {
+        const now = new Date('2026-05-24T18:00:00.000Z');
+        const sunrise = new Date('2026-05-24T11:41:00.000Z');
+        const next = computeNextMorningAt(now, sunrise, 60);
+
+        expect(next).toBeNull();
+    });
+
+    it('respects a non-default offset', () => {
+        const now = new Date('2026-05-24T04:00:00.000Z');
+        const sunrise = new Date('2026-05-24T11:41:00.000Z');
+        const next = computeNextMorningAt(now, sunrise, 30);
+
+        expect(next?.toISOString()).toBe('2026-05-24T12:11:00.000Z');
+    });
+});
+
+describe('pickUpcomingSunrise', () => {
+    it('returns null for an empty daily array', () => {
+        const result = pickUpcomingSunrise([], new Date('2026-05-24T04:00:00Z'), 60);
+
+        expect(result).toBeNull();
+    });
+
+    it('returns the first sunrise whose +offset is still in the future', () => {
+        const daily = [
+            { sunrise: dayjs('2026-05-24T11:41:00Z') },
+            { sunrise: dayjs('2026-05-25T11:40:00Z') },
+        ];
+        const at = new Date('2026-05-24T04:00:00Z');
+
+        const result = pickUpcomingSunrise(daily, at, 60);
+
+        expect(result?.toISOString()).toBe('2026-05-24T11:41:00.000Z');
+    });
+
+    it('skips a past sunrise and falls through to tomorrows', () => {
+        const daily = [
+            { sunrise: dayjs('2026-05-24T11:41:00Z') }, // 11:41 + 60 = 12:41 — already past at 18:00
+            { sunrise: dayjs('2026-05-25T11:40:00Z') },
+        ];
+        const at = new Date('2026-05-24T18:00:00Z');
+
+        const result = pickUpcomingSunrise(daily, at, 60);
+
+        expect(result?.toISOString()).toBe('2026-05-25T11:40:00.000Z');
+    });
+
+    it('returns null when all sunrises are in the past', () => {
+        const daily = [
+            { sunrise: dayjs('2026-05-23T11:41:00Z') },
+            { sunrise: dayjs('2026-05-24T11:41:00Z') },
+        ];
+        const at = new Date('2026-05-24T18:00:00Z');
+
+        const result = pickUpcomingSunrise(daily, at, 60);
+
+        expect(result).toBeNull();
+    });
+
+    it('honours the offset threshold exactly (boundary)', () => {
+        const sunrise = dayjs('2026-05-24T11:41:00Z');
+        const daily = [{ sunrise }];
+
+        // sunrise+60min = 12:41. At exactly 12:41 the candidate should NOT
+        // qualify (the past-or-equal check uses `<=`).
+        const atEqual = new Date('2026-05-24T12:41:00.000Z');
+        expect(pickUpcomingSunrise(daily, atEqual, 60)).toBeNull();
+
+        // One millisecond earlier — still in the future.
+        const atJustBefore = new Date('2026-05-24T12:40:59.999Z');
+        expect(pickUpcomingSunrise(daily, atJustBefore, 60)?.toISOString()).toBe('2026-05-24T11:41:00.000Z');
+    });
+
+    it('ignores entries with no sunrise field', () => {
+        const daily = [
+            {},
+            { sunrise: dayjs('2026-05-24T11:41:00Z') },
+        ];
+
+        const result = pickUpcomingSunrise(daily, new Date('2026-05-24T04:00:00Z'), 60);
+
+        expect(result?.toISOString()).toBe('2026-05-24T11:41:00.000Z');
+    });
+});
+
+describe('pickNextTick', () => {
+    it('returns morning when the morning tick fires before the next evening', () => {
+        const result = pickNextTick({
+            now: new Date('2026-05-04T04:00:00Z'),
+            eveningHourLocal: 20,
+            siteTimezone: 'UTC',
+            latestKnownSunrise: new Date('2026-05-04T11:41:00Z'),
+            morningOffsetMinutes: 60,
+        });
+
+        expect(result.kind).toBe('morning');
+        expect(result.at.toISOString()).toBe('2026-05-04T12:41:00.000Z');
+    });
+
+    it('returns evening when no sunrise anchor is known', () => {
+        const result = pickNextTick({
+            now: new Date('2026-05-04T04:00:00Z'),
+            eveningHourLocal: 20,
+            siteTimezone: 'UTC',
+            latestKnownSunrise: null,
+            morningOffsetMinutes: 60,
+        });
+
+        expect(result.kind).toBe('evening');
+        expect(result.at.toISOString()).toBe('2026-05-04T20:00:00.000Z');
+    });
+
+    it('returns evening when the morning tick has already passed', () => {
+        const result = pickNextTick({
+            now: new Date('2026-05-04T15:00:00Z'),
+            eveningHourLocal: 20,
+            siteTimezone: 'UTC',
+            latestKnownSunrise: new Date('2026-05-04T11:41:00Z'),
+            morningOffsetMinutes: 60,
+        });
+
+        expect(result.kind).toBe('evening');
+        expect(result.at.toISOString()).toBe('2026-05-04T20:00:00.000Z');
+    });
+
+    it('returns morning when the evening tick is later than the next morning', () => {
+        // After 20:00 the next evening tick is tomorrow. If tomorrow's
+        // morning tick fires before tomorrow's evening, morning wins.
+        const result = pickNextTick({
+            now: new Date('2026-05-04T21:00:00Z'),
+            eveningHourLocal: 20,
+            siteTimezone: 'UTC',
+            latestKnownSunrise: new Date('2026-05-05T11:41:00Z'),
+            morningOffsetMinutes: 60,
+        });
+
+        expect(result.kind).toBe('morning');
+        expect(result.at.toISOString()).toBe('2026-05-05T12:41:00.000Z');
+    });
+});

--- a/api/service/daemon/scheduling/index.ts
+++ b/api/service/daemon/scheduling/index.ts
@@ -1,0 +1,90 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * Distinguishes the daemon's two scheduled ticks. The morning tick
+ * (~sunrise+60min) reconciles depletion against actual HA actuation history
+ * for the prior night; the evening tick (20:00 local) advances depletion
+ * through the day's observed weather and forward-plans tonight's cycles.
+ */
+export type TickKind = 'morning' | 'evening';
+
+/**
+ * Returns the next wall-clock occurrence of `hourLocal:00` after `now`,
+ * resolved against the supplied IANA timezone. Pure function so the
+ * scheduling math is unit-testable directly.
+ */
+export function computeNextRePlanAt(now: Date, hourLocal: number, tz: string): Date {
+    const ref = dayjs(now).tz(tz);
+    const todayAtHour = ref.hour(hourLocal).minute(0).second(0).millisecond(0);
+    const next = todayAtHour.isAfter(ref) ? todayAtHour : todayAtHour.add(1, 'day');
+    return next.toDate();
+}
+
+/**
+ * Returns `sunrise + offsetMinutes` if that instant is still in the future
+ * relative to `now`; otherwise `null`. Used by `pickNextTick` to decide
+ * whether the next scheduled fire is the morning reconciliation tick or
+ * the evening forward-plan tick. When the latest known sunrise has already
+ * passed (or no sunrise has been observed yet), the daemon falls back to
+ * scheduling the evening tick only, and the next successful weather fetch
+ * refreshes the morning anchor.
+ */
+export function computeNextMorningAt(now: Date, sunrise: Date | null, offsetMinutes: number): Date | null {
+    if (sunrise === null) return null;
+    const candidate = new Date(sunrise.getTime() + offsetMinutes * 60_000);
+    if (candidate.getTime() <= now.getTime()) return null;
+    return candidate;
+}
+
+/**
+ * Picks the soonest sunrise from a daily-weather array whose
+ * `sunrise + offsetMinutes` is still in the future relative to `at`. Returns
+ * `null` if no entry qualifies (e.g. the last day of the horizon already
+ * morning-ticked). Pure — used by both the boot weather seed and the
+ * per-tick weather refresh to update the morning-tick anchor.
+ */
+export function pickUpcomingSunrise(
+    daily: ReadonlyArray<{ sunrise?: dayjs.Dayjs }>,
+    at: Date,
+    offsetMinutes: number,
+): Date | null {
+    const thresholdMs = at.getTime() - offsetMinutes * 60_000;
+    for (const day of daily) {
+        const candidate = day.sunrise?.toDate();
+        if (candidate && candidate.getTime() > thresholdMs) return candidate;
+    }
+    return null;
+}
+
+/**
+ * Inputs for `pickNextTick`. The daemon supplies its current state and the
+ * function returns the next tick's kind and wall-clock time. No side
+ * effects — the caller is responsible for installing the timer.
+ */
+export type PickNextTickInput = {
+    now: Date;
+    eveningHourLocal: number;
+    siteTimezone: string;
+    latestKnownSunrise: Date | null;
+    morningOffsetMinutes: number;
+};
+
+/**
+ * Returns the soonest of (next morning tick, next evening tick), tagged with
+ * its kind. Morning is null until a weather fetch has populated
+ * `latestKnownSunrise`, in which case evening is always picked.
+ */
+export function pickNextTick(input: PickNextTickInput): { kind: TickKind; at: Date } {
+    const { now, eveningHourLocal, siteTimezone, latestKnownSunrise, morningOffsetMinutes } = input;
+    const nextEvening = computeNextRePlanAt(now, eveningHourLocal, siteTimezone);
+    const nextMorning = computeNextMorningAt(now, latestKnownSunrise, morningOffsetMinutes);
+    if (nextMorning !== null && nextMorning.getTime() < nextEvening.getTime()) {
+        return { kind: 'morning', at: nextMorning };
+    }
+    return { kind: 'evening', at: nextEvening };
+}

--- a/api/service/daemon/tick/.test.ts
+++ b/api/service/daemon/tick/.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from 'bun:test';
+import dayjs from 'dayjs';
+import type { AlertEvent, Alerter, AlertsDb } from '@/alerts';
+import type { ZoneActuationInterval } from '@/data/home-assistant';
+import { createTestZone } from '@/mock/zone';
+import type { HourlyWeather, WeatherData, Zone } from '@/models';
+import type { PersistedCycle } from '@/models/cycle';
+import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { Schedule } from '@/repositories/schedules';
+import type { WeatherStateRepository } from '@/repositories/weather-state';
+import type { ZonesRepository } from '@/repositories/zones';
+import type { Clock } from '../runtime';
+import { runTickForZone, type TickDeps } from '.';
+
+const SITE_TIMEZONE = 'UTC';
+const NOW = new Date('2026-05-04T20:00:00.000Z');
+
+function buildClock(now: Date = NOW): Clock {
+    return {
+        now: () => now,
+        setTimeout: () => 0 as unknown as ReturnType<typeof setTimeout>,
+        clearTimeout: () => {},
+    };
+}
+
+function buildSchedule(overrides?: Partial<Schedule>): Schedule {
+    return {
+        id: 'sched-001',
+        name: 'maintenance',
+        slug: 'maintenance',
+        siteId: 'test-site-001',
+        isActive: true,
+        allowedDays: null,
+        allowedTimeWindows: null,
+        rootDepthMOverride: null,
+        allowableDepletionFractionOverride: null,
+        endBySunrise: false,
+        skippedNightDate: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        ...overrides,
+    } as Schedule;
+}
+
+function recordingAlerter(): { alerter: Alerter; calls: AlertEvent[] } {
+    const calls: AlertEvent[] = [];
+    const alerter: Alerter = async (event) => { calls.push(event); };
+    return { alerter, calls };
+}
+
+type DepletionAdvance = { zoneId: string; depletionMm: number; reconciledAt: Date };
+
+function buildDeps(overrides?: {
+    getWeather?: (zone: Zone) => Promise<WeatherData>;
+    getZoneActuationHistory?: (zone: Zone, since: Date, until: Date) => Promise<ZoneActuationInterval[]>;
+    runPlan?: TickDeps['runPlan'];
+    alerter?: Alerter;
+    weatherIsStale?: boolean;
+    onAdvanceDepletion?: (advance: DepletionAdvance) => void;
+    onReplaceForZone?: () => Array<PersistedCycle>;
+}): { deps: TickDeps; depletionAdvances: DepletionAdvance[]; alertCalls: AlertEvent[] } {
+    const depletionAdvances: DepletionAdvance[] = [];
+    const { alerter, calls: alertCalls } = overrides?.alerter ? { alerter: overrides.alerter, calls: [] as AlertEvent[] } : recordingAlerter();
+    const zonesRepo: ZonesRepository = {
+        loadEnabled: async () => [],
+        findById: async () => null,
+        count: async () => ({ total: 0, enabled: 0 }),
+        loadJoinedRowsForSummary: async () => [],
+        loadLatestFires: async () => [],
+        advanceDepletion: async (zoneId, depletionMm, reconciledAt) => {
+            const advance = { zoneId, depletionMm, reconciledAt };
+            depletionAdvances.push(advance);
+            overrides?.onAdvanceDepletion?.(advance);
+        },
+    };
+    const scheduleEntriesRepo: ScheduleEntriesRepository = {
+        loadFutureCycles: async () => [],
+        loadInFlightCycles: async () => [],
+        replaceForZone: async () => ({ cycles: overrides?.onReplaceForZone?.() ?? [] }),
+        markCycleFired: async () => {},
+        markCycleClosed: async () => {},
+        findScheduledFromDate: async () => [],
+    };
+    const weatherStateRepo: WeatherStateRepository = {
+        markFetchSuccessful: async () => {},
+        isStale: async () => overrides?.weatherIsStale ?? false,
+    };
+    return {
+        deps: {
+            clock: buildClock(),
+            alerter,
+            runPlan: overrides?.runPlan ?? (async () => ({ entries: [], projectedNextDepletionMm: 0 })),
+            getWeather: overrides?.getWeather ?? (async () => ({ daily: [], hourly: [] })),
+            getZoneActuationHistory: overrides?.getZoneActuationHistory ?? (async () => []),
+            zonesRepo,
+            scheduleEntriesRepo,
+            weatherStateRepo,
+            getAlertsDb: () => null as unknown as AlertsDb,
+        },
+        depletionAdvances,
+        alertCalls,
+    };
+}
+
+function mkHourly(timeIso: string, precipitationMm: number, evapotranspirationMm: number): HourlyWeather {
+    return { time: dayjs(timeIso), precipitationMm, evapotranspirationMm };
+}
+
+describe('runTickForZone — morning', () => {
+    it('reconciles depletion against HA actuation history and observed weather', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const zone = createTestZone({
+            id: 'zone-001',
+            currentDepletionMm: 10,
+            currentDepletionReconciledAt: reconciledAt,
+            precipitationRateMmPerHr: 9,
+        });
+        const { deps, depletionAdvances } = buildDeps({
+            getWeather: async () => ({
+                daily: [],
+                hourly: [mkHourly('2026-05-04T10:00:00Z', 0, 1)],
+            }),
+            getZoneActuationHistory: async () => ([
+                { onAt: new Date('2026-05-04T09:00:00Z'), offAt: new Date('2026-05-04T09:30:00Z') },
+                { onAt: new Date('2026-05-04T10:00:00Z'), offAt: new Date('2026-05-04T10:30:00Z') },
+            ]),
+        });
+
+        await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'morning',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        // 10 + 1 - 0 - 9 = 2 mm
+        expect(depletionAdvances).toHaveLength(1);
+        expect(depletionAdvances[0]?.depletionMm).toBeCloseTo(2, 6);
+        expect(depletionAdvances[0]?.reconciledAt).toEqual(NOW);
+    });
+
+    it('raises actuation-stale and falls through to weather-only advance when HA history fetch throws', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const zone = createTestZone({
+            id: 'zone-001',
+            name: 'North',
+            currentDepletionMm: 5,
+            currentDepletionReconciledAt: reconciledAt,
+        });
+        const { deps, depletionAdvances, alertCalls } = buildDeps({
+            getWeather: async () => ({
+                daily: [],
+                hourly: [mkHourly('2026-05-04T10:00:00Z', 0, 2)],
+            }),
+            getZoneActuationHistory: async () => { throw new Error('HA fetch ECONNREFUSED'); },
+        });
+
+        await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'morning',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        // 5 + 2 = 7 (no actuation deduction because history threw).
+        expect(depletionAdvances[0]?.depletionMm).toBeCloseTo(7, 6);
+        const stale = alertCalls.filter(a => a.class === 'actuation-stale');
+        expect(stale).toHaveLength(1);
+        expect(stale[0]).toMatchObject({ class: 'actuation-stale', tone: 'warn', zoneId: 'zone-001', zoneName: 'North' });
+    });
+});
+
+describe('runTickForZone — evening', () => {
+    it('advances depletion from observed weather only', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const zone = createTestZone({
+            id: 'zone-001',
+            currentDepletionMm: 5,
+            currentDepletionReconciledAt: reconciledAt,
+        });
+        const { deps, depletionAdvances } = buildDeps({
+            getWeather: async () => ({
+                daily: [],
+                hourly: [mkHourly('2026-05-04T15:00:00Z', 0, 2)],
+            }),
+        });
+
+        await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'evening',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        expect(depletionAdvances[0]?.depletionMm).toBeCloseTo(7, 6);
+    });
+
+    it('clamps depletion to zero when rain exceeds the deficit', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const zone = createTestZone({
+            id: 'zone-001',
+            currentDepletionMm: 3,
+            currentDepletionReconciledAt: reconciledAt,
+        });
+        const { deps, depletionAdvances } = buildDeps({
+            getWeather: async () => ({
+                daily: [],
+                hourly: [mkHourly('2026-05-04T15:00:00Z', 50, 1)],
+            }),
+        });
+
+        await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'evening',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        expect(depletionAdvances[0]?.depletionMm).toBe(0);
+    });
+});
+
+describe('runTickForZone — kill switch and fresh seed', () => {
+    it('stamps reconciledAt without advancing depletion when the prior anchor is null', async () => {
+        const zone = createTestZone({
+            id: 'zone-001',
+            currentDepletionMm: 12.4,
+            currentDepletionReconciledAt: undefined,
+        });
+        const { deps, depletionAdvances } = buildDeps({
+            getWeather: async () => ({
+                daily: [],
+                // Even heavy rain should be ignored on the first tick.
+                hourly: [mkHourly('2026-05-04T15:00:00Z', 50, 0)],
+            }),
+        });
+
+        await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'evening',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        expect(depletionAdvances[0]?.depletionMm).toBeCloseTo(12.4, 6);
+    });
+
+    it('still reconciles depletion when irrigation is disabled, but skips planning', async () => {
+        const reconciledAt = new Date('2026-05-04T08:00:00.000Z');
+        const zone = createTestZone({
+            id: 'zone-001',
+            currentDepletionMm: 4,
+            currentDepletionReconciledAt: reconciledAt,
+            precipitationRateMmPerHr: 9,
+        });
+        let runPlanCalls = 0;
+        const { deps, depletionAdvances } = buildDeps({
+            getWeather: async () => ({
+                daily: [],
+                hourly: [mkHourly('2026-05-04T10:00:00Z', 0, 1)],
+            }),
+            getZoneActuationHistory: async () => ([
+                { onAt: new Date('2026-05-04T09:00:00Z'), offAt: new Date('2026-05-04T09:20:00Z') },
+            ]),
+            runPlan: async () => {
+                runPlanCalls += 1;
+                return { entries: [], projectedNextDepletionMm: 999 };
+            },
+        });
+
+        const result = await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'morning',
+            isScheduledTick: true,
+            irrigationEnabled: false,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        // 4 + 1 - 0 - 3 = 2 mm reconciled despite kill switch.
+        expect(depletionAdvances[0]?.depletionMm).toBeCloseTo(2, 6);
+        expect(runPlanCalls).toBe(0);
+        expect(result.cyclesToArm).toEqual([]);
+    });
+});
+
+describe('runTickForZone — weather failure', () => {
+    it('raises weather-stale when getWeather throws and the state is stale', async () => {
+        const zone = createTestZone({ id: 'zone-001', name: 'North' });
+        const { deps, alertCalls } = buildDeps({
+            getWeather: async () => { throw new Error('Open-Meteo down'); },
+            weatherIsStale: true,
+        });
+
+        const result = await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'evening',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        const weatherAlerts = alertCalls.filter(a => a.class === 'weather-stale');
+        expect(weatherAlerts).toHaveLength(1);
+        expect(weatherAlerts[0]).toMatchObject({ tone: 'warn', title: 'Weather API stale', zoneName: 'North' });
+        expect(result).toEqual({ cyclesToArm: [], newBusyWindows: [], observedSunrise: null });
+    });
+
+    it('returns empty cyclesToArm without raising weather-stale when the state is fresh', async () => {
+        const zone = createTestZone({ id: 'zone-001' });
+        const { deps, alertCalls } = buildDeps({
+            getWeather: async () => { throw new Error('transient blip'); },
+            weatherIsStale: false,
+        });
+
+        await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'evening',
+            isScheduledTick: true,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        expect(alertCalls.filter(a => a.class === 'weather-stale')).toHaveLength(0);
+    });
+});
+
+describe('runTickForZone — observedSunrise reporting', () => {
+    it('returns the upcoming sunrise so the caller can refresh its anchor', async () => {
+        const sunrise = dayjs('2026-05-05T11:41:00Z');
+        const zone = createTestZone({ id: 'zone-001' });
+        const { deps } = buildDeps({
+            getWeather: async () => ({
+                daily: [{ date: sunrise, sunrise }],
+                hourly: [],
+            }),
+        });
+
+        const result = await runTickForZone({
+            zone,
+            activeSchedule: buildSchedule(),
+            today: dayjs(NOW).tz(SITE_TIMEZONE),
+            busyWindows: [],
+            pastWindow: { start: new Date(0), end: NOW },
+            tickKind: 'evening',
+            isScheduledTick: false,
+            irrigationEnabled: true,
+            morningTickMinutesAfterSunrise: 60,
+            deps,
+        });
+
+        expect(result.observedSunrise?.toISOString()).toBe('2026-05-05T11:41:00.000Z');
+    });
+});

--- a/api/service/daemon/tick/index.ts
+++ b/api/service/daemon/tick/index.ts
@@ -1,0 +1,238 @@
+import dayjs from 'dayjs';
+import { clearAlertsByClass, type Alerter, type AlertsDb } from '@/alerts';
+import {
+    type ZoneActuationInterval,
+} from '@/data/home-assistant';
+import { sumHourlyWeatherBetween } from '@/data/weather';
+import type { WeatherData, Zone } from '@/models';
+import type { PersistedCycle } from '@/models/cycle';
+import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { Schedule } from '@/repositories/schedules';
+import type { WeatherStateRepository } from '@/repositories/weather-state';
+import type { ZonesRepository } from '@/repositories/zones';
+import type { RunScheduleForZoneOptions } from '@/schedules';
+import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
+import { advanceFromObservedWeather, reconcileFromActuationHistory } from '../depletion';
+import type { Clock } from '../runtime';
+import { pickUpcomingSunrise, type TickKind } from '../scheduling';
+
+/**
+ * Dependencies consumed by `runTickForZone`. Mirrors the injection seams in
+ * `DaemonOptions` plus the repository handles the daemon resolves at boot.
+ * Pulled into a single object so the per-zone tick body has one parameter
+ * for collaborators rather than a wide positional list.
+ */
+export type TickDeps = {
+    clock: Clock;
+    alerter: Alerter;
+    runPlan: (zone: Zone, options?: RunScheduleForZoneOptions) => Promise<PlanZoneScheduleResult>;
+    getWeather: (zone: Zone) => Promise<WeatherData>;
+    getZoneActuationHistory: (zone: Zone, since: Date, until: Date) => Promise<ZoneActuationInterval[]>;
+    zonesRepo: ZonesRepository;
+    scheduleEntriesRepo: ScheduleEntriesRepository;
+    weatherStateRepo: WeatherStateRepository;
+    getAlertsDb: () => AlertsDb | null;
+};
+
+export type RunTickForZoneInput = {
+    zone: Zone;
+    /**
+     * Active schedule for the zone's site, or `undefined` if no schedule is
+     * active. When undefined, reconciliation still runs (depletion accuracy
+     * doesn't depend on a schedule) but the planning + arming portion is
+     * skipped.
+     */
+    activeSchedule: Schedule | undefined;
+    today: dayjs.Dayjs;
+    /**
+     * Busy windows already reserved by earlier zones in this tick (plus the
+     * pre-tick in-flight cycles). The planner shifts conflicting cycles
+     * forward; cycles that still overlap are dropped from arming.
+     */
+    busyWindows: ReadonlyArray<{ start: Date; end: Date }>;
+    /** Epoch → now window, prepended to busyWindows when calling runPlan. */
+    pastWindow: { start: Date; end: Date };
+    tickKind: TickKind;
+    isScheduledTick: boolean;
+    irrigationEnabled: boolean;
+    morningTickMinutesAfterSunrise: number;
+    deps: TickDeps;
+};
+
+/**
+ * Outcome of a single zone's tick. The caller appends `cyclesToArm` and
+ * `newBusyWindows` to its accumulators, and updates `latestKnownSunrise` if
+ * `observedSunrise` is non-null. Returning rather than mutating shared state
+ * keeps the function easy to unit-test.
+ */
+export type RunTickForZoneResult = {
+    cyclesToArm: Array<{ zone: Zone; cycle: PersistedCycle }>;
+    newBusyWindows: Array<{ start: Date; end: Date }>;
+    observedSunrise: Date | null;
+};
+
+const EMPTY_RESULT: RunTickForZoneResult = { cyclesToArm: [], newBusyWindows: [], observedSunrise: null };
+
+/**
+ * Runs one zone's body of the daemon's `_rePlan`: fetches weather, reconciles
+ * depletion against the morning or evening source of truth, persists the new
+ * depletion (only on scheduled ticks), then plans and replaces schedule
+ * entries when irrigation is enabled. Caller is responsible for arming the
+ * returned `cyclesToArm` after iterating every zone.
+ *
+ * Exceptions from `getWeather` (or anything else inside the try) are caught
+ * here: a `weather-stale` alert fires if the weather-state repo says the last
+ * successful fetch is stale, and the function returns an empty result. The
+ * daemon loop continues with the next zone.
+ *
+ * @returns Cycles to arm + busy-window contributions + the observed sunrise
+ *   (for the caller to update its morning-tick anchor).
+ */
+export async function runTickForZone(input: RunTickForZoneInput): Promise<RunTickForZoneResult> {
+    const {
+        zone, activeSchedule, today, busyWindows, pastWindow,
+        tickKind, isScheduledTick, irrigationEnabled,
+        morningTickMinutesAfterSunrise, deps,
+    } = input;
+    const { clock, alerter, runPlan, getWeather, getZoneActuationHistory, zonesRepo, scheduleEntriesRepo, weatherStateRepo, getAlertsDb } = deps;
+
+    const tickNow = clock.now();
+    let observedSunrise: Date | null = null;
+    let weather: WeatherData;
+    try {
+        weather = await getWeather(zone);
+    } catch (err) {
+        await emitWeatherStaleIfStale(err, zone, weatherStateRepo, alerter, clock);
+        return EMPTY_RESULT;
+    }
+
+    // Refresh the morning-tick anchor with the soonest upcoming sunrise
+    // still inside the offset window.
+    observedSunrise = pickUpcomingSunrise(weather.daily, tickNow, morningTickMinutesAfterSunrise);
+
+    let newDepletionMm = zone.currentDepletionMm;
+    try {
+        if (isScheduledTick) {
+            if (zone.currentDepletionReconciledAt) {
+                const weatherDelta = sumHourlyWeatherBetween(
+                    weather.hourly, zone.currentDepletionReconciledAt, tickNow,
+                );
+                if (tickKind === 'morning') {
+                    let history: ZoneActuationInterval[] = [];
+                    try {
+                        history = await getZoneActuationHistory(zone, zone.currentDepletionReconciledAt, tickNow);
+                    } catch (err) {
+                        const reason = err instanceof Error ? err.message : String(err);
+                        console.error(`daemon: HA actuation history fetch failed for zone ${zone.id}; falling through to weather-only advance.`, err);
+                        await alerter({
+                            class: 'actuation-stale',
+                            tone: 'warn',
+                            title: 'HA actuation history stale',
+                            sub: `Depletion advanced from weather only. Last fetch error: ${reason}.`,
+                            zoneId: zone.id,
+                            zoneName: zone.name,
+                        });
+                    }
+                    const result = reconcileFromActuationHistory({
+                        previousDepletionMm: zone.currentDepletionMm,
+                        weatherDelta,
+                        history,
+                        precipitationRateMmPerHr: zone.precipitationRateMmPerHr,
+                    });
+                    newDepletionMm = result.newDepletionMm;
+                    console.log(`daemon: zone ${zone.id} morning reconcile — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, applied=${result.appliedDepthMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
+                } else {
+                    newDepletionMm = advanceFromObservedWeather({
+                        previousDepletionMm: zone.currentDepletionMm,
+                        weatherDelta,
+                    });
+                    console.log(`daemon: zone ${zone.id} evening weather advance — rain=${weatherDelta.rainMm.toFixed(2)}mm, ET=${weatherDelta.etMm.toFixed(2)}mm, depletion=${zone.currentDepletionMm.toFixed(2)}→${newDepletionMm.toFixed(2)}mm.`);
+                }
+            } else {
+                console.log(`daemon: zone ${zone.id} has null currentDepletionReconciledAt — stamping ${tickNow.toISOString()} without advancing depletion.`);
+            }
+            // Persist the reality-derived depletion + the new anchor
+            // immediately. Planning runs afterward; if it skips (kill switch
+            // off, no active schedule), the reconciliation still landed.
+            await zonesRepo.advanceDepletion(zone.id, newDepletionMm, tickNow);
+        }
+
+        // Successful weather fetch — refresh the staleness timestamp and
+        // clear any lingering unacked weather-stale alert.
+        const alertsDb = getAlertsDb();
+        await Promise.all([
+            weatherStateRepo.markFetchSuccessful(clock.now()),
+            alertsDb ? clearAlertsByClass(alertsDb, 'weather-stale') : Promise.resolve(),
+        ]);
+
+        // Planning + arming portion. Skipped when irrigation is disabled
+        // (kill switch off) or the zone's site has no active schedule.
+        if (!irrigationEnabled) return { cyclesToArm: [], newBusyWindows: [], observedSunrise };
+        if (!activeSchedule) {
+            console.warn(`daemon: no active schedule for site ${zone.siteId} — skipping plan/arm of zone ${zone.id} (${zone.name}).`);
+            return { cyclesToArm: [], newBusyWindows: [], observedSunrise };
+        }
+
+        const restrictions = {
+            allowedDays: activeSchedule.allowedDays,
+            allowedTimeWindows: activeSchedule.allowedTimeWindows,
+            endBySunrise: activeSchedule.endBySunrise ?? false,
+            skippedNightDate: activeSchedule.skippedNightDate ?? null,
+        };
+        const overrides = {
+            rootDepthM: activeSchedule.rootDepthMOverride ?? undefined,
+            allowableDepletionFraction: activeSchedule.allowableDepletionFractionOverride ?? undefined,
+        };
+        const planningZone = isScheduledTick
+            ? { ...zone, currentDepletionMm: newDepletionMm, currentDepletionReconciledAt: tickNow }
+            : zone;
+        const { entries } = await runPlan(planningZone, {
+            busyWindows: [pastWindow, ...busyWindows],
+            restrictions,
+            overrides,
+            forecastDays: 14,
+        });
+        const { cycles } = await scheduleEntriesRepo.replaceForZone(
+            zone.id, entries, today, activeSchedule.id,
+        );
+
+        const cyclesToArm: Array<{ zone: Zone; cycle: PersistedCycle }> = [];
+        const newBusyWindows: Array<{ start: Date; end: Date }> = [];
+        for (const cycle of cycles) {
+            const cycleEnd = new Date(cycle.startTime.getTime() + cycle.durationMin * 60_000);
+            const window = { start: cycle.startTime, end: cycleEnd };
+            const overlaps = busyWindows.some(w => cycle.startTime < w.end && cycleEnd > w.start)
+                || newBusyWindows.some(w => cycle.startTime < w.end && cycleEnd > w.start);
+            if (overlaps) {
+                console.warn(`daemon: cycle ${cycle.id} for zone ${zone.id} (${zone.name}) overlaps a busy window — not arming.`);
+                continue;
+            }
+            cyclesToArm.push({ zone, cycle });
+            newBusyWindows.push(window);
+        }
+        return { cyclesToArm, newBusyWindows, observedSunrise };
+    } catch (err) {
+        await emitWeatherStaleIfStale(err, zone, weatherStateRepo, alerter, clock);
+        return { cyclesToArm: [], newBusyWindows: [], observedSunrise };
+    }
+}
+
+async function emitWeatherStaleIfStale(
+    err: unknown,
+    zone: Zone,
+    weatherStateRepo: WeatherStateRepository,
+    alerter: Alerter,
+    clock: Clock,
+): Promise<void> {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(`daemon: re-plan failed for zone ${zone.id}.`, err);
+    if (await weatherStateRepo.isStale(clock.now())) {
+        await alerter({
+            class: 'weather-stale',
+            tone: 'warn',
+            title: 'Weather API stale',
+            sub: `Planner using fallback ET zero. Last fetch error: ${reason}.`,
+            zoneName: zone.name,
+        });
+    }
+}


### PR DESCRIPTION
## Ticket

[API-80](http://192.168.2.100:7123/home/browse/API-80/) — Modularize api/service/daemon/index.ts.

## Summary

Pure refactor — no behaviour change. After API-79 landed, the daemon's `start()` was a 315-line closure carrying boot orchestration, the per-zone `_rePlan` body, tick scheduling, the sunrise seed, and the public control surface. This PR splits those concerns into focused modules while preserving all existing DI seams.

- **`service/daemon/scheduling/`** — `TickKind`, `computeNextRePlanAt`, `computeNextMorningAt`, `pickUpcomingSunrise`, new `pickNextTick`. Pure scheduling math.
- **`service/daemon/tick/`** — `runTickForZone()` — the per-zone body of `_rePlan` (depletion reconcile + plan + arm-queue). All deps injected as `TickDeps`.
- **`service/daemon/boot/`** — `runBootSequence()` — relay reconcile, future-cycle arming under the kill switch, zone-count warnings, boot weather seed.
- **`service/daemon/markers/`** — `ArmableCycle` + `armCyclesWithScheduleMarkers` (lifted unchanged from index.ts).
- **`service/daemon/index.ts`** — now assembles the above. 543 → 290 lines (47% reduction).

Existing tests pass unchanged. Per-module unit tests added: scheduling (+10), tick (+9), boot (+6) = 25 new tests; previously-existing daemon integration tests still cover end-to-end wiring.

## Test plan

- [x] `bun --cwd=./api run type-check` clean
- [x] `bun --cwd=./api test` — 901 passing (876 pre-PR + 25 new)
- [x] No behaviour change: existing daemon integration suite passes unchanged
- [ ] After merge, smoke-check the daemon boot logs to confirm the same boot sequence (relay reconcile → future-cycle arming → weather seed → first tick scheduled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)