### PR TITLE
[APP-27] Zone detail screen — battery hero, attributes, recent runs

### DIFF
--- a/app/app/modal.tsx
+++ b/app/app/modal.tsx
@@ -8,7 +8,7 @@ export default function ModalScreen() {
   return (
     <ThemedView style={styles.container}>
       <ThemedText type="title">This is a modal</ThemedText>
-      <Link href="/" dismissTo style={styles.link}>
+      <Link href={'/' as never} dismissTo style={styles.link}>
         <ThemedText type="link">Go to home screen</ThemedText>
       </Link>
     </ThemedView>

--- a/app/app/zone/[slug].tsx
+++ b/app/app/zone/[slug].tsx
@@ -1,0 +1,69 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
+import { ZoneDetail } from '@/components/zone-detail';
+import { FontFamily } from '@/constants/fonts';
+import { useActivity } from '@/hooks/activity';
+import { useNextRun } from '@/hooks/next-run';
+import { useZone } from '@/hooks/zone';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Zone detail route. Composes `useZone`, `useNextRun`, and `useActivity`
+ * into the `<ZoneDetail>` body. Redirects to Home when the route slug
+ * doesn't match any known zone (stale deep link).
+ */
+export default function ZoneScreen() {
+    const { slug } = useLocalSearchParams<{ slug: string }>();
+    const { zone, isPending } = useZone(slug);
+    const nextRun = useNextRun();
+    const activity = useActivity({ zoneId: zone?.id });
+
+    // Redirect when the slug doesn't match any zone in the loaded list.
+    const shouldRedirect = !isPending && zone === undefined;
+    useEffect(() => {
+        if (shouldRedirect) router.replace('/' as never);
+    }, [shouldRedirect]);
+
+    if (isPending) {
+        return (
+            <RefreshableScrollView>
+                <Text style={styles.hint}>Loading zone…</Text>
+            </RefreshableScrollView>
+        );
+    }
+
+    if (zone === undefined) {
+        // The effect above will fire on the next paint; render nothing in
+        // the meantime so we don't flash an empty layout.
+        return <View />;
+    }
+
+    const flattened = activity.data?.pages.flatMap(page => page.activity) ?? [];
+
+    return (
+        <RefreshableScrollView>
+            <ZoneDetail
+                zone={zone}
+                nextRun={nextRun.data}
+                activity={flattened}
+                isActivityLoading={activity.isPending}
+                onRunNow={() => {}}
+            />
+        </RefreshableScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    hint: {
+        padding: 20,
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+});

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import type { ActivityDto } from '@/api/types/activity';
+import type { NextRunDto } from '@/api/types/next-run';
+import type { ZoneSummary } from '@/api/types/zones';
+import { ZoneDetail } from '.';
+
+function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
+    return {
+        id: 'z-1',
+        slug: 'north',
+        name: 'North',
+        isEnabled: true,
+        grassType: { name: 'Kentucky Bluegrass' },
+        soilType: { name: 'Loam' },
+        areaM2: 100,
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        microclimateFactor: 1.05,
+        precipitationRateMmPerHr: 14,
+        currentDepletionMm: 5,
+        rawMm: 22.5,
+        lastFiredAt: null,
+        lastAppliedMm: null,
+        homeAssistantEntityId: 'switch.north_zone',
+        patch: 'a',
+        ...overrides,
+    };
+}
+
+function buildActivity(overrides?: Partial<ActivityDto>): ActivityDto {
+    return {
+        id: 'act-1',
+        date: '2026-05-03T05:00:00.000Z',
+        zone: { id: 'z-1', name: 'North', slug: 'north' },
+        appliedDepthMm: 9,
+        durationMin: 30,
+        depletionBeforeMm: 22,
+        depletionAfterMm: 0,
+        source: 'planner',
+        ...overrides,
+    };
+}
+
+function buildNextRun(): NextRunDto {
+    return {
+        state: 'scheduled',
+        startTime: '2026-05-04T05:00:00.000Z',
+        endsAt: '2026-05-04T07:00:00.000Z',
+        axisStart: '04:00',
+        axisEnd: '08:00',
+        sunset: '20:30',
+        sunrise: '05:30',
+        timezone: 'America/Edmonton',
+        zoneOrder: ['north'],
+        totalCycles: 1,
+        zones: [
+            { name: 'North', slug: 'north', patch: 'a', cycles: [{ start: '05:00', durMin: 15 }] },
+        ],
+    };
+}
+
+describe('ZoneDetail', () => {
+    it('renders the zone name, grass + area eyebrow, and depletion mm figure.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone({ currentDepletionMm: 27.4 })}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('North')).toBeOnTheScreen();
+        expect(screen.getByText('Kentucky Bluegrass · 100 m²')).toBeOnTheScreen();
+        expect(screen.getByText('27.4')).toBeOnTheScreen();
+        expect(screen.getByText('mm')).toBeOnTheScreen();
+    });
+
+    it('renders all physical attribute rows.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Grass type')).toBeOnTheScreen();
+        expect(screen.getByText('Area')).toBeOnTheScreen();
+        expect(screen.getByText('100 m²')).toBeOnTheScreen();
+        expect(screen.getByText('Root depth')).toBeOnTheScreen();
+        expect(screen.getByText('0.30 m')).toBeOnTheScreen();
+        expect(screen.getByText('Allowable depletion')).toBeOnTheScreen();
+        expect(screen.getByText('0.50')).toBeOnTheScreen();
+        expect(screen.getByText('Soil')).toBeOnTheScreen();
+        expect(screen.getByText('Loam')).toBeOnTheScreen();
+        expect(screen.getByText('Precipitation rate')).toBeOnTheScreen();
+        expect(screen.getByText('14.0 mm/hr')).toBeOnTheScreen();
+        expect(screen.getByText('Microclimate factor')).toBeOnTheScreen();
+        expect(screen.getByText('1.05')).toBeOnTheScreen();
+        expect(screen.getByText('Entity')).toBeOnTheScreen();
+        expect(screen.getByText('switch.north_zone')).toBeOnTheScreen();
+    });
+
+    it('renders "—" for precipitation rate and entity when they are null.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone({ precipitationRateMmPerHr: null, homeAssistantEntityId: null })}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        // Two — placeholders (one for each null field).
+        expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('renders the tone copy without qualifier when no nextRun is supplied.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone({ currentDepletionMm: 27.4, rawMm: 22.5 })}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Past RAW')).toBeOnTheScreen();
+    });
+
+    it('appends the next-run start time to the tone copy when nextRun has cycles for the zone.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone({ currentDepletionMm: 27.4, rawMm: 22.5 })}
+                nextRun={buildNextRun()}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Past RAW · next run at 05:00')).toBeOnTheScreen();
+    });
+
+    it('renders the recent-runs rows from the supplied activity.', () => {
+        const activity = [
+            buildActivity({ id: 'a-1', date: '2026-05-03T05:00:00.000Z', appliedDepthMm: 9, durationMin: 30, depletionBeforeMm: 22, depletionAfterMm: 0 }),
+            buildActivity({ id: 'a-2', date: '2026-05-02T05:00:00.000Z', appliedDepthMm: 4.5, durationMin: 15, depletionBeforeMm: 13, depletionAfterMm: 0 }),
+        ];
+
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={activity}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('9.0 mm · 30 min')).toBeOnTheScreen();
+        expect(screen.getByText('22.0 → 0.0 mm')).toBeOnTheScreen();
+        expect(screen.getByText('4.5 mm · 15 min')).toBeOnTheScreen();
+        expect(screen.getByText('13.0 → 0.0 mm')).toBeOnTheScreen();
+    });
+
+    it('renders an empty state when activity is empty and not loading.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('No runs recorded yet.')).toBeOnTheScreen();
+    });
+
+    it('renders a loading hint when activity is empty and isActivityLoading is true.', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Loading recent runs…')).toBeOnTheScreen();
+    });
+
+    it('fires onRunNow when the Run now button is tapped.', () => {
+        const onRunNow = jest.fn();
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={onRunNow}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Run now'));
+
+        expect(onRunNow).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/components/zone-detail/index.tsx
+++ b/app/components/zone-detail/index.tsx
@@ -1,0 +1,315 @@
+import dayjs from 'dayjs';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { ActivityDto } from '@/api/types/activity';
+import type { NextRunDto } from '@/api/types/next-run';
+import type { ZoneSummary } from '@/api/types/zones';
+import { Battery, computeBatteryGeometry } from '@/components/battery';
+import { Button } from '@/components/button';
+import { LawnPatch, type LawnPatchSlug } from '@/components/lawn-patch';
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+import { computeZoneStatusCopy } from './zone-status';
+
+const colors = config.theme.extend.colors;
+
+const TONE_COLOR = {
+    ok: colors.accent,
+    warn: colors.warn,
+    danger: colors.danger,
+} as const;
+
+/**
+ * Props for the Zone detail screen body.
+ */
+export type ZoneDetailProps = {
+    /** Required. The zone whose detail is being rendered. */
+    zone: ZoneSummary;
+
+    /** Optional. Next-run summary used to append `· next run at HH:MM` to the tone copy. `undefined` while the query is loading or unavailable. */
+    nextRun: NextRunDto | undefined;
+
+    /** Required. Recent run rows for this zone, flattened from the activity query's pages. */
+    activity: ReadonlyArray<ActivityDto>;
+
+    /** Required. Whether the activity query is still in its first load. The component renders a hint when this is true and `activity` is empty. */
+    isActivityLoading: boolean;
+
+    /** Required. Fires when the user taps "Run now". The FireSheet wiring is a separate ticket; the route currently passes a no-op. */
+    onRunNow: () => void;
+};
+
+/**
+ * Zone detail screen body: header (LawnPatch + name + tone copy), battery
+ * hero, Run-now CTA, physical attributes table, and recent runs log. Pure
+ * presentational — all data is supplied by the route, which composes
+ * `useZone`, `useNextRun`, and `useActivity`.
+ */
+export function ZoneDetail({ zone, nextRun, activity, isActivityLoading, onRunNow }: ZoneDetailProps) {
+    const geometry = computeBatteryGeometry(zone.currentDepletionMm, zone.rawMm);
+    const toneColor = TONE_COLOR[geometry.tone];
+    const statusCopy = computeZoneStatusCopy(zone, nextRun);
+    const scaleMaxMm = Math.round(geometry.scaleMax);
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.eyebrow}>{zone.grassType.name} · {zone.areaM2} m²</Text>
+
+            <View style={styles.headerRow}>
+                <LawnPatch slug={normaliseSlug(zone.patch)} size={44} tone={toneColor} />
+                <View style={styles.headerText}>
+                    <Text style={styles.name}>{zone.name}</Text>
+                    <Text style={[styles.statusCopy, geometry.tone === 'danger' ? { color: colors.danger } : null]}>
+                        {statusCopy}
+                    </Text>
+                </View>
+            </View>
+
+            <View style={styles.heroCard}>
+                <Text style={styles.heroEyebrow}>Soil-moisture deficit</Text>
+                <View style={styles.heroFigureRow}>
+                    <Text style={[styles.heroFigure, { color: toneColor }]}>{zone.currentDepletionMm.toFixed(1)}</Text>
+                    <Text style={styles.heroUnit}>mm</Text>
+                </View>
+                <View style={styles.heroBattery}>
+                    <Battery depletion={zone.currentDepletionMm} raw={zone.rawMm} tall />
+                </View>
+                <View style={styles.heroAxisRow}>
+                    <Text style={styles.heroAxisTick}>0</Text>
+                    <Text style={[styles.heroAxisTick, { color: colors.warn }]}>RAW · {zone.rawMm}</Text>
+                    <Text style={styles.heroAxisTick}>{scaleMaxMm}</Text>
+                </View>
+            </View>
+
+            <Button variant='primary' size='lg' onPress={onRunNow}>Run now</Button>
+
+            <View>
+                <Text style={styles.sectionHeading}>Physical</Text>
+                <View style={styles.attrTable}>
+                    <AttrRow label='Grass type' value={zone.grassType.name} />
+                    <AttrRow label='Area' value={`${zone.areaM2} m²`} />
+                    <AttrRow label='Root depth' value={`${zone.rootDepthM.toFixed(2)} m`} />
+                    <AttrRow label='Allowable depletion' value={zone.allowableDepletionFraction.toFixed(2)} />
+                    <AttrRow label='Soil' value={zone.soilType.name} />
+                    <AttrRow label='Precipitation rate' value={formatPrecipitation(zone.precipitationRateMmPerHr)} />
+                    <AttrRow label='Microclimate factor' value={zone.microclimateFactor.toFixed(2)} />
+                    <AttrRow label='Entity' value={zone.homeAssistantEntityId ?? '—'} mono />
+                </View>
+            </View>
+
+            <View>
+                <Text style={styles.sectionHeading}>Recent runs</Text>
+                {activity.length === 0 && isActivityLoading ? (
+                    <Text style={styles.emptyState}>Loading recent runs…</Text>
+                ) : activity.length === 0 ? (
+                    <Text style={styles.emptyState}>No runs recorded yet.</Text>
+                ) : (
+                    <View style={styles.fireLog}>
+                        {activity.map(row => (
+                            <RecentRunRow key={row.id} row={row} />
+                        ))}
+                    </View>
+                )}
+            </View>
+        </View>
+    );
+}
+
+function AttrRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+    return (
+        <View style={styles.attrRow}>
+            <Text style={styles.attrLabel}>{label}</Text>
+            <Text style={[styles.attrValue, mono ? styles.attrValueMono : null]}>{value}</Text>
+        </View>
+    );
+}
+
+function RecentRunRow({ row }: { row: ActivityDto }) {
+    return (
+        <View style={styles.fireRow}>
+            <Text style={styles.fireDate}>{dayjs(row.date).format('MMM D')}</Text>
+            <Text style={styles.fireApplied}>
+                {row.appliedDepthMm.toFixed(1)} mm · {row.durationMin} min
+            </Text>
+            <Text style={styles.fireDelta}>
+                {row.depletionBeforeMm.toFixed(1)} → {row.depletionAfterMm.toFixed(1)} mm
+            </Text>
+        </View>
+    );
+}
+
+function normaliseSlug(patch: string): LawnPatchSlug {
+    if (patch === 'a' || patch === 'b' || patch === 'c') return patch;
+    return 'a';
+}
+
+function formatPrecipitation(value: number | null): string {
+    if (value === null) return '—';
+    return `${value.toFixed(1)} mm/hr`;
+}
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 18,
+        paddingHorizontal: 20,
+        paddingTop: 12,
+        paddingBottom: 32,
+    },
+    eyebrow: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 10,
+        lineHeight: 12,
+        letterSpacing: 1.4,
+        textTransform: 'uppercase',
+        color: colors['fg-muted'],
+    },
+    headerRow: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        gap: 14,
+    },
+    headerText: {
+        flex: 1,
+        minWidth: 0,
+    },
+    name: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 32,
+        lineHeight: 34,
+        letterSpacing: -0.8,
+        color: colors.fg,
+    },
+    statusCopy: {
+        marginTop: 4,
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+    heroCard: {
+        backgroundColor: colors['ink-300'],
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 4,
+        padding: 18,
+        gap: 8,
+    },
+    heroEyebrow: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 10,
+        lineHeight: 12,
+        letterSpacing: 1.4,
+        textTransform: 'uppercase',
+        color: colors['fg-muted'],
+    },
+    heroFigureRow: {
+        flexDirection: 'row',
+        alignItems: 'baseline',
+        gap: 6,
+        marginTop: 6,
+    },
+    heroFigure: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 56,
+        lineHeight: 56,
+        letterSpacing: -2,
+    },
+    heroUnit: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 20,
+        lineHeight: 24,
+        color: colors['fg-muted'],
+    },
+    heroBattery: {
+        marginTop: 14,
+    },
+    heroAxisRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        marginTop: 4,
+    },
+    heroAxisTick: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        color: colors['fg-dim'],
+    },
+    sectionHeading: {
+        marginBottom: 10,
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 16,
+        lineHeight: 20,
+        color: colors.fg,
+    },
+    attrTable: {
+        borderTopWidth: 1,
+        borderTopColor: colors.hairline,
+    },
+    attrRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 10,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.hairline,
+        gap: 12,
+    },
+    attrLabel: {
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+    attrValue: {
+        flexShrink: 1,
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors.fg,
+        textAlign: 'right',
+    },
+    attrValueMono: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 12,
+    },
+    fireLog: {
+        borderTopWidth: 1,
+        borderTopColor: colors.hairline,
+    },
+    fireRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 10,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.hairline,
+        gap: 8,
+    },
+    fireDate: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors.fg,
+        width: 64,
+    },
+    fireApplied: {
+        flex: 1,
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 12,
+        lineHeight: 14,
+        color: colors['fg-muted'],
+    },
+    fireDelta: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 12,
+        lineHeight: 14,
+        color: colors['fg-dim'],
+    },
+    emptyState: {
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+});

--- a/app/components/zone-detail/zone-status.test.ts
+++ b/app/components/zone-detail/zone-status.test.ts
@@ -1,0 +1,86 @@
+import type { NextRunDto } from '@/api/types/next-run';
+import type { ZoneSummary } from '@/api/types/zones';
+import { computeZoneStatusCopy } from './zone-status';
+
+function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
+    return {
+        id: 'z-1',
+        slug: 'north',
+        name: 'North',
+        isEnabled: true,
+        grassType: { name: 'Kentucky Bluegrass' },
+        soilType: { name: 'Loam' },
+        areaM2: 100,
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        microclimateFactor: 1,
+        precipitationRateMmPerHr: 14,
+        currentDepletionMm: 5,
+        rawMm: 22.5,
+        lastFiredAt: null,
+        lastAppliedMm: null,
+        homeAssistantEntityId: 'switch.north_zone',
+        patch: 'a',
+        ...overrides,
+    };
+}
+
+function buildNextRun(overrides?: Partial<NextRunDto>): NextRunDto {
+    return {
+        state: 'scheduled',
+        startTime: '2026-05-04T05:00:00.000Z',
+        endsAt: '2026-05-04T07:00:00.000Z',
+        axisStart: '04:00',
+        axisEnd: '08:00',
+        sunset: '20:30',
+        sunrise: '05:30',
+        timezone: 'America/Edmonton',
+        zoneOrder: ['north'],
+        totalCycles: 1,
+        zones: [
+            { name: 'North', slug: 'north', patch: 'a', cycles: [{ start: '05:00', durMin: 15 }] },
+        ],
+        ...overrides,
+    };
+}
+
+describe('computeZoneStatusCopy', () => {
+    it('returns "Within tolerance" when depletion is well below RAW.', () => {
+        const zone = buildZone({ currentDepletionMm: 5, rawMm: 22.5 });
+        expect(computeZoneStatusCopy(zone, undefined)).toBe('Within tolerance');
+    });
+
+    it('returns "Approaching RAW" when depletion is between 80% and 100% of RAW.', () => {
+        const zone = buildZone({ currentDepletionMm: 19, rawMm: 22.5 });
+        expect(computeZoneStatusCopy(zone, undefined)).toBe('Approaching RAW');
+    });
+
+    it('returns "Past RAW" when depletion is at or above RAW.', () => {
+        const zone = buildZone({ currentDepletionMm: 27.4, rawMm: 22.5 });
+        expect(computeZoneStatusCopy(zone, undefined)).toBe('Past RAW');
+    });
+
+    it('appends "· next run at HH:MM" when nextRun has cycles for this zone.', () => {
+        const zone = buildZone({ slug: 'north', currentDepletionMm: 27.4, rawMm: 22.5 });
+        expect(computeZoneStatusCopy(zone, buildNextRun())).toBe('Past RAW · next run at 05:00');
+    });
+
+    it('omits the qualifier when nextRun is undefined.', () => {
+        const zone = buildZone({ currentDepletionMm: 27.4, rawMm: 22.5 });
+        expect(computeZoneStatusCopy(zone, undefined)).toBe('Past RAW');
+    });
+
+    it('omits the qualifier when the zone is absent from nextRun.zones.', () => {
+        const zone = buildZone({ slug: 'east', currentDepletionMm: 27.4, rawMm: 22.5 });
+        expect(computeZoneStatusCopy(zone, buildNextRun())).toBe('Past RAW');
+    });
+
+    it('omits the qualifier when the zone is present but has zero cycles.', () => {
+        const zone = buildZone({ slug: 'north', currentDepletionMm: 5, rawMm: 22.5 });
+        const nextRun = buildNextRun({
+            zones: [{ name: 'North', slug: 'north', patch: 'a', cycles: [] }],
+        });
+        expect(computeZoneStatusCopy(zone, nextRun)).toBe('Within tolerance');
+    });
+});

--- a/app/components/zone-detail/zone-status.ts
+++ b/app/components/zone-detail/zone-status.ts
@@ -1,0 +1,29 @@
+import type { ZoneSummary } from '@/api/types/zones';
+import type { NextRunDto } from '@/api/types/next-run';
+import { computeBatteryGeometry } from '@/components/battery';
+
+const BASE_COPY = {
+    ok: 'Within tolerance',
+    warn: 'Approaching RAW',
+    danger: 'Past RAW',
+} as const;
+
+/**
+ * Composes the tone-status line shown under the zone name on the Zone
+ * detail screen. The base phrase comes from the same battery-tone bucket
+ * the hero uses (`ok` / `warn` / `danger`); when `nextRun` reports cycles
+ * for this zone, the helper appends ` · next run at HH:MM` using the first
+ * cycle's site-local start time.
+ *
+ * @param zone - Zone summary providing depletion + RAW.
+ * @param nextRun - Optional next-run DTO. When `undefined` (loading or
+ *   unavailable) or when the zone has no cycles, the qualifier is omitted.
+ * @returns The composed copy ready to render in a single `<Text>` element.
+ */
+export function computeZoneStatusCopy(zone: ZoneSummary, nextRun: NextRunDto | undefined): string {
+    const { tone } = computeBatteryGeometry(zone.currentDepletionMm, zone.rawMm);
+    const base = BASE_COPY[tone];
+    const cycleStart = nextRun?.zones.find(z => z.slug === zone.slug)?.cycles[0]?.start;
+    if (cycleStart === undefined) return base;
+    return `${base} · next run at ${cycleStart}`;
+}

--- a/app/hooks/zone/.test.tsx
+++ b/app/hooks/zone/.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import { useZone } from '.';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('useZone', () => {
+    it('returns the zone matching the supplied slug.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({
+            zones: [
+                { id: 'z-1', slug: 'north', name: 'North' },
+                { id: 'z-2', slug: 'south', name: 'South' },
+            ],
+        }));
+
+        const { result } = renderHook(() => useZone('south'), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isPending).toBe(false));
+        expect(result.current.zone?.name).toBe('South');
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('returns undefined zone when no zone matches the slug.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({
+            zones: [
+                { id: 'z-1', slug: 'north', name: 'North' },
+            ],
+        }));
+
+        const { result } = renderHook(() => useZone('east'), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isPending).toBe(false));
+        expect(result.current.zone).toBeUndefined();
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('returns undefined zone when slug is undefined.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({
+            zones: [
+                { id: 'z-1', slug: 'north', name: 'North' },
+            ],
+        }));
+
+        const { result } = renderHook(() => useZone(undefined), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isPending).toBe(false));
+        expect(result.current.zone).toBeUndefined();
+    });
+
+    it('mirrors isPending=true while the underlying /zones query is in flight.', () => {
+        mockFetch.mockReturnValueOnce(new Promise(() => {})); // never resolves
+
+        const { result } = renderHook(() => useZone('north'), { wrapper: buildApiWrapper().wrapper });
+
+        expect(result.current.isPending).toBe(true);
+        expect(result.current.zone).toBeUndefined();
+    });
+
+    it('surfaces an ApiError on a non-2xx /zones response.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'not-found', message: 'no zones' }, 404));
+
+        const { result } = renderHook(() => useZone('north'), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.status).toBe(404);
+        expect(result.current.zone).toBeUndefined();
+    });
+});

--- a/app/hooks/zone/index.ts
+++ b/app/hooks/zone/index.ts
@@ -1,0 +1,34 @@
+import type { ApiError } from '@/api/client';
+import type { ZoneSummary } from '@/api/types/zones';
+import { useZones } from '@/hooks/zones';
+
+/**
+ * Result of `useZone`. `zone` is `undefined` while the underlying list is
+ * loading **or** when the supplied `slug` doesn't match any returned zone —
+ * the caller distinguishes those by inspecting `isPending`.
+ */
+export type UseZoneResult = {
+    zone: ZoneSummary | undefined;
+    isPending: boolean;
+    isError: boolean;
+    error: ApiError | null;
+};
+
+/**
+ * Derived hook that returns a single zone by slug. Composes `useZones()` so
+ * the underlying query is shared with the Home zone-tile list (no extra
+ * network call when navigating Home → Zone detail).
+ *
+ * @param slug - The zone slug from the route param. `undefined` returns the
+ *   underlying query's loading/error state with `zone: undefined`.
+ */
+export function useZone(slug: string | undefined): UseZoneResult {
+    const zones = useZones();
+    const zone = zones.data?.find(z => z.slug === slug);
+    return {
+        zone,
+        isPending: zones.isPending,
+        isError: zones.isError,
+        error: zones.error ?? null,
+    };
+}


### PR DESCRIPTION
## Ticket

[APP-27](http://192.168.2.100:7123/home/browse/APP-27/) — Zone detail screen.

## Summary

Builds the destination for the Home screen's zone-tile taps (which previously 404'd on the unrouted `/zone/<slug>` path). Matches `ZoneView` in `app/design/ui_kit/Mobile.jsx`.

- **Header**: `LawnPatch` + zone name + tone copy. Copy is computed by `computeZoneStatusCopy`: `Within tolerance` / `Approaching RAW` / `Past RAW`, optionally appended with `· next run at HH:MM` when the next-run DTO has cycles for this zone.
- **Battery hero**: large mono deficit figure + `<Battery tall>` + `0 / RAW · {raw} / {scale-max}` axis labels.
- **Run-now CTA**: primary large button; route currently passes a no-op `onRunNow`. FireSheet wiring is a separate ticket.
- **Physical attributes**: definition list of grass type, area, root depth, allowable depletion, soil, precipitation rate, microclimate factor, HA entity ID.
- **Recent runs**: rows from `useActivity({ zoneId })`, formatted `MMM D` / `{appliedMm} mm · {durationMin} min` / `{before} → {after} mm`. Loading + empty states.

Stale-slug deep links redirect to Home.

## Notable changes

- New `useZone(slug)` derived hook composes the existing `useZones()` query — no extra fetch when navigating Home → Zone detail.
- Drive-by fix: `app/app/modal.tsx` had a pre-existing typed-routes typecheck error (`href="/"`). Patched to `href={'/' as never}` to match the project's existing nav pattern.
- Follow-up filed as **APP-67**: link the "Recent runs" section to the Activity view with the current zone preselected in the filter.

## Test plan

- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 593 passing, 78 suites (21 new tests on this branch)
- [ ] Smoke: tap a zone tile on Home → land on detail screen with correct data
- [ ] Smoke: deep-link to `/zone/zzz` (unknown slug) → redirects to Home
- [ ] Smoke: tap "Run now" → no-op (FireSheet ticket pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)