### PR TITLE
[APP-65] Center Toggle thumb inside the track

### DIFF
--- a/app/components/toggle/.test.tsx
+++ b/app/components/toggle/.test.tsx
@@ -1,7 +1,47 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { StyleSheet, View } from 'react-native';
 
-import { Toggle } from '.';
+import { Toggle, computeToggleGeometry } from '.';
+
+describe('computeToggleGeometry', () => {
+    it('returns the documented default-size geometry.', () => {
+        expect(computeToggleGeometry('default')).toEqual({
+            width: 44,
+            height: 26,
+            thumbSize: 18,
+            thumbInset: 4,
+            thumbTravel: 18,
+        });
+    });
+
+    it('returns the documented lg-size geometry.', () => {
+        expect(computeToggleGeometry('lg')).toEqual({
+            width: 54,
+            height: 30,
+            thumbSize: 22,
+            thumbInset: 4,
+            thumbTravel: 24,
+        });
+    });
+
+    it.each(['default', 'lg'] as const)(
+        'centers the %s-size thumb vertically (top space equals bottom space) (APP-65).',
+        (size) => {
+            const g = computeToggleGeometry(size);
+            const bottomSpace = g.height - g.thumbInset - g.thumbSize;
+            expect(g.thumbInset).toBe(bottomSpace);
+        },
+    );
+
+    it.each(['default', 'lg'] as const)(
+        'matches the %s-size off-state left gap to the on-state right gap (APP-65).',
+        (size) => {
+            const g = computeToggleGeometry(size);
+            const onStateRightGap = g.width - g.thumbInset - g.thumbTravel - g.thumbSize;
+            expect(g.thumbInset).toBe(onStateRightGap);
+        },
+    );
+});
 
 describe('Toggle', () => {
     it('exposes the switch role with the supplied accessibility label.', () => {

--- a/app/components/toggle/index.tsx
+++ b/app/components/toggle/index.tsx
@@ -17,6 +17,38 @@ const SIZE_SPEC = {
     lg: { width: 54, height: 30, padding: 3 },
 } as const;
 
+export type ToggleSize = keyof typeof SIZE_SPEC;
+
+/**
+ * Pure geometry helper. Returns the width, height, thumb size, thumb inset,
+ * and translateX distance the `Toggle` renders for a given size.
+ *
+ * The thumb is sized to fit inside the track minus the 1px border on each
+ * side plus the design's `padding` gap around the thumb:
+ *     thumbSize = height − 2*padding − 2  // -2 = top border + bottom border
+ *
+ * `thumbInset` is the symmetric distance from the track's outer edge to the
+ * thumb on the closer side (top / off-state-left / on-state-right). Using it
+ * for both `top` and `left` keeps the off-state and on-state visual gaps
+ * symmetric on all four sides — without it the thumb sits 2px too high and
+ * the off-state-left gap differs from the on-state-right gap by 2px (APP-65).
+ *
+ *     thumbInset = (height - thumbSize) / 2  // = padding + 1 after the math falls out
+ */
+export function computeToggleGeometry(size: ToggleSize): {
+    width: number;
+    height: number;
+    thumbSize: number;
+    thumbInset: number;
+    thumbTravel: number;
+} {
+    const spec = SIZE_SPEC[size];
+    const thumbSize = spec.height - spec.padding * 2 - 2;
+    const thumbInset = (spec.height - thumbSize) / 2;
+    const thumbTravel = spec.width - spec.height;
+    return { width: spec.width, height: spec.height, thumbSize, thumbInset, thumbTravel };
+}
+
 const toggle = tv({
     slots: {
         track: 'rounded-r-1 border',
@@ -48,7 +80,7 @@ export type ToggleProps = {
     onValueChange: (next: boolean) => void;
 
     /** Optional. Hit-target size. `default` 44×26; `lg` 54×30 (used by the master irrigation switch). Defaults to `default`. */
-    size?: keyof typeof SIZE_SPEC;
+    size?: ToggleSize;
 
     /** Optional. Disables interaction and dims the control. Defaults to `false`. */
     disabled?: ToggleVariants['disabled'];
@@ -71,9 +103,7 @@ export function Toggle({
     disabled = false,
     accessibilityLabel,
 }: ToggleProps) {
-    const spec = SIZE_SPEC[size];
-    const thumbSize = spec.height - spec.padding * 2 - 2;
-    const thumbTravel = spec.width - spec.height;
+    const geometry = computeToggleGeometry(size);
 
     const animated = useRef(new Animated.Value(value ? 1 : 0)).current;
     useEffect(() => {
@@ -94,7 +124,7 @@ export function Toggle({
     });
     const thumbTranslateX = animated.interpolate({
         inputRange: [0, 1],
-        outputRange: [0, thumbTravel],
+        outputRange: [0, geometry.thumbTravel],
     });
 
     const styles = toggle({ on: value, disabled });
@@ -107,7 +137,7 @@ export function Toggle({
             accessibilityLabel={accessibilityLabel}
             accessibilityState={{ checked: value, disabled }}
         >
-            <View style={{ width: spec.width, height: spec.height }}>
+            <View style={{ width: geometry.width, height: geometry.height }}>
                 <Animated.View
                     className={styles.track()}
                     style={{
@@ -122,10 +152,10 @@ export function Toggle({
                 <Animated.View
                     className={styles.thumb()}
                     style={{
-                        top: spec.padding,
-                        left: spec.padding,
-                        width: thumbSize,
-                        height: thumbSize,
+                        top: geometry.thumbInset,
+                        left: geometry.thumbInset,
+                        width: geometry.thumbSize,
+                        height: geometry.thumbSize,
                         backgroundColor: thumbBackgroundColor,
                         transform: [{ translateX: thumbTranslateX }],
                     }}


### PR DESCRIPTION
## Ticket

[APP-65](http://192.168.2.100:7123/home/browse/APP-65/) — Irrigation toggle thumb sits too high inside the track.

## Root cause

`Toggle`'s thumb sizing correctly accounted for the 1px border + padding on each side (`thumbSize = height - 2*padding - 2`), but its positioning used `top: padding` — ignoring the top border. Same on the left axis. Net effect: thumb 2px too high; off-state-left gap and on-state-right gap differed by 2px.

## Fix

Extracted a pure `computeToggleGeometry(size)` helper returning `{ width, height, thumbSize, thumbInset, thumbTravel }` where `thumbInset = (height - thumbSize) / 2`. Toggle uses that inset for **both** `top` and `left`. After the math falls out, `thumbInset = padding + 1` (the 1px border) and works out to 4 for both `default` and `lg` sizes, producing 4px of symmetric gap on all four sides.

## Test plan

- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 604 passing (6 new on this branch)
- [x] New tests assert symmetry: top space equals bottom space; off-state-left gap equals on-state-right gap; both `default` and `lg` sizes covered
- [ ] Smoke: master-irrigation toggle in the app — thumb is vertically centered in both on and off states

🤖 Generated with [Claude Code](https://claude.com/claude-code)