### PR TITLE
[APP-67] Link Recent runs to Activity view with zone preselected

### DIFF
--- a/app/app/activity.tsx
+++ b/app/app/activity.tsx
@@ -1,5 +1,13 @@
+import { useLocalSearchParams } from 'expo-router';
+
 import { ActivityView } from '@/components/activity-view';
 
+/**
+ * Activity route. Forwards an optional `zoneId` query param so deep links
+ * (e.g. the "View all in Activity" link on Zone detail, APP-67) can seed
+ * the chip-strip filter on mount.
+ */
 export default function ActivityScreen() {
-    return <ActivityView />;
+    const { zoneId } = useLocalSearchParams<{ zoneId?: string }>();
+    return <ActivityView initialZoneId={zoneId} />;
 }

--- a/app/app/zone/[slug].tsx
+++ b/app/app/zone/[slug].tsx
@@ -53,6 +53,7 @@ export default function ZoneScreen() {
                 activity={flattened}
                 isActivityLoading={activity.isPending}
                 onRunNow={() => {}}
+                onViewActivity={() => router.push({ pathname: '/activity', params: { zoneId: zone.id } } as never)}
             />
         </RefreshableScrollView>
     );

--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -303,4 +303,40 @@ describe('ActivityView', () => {
 
         await waitFor(() => expect(screen.getByText('Chronological · South')).toBeOnTheScreen());
     });
+
+    it('seeds the filter from initialZoneId so the eyebrow reflects the preselected zone (APP-67).', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.zones.list(), ZONES);
+        mockFetch.mockImplementation(async () => jsonResponse(activityResult([buildActivity()])));
+
+        render(<ActivityView initialZoneId='z-2' />, { wrapper });
+
+        await waitFor(() => expect(screen.getByText('Chronological · South')).toBeOnTheScreen());
+        expect(screen.getByLabelText('Filter to South').props.accessibilityState).toMatchObject({ selected: true });
+    });
+
+    it('issues the initial /activity fetch with zoneId when initialZoneId is supplied (APP-67).', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.zones.list(), ZONES);
+        mockFetch.mockImplementation(async () => jsonResponse(activityResult([buildActivity()])));
+
+        render(<ActivityView initialZoneId='z-1' />, { wrapper });
+
+        await waitFor(() => {
+            const scopedCall = mockFetch.mock.calls.find(([u]) => {
+                const url = new URL(String(u));
+                return url.pathname === '/activity' && url.searchParams.get('zoneId') === 'z-1';
+            });
+            expect(scopedCall).toBeDefined();
+        });
+    });
+
+    it('defaults to all-zones when initialZoneId is undefined (regression).', () => {
+        const { wrapper } = buildApiWrapper();
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        render(<ActivityView />, { wrapper });
+
+        expect(screen.getByText('Chronological · all zones')).toBeOnTheScreen();
+    });
 });

--- a/app/components/activity-view/index.tsx
+++ b/app/components/activity-view/index.tsx
@@ -17,6 +17,21 @@ const DEFAULT_TIMEZONE = 'UTC';
 const ALL_ZONES_LABEL = 'all zones';
 
 /**
+ * Props for the Activity smart container.
+ */
+export type ActivityViewProps = {
+    /**
+     * Optional. Zone id to preselect in the filter chip strip on first
+     * render. Threaded from the route's `zoneId` query param so that the
+     * "View all in Activity" link on Zone detail (APP-67) lands here with
+     * the originating zone already filtered. The chip strip stays
+     * user-controlled afterwards — taps on other chips replace the
+     * selection as normal.
+     */
+    initialZoneId?: string;
+};
+
+/**
  * Smart container for the Activity screen. Composes the eyebrow + page
  * title with a zone-filter chip strip and the chronological fire log
  * sourced from `GET /activity`. Reads `useNextRun()` only for the site
@@ -26,11 +41,11 @@ const ALL_ZONES_LABEL = 'all zones';
  * fresh query — so the fire log re-fetches the first page automatically.
  * RN port of `ActivityView` from `Mobile.jsx` — minus the alert region,
  * since alerts have no dismiss affordance yet and lingering non-
- * interactive copy is worse than silence here. APP-32 / APP-61.
+ * interactive copy is worse than silence here. APP-32 / APP-61 / APP-67.
  */
-export function ActivityView() {
+export function ActivityView({ initialZoneId }: ActivityViewProps = {}) {
     const insets = useSafeAreaInsets();
-    const [selectedZoneId, setSelectedZoneId] = useState<string | undefined>(undefined);
+    const [selectedZoneId, setSelectedZoneId] = useState<string | undefined>(initialZoneId);
     const activity = useActivity({ ...(selectedZoneId !== undefined ? { zoneId: selectedZoneId } : {}) });
     const nextRun = useNextRun();
     const zones = useZones();

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -216,4 +216,36 @@ describe('ZoneDetail', () => {
 
         expect(onRunNow).toHaveBeenCalledTimes(1);
     });
+
+    it('renders the View all in Activity link when onViewActivity is supplied (APP-67).', () => {
+        const onViewActivity = jest.fn();
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+                onViewActivity={onViewActivity}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('View all in Activity →'));
+
+        expect(onViewActivity).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the View all in Activity link when onViewActivity is omitted (APP-67).', () => {
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+            />,
+        );
+
+        expect(screen.queryByText('View all in Activity →')).toBeNull();
+    });
 });

--- a/app/components/zone-detail/index.tsx
+++ b/app/components/zone-detail/index.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import type { ActivityDto } from '@/api/types/activity';
 import type { NextRunDto } from '@/api/types/next-run';
@@ -38,6 +38,9 @@ export type ZoneDetailProps = {
 
     /** Required. Fires when the user taps "Run now". The FireSheet wiring is a separate ticket; the route currently passes a no-op. */
     onRunNow: () => void;
+
+    /** Optional. Fires when the user taps "View all in Activity →" in the Recent runs section heading. When omitted, the link is hidden. APP-67. */
+    onViewActivity?: () => void;
 };
 
 /**
@@ -46,7 +49,7 @@ export type ZoneDetailProps = {
  * presentational — all data is supplied by the route, which composes
  * `useZone`, `useNextRun`, and `useActivity`.
  */
-export function ZoneDetail({ zone, nextRun, activity, isActivityLoading, onRunNow }: ZoneDetailProps) {
+export function ZoneDetail({ zone, nextRun, activity, isActivityLoading, onRunNow, onViewActivity }: ZoneDetailProps) {
     const geometry = computeBatteryGeometry(zone.currentDepletionMm, zone.rawMm);
     const toneColor = TONE_COLOR[geometry.tone];
     const statusCopy = computeZoneStatusCopy(zone, nextRun);
@@ -99,7 +102,19 @@ export function ZoneDetail({ zone, nextRun, activity, isActivityLoading, onRunNo
             </View>
 
             <View>
-                <Text style={styles.sectionHeading}>Recent runs</Text>
+                <View style={styles.recentRunsHeading}>
+                    <Text style={styles.sectionHeading}>Recent runs</Text>
+                    {onViewActivity && (
+                        <Pressable
+                            onPress={onViewActivity}
+                            accessibilityRole='link'
+                            accessibilityLabel='View all in Activity'
+                            hitSlop={8}
+                        >
+                            <Text style={styles.recentRunsLink}>View all in Activity →</Text>
+                        </Pressable>
+                    )}
+                </View>
                 {activity.length === 0 && isActivityLoading ? (
                     <Text style={styles.emptyState}>Loading recent runs…</Text>
                 ) : activity.length === 0 ? (
@@ -241,6 +256,18 @@ const styles = StyleSheet.create({
         fontSize: 16,
         lineHeight: 20,
         color: colors.fg,
+    },
+    recentRunsHeading: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+    },
+    recentRunsLink: {
+        marginBottom: 10,
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 12,
+        lineHeight: 14,
+        color: colors['fg-muted'],
     },
     attrTable: {
         borderTopWidth: 1,


### PR DESCRIPTION
## Ticket

[APP-67](http://192.168.2.100:7123/home/browse/APP-67/) — Link "Recent runs" on Zone detail to Activity view with zone preselected.

## Summary

Adds a "View all in Activity →" link at the top-right of the Zone detail's "Recent runs" section heading. Tapping it navigates to `/activity?zoneId=<id>`, where the Activity view seeds its filter chip strip from the param so the zone is preselected on mount.

- `ActivityView` gets an optional `initialZoneId` prop; the route reads `useLocalSearchParams<{ zoneId?: string }>()` and threads it through.
- `ZoneDetail` gets an optional `onViewActivity` callback; the route wires it to `router.push({ pathname: '/activity', params: { zoneId: zone.id } } as never)`.
- Chip strip remains user-controlled after first render — tapping a different chip (or "All zones") replaces the selection normally.

## Test plan

- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 598 passing (5 new on this branch)
- [ ] Smoke: Home → zone tile → Zone detail → tap "View all in Activity →" → Activity opens with the zone chip selected and the fire log filtered.
- [ ] Smoke: from the seeded Activity view, tap "All zones" → filter clears, fire log refetches without zoneId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)