### PR TITLE
[APP-28] Manual zone-run sheet with duration stepper

### DIFF
--- a/app/app/zone/[slug].tsx
+++ b/app/app/zone/[slug].tsx
@@ -1,13 +1,15 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { FireSheet } from '@/components/fire-sheet';
 import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
 import { ZoneDetail } from '@/components/zone-detail';
 import { FontFamily } from '@/constants/fonts';
 import { useActivity } from '@/hooks/activity';
 import { useNextRun } from '@/hooks/next-run';
 import { useZone } from '@/hooks/zone';
+import { useRunZone } from '@/hooks/zone-control';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
@@ -22,6 +24,8 @@ export default function ZoneScreen() {
     const { zone, isPending } = useZone(slug);
     const nextRun = useNextRun();
     const activity = useActivity({ zoneId: zone?.id });
+    const runZone = useRunZone();
+    const [isFireSheetOpen, setFireSheetOpen] = useState<boolean>(false);
 
     // Redirect when the slug doesn't match any zone in the loaded list.
     const shouldRedirect = !isPending && zone === undefined;
@@ -52,8 +56,20 @@ export default function ZoneScreen() {
                 nextRun={nextRun.data}
                 activity={flattened}
                 isActivityLoading={activity.isPending}
-                onRunNow={() => {}}
+                onRunNow={() => setFireSheetOpen(true)}
                 onViewActivity={() => router.push({ pathname: '/activity', params: { zoneId: zone.id } } as never)}
+            />
+            <FireSheet
+                visible={isFireSheetOpen}
+                zone={zone}
+                onCancel={() => setFireSheetOpen(false)}
+                onRun={durationMin => {
+                    runZone.mutate(
+                        { zoneId: zone.id, durationMin },
+                        { onSettled: () => setFireSheetOpen(false) },
+                    );
+                }}
+                isSubmitting={runZone.isPending}
             />
         </RefreshableScrollView>
     );

--- a/app/components/fire-sheet/.test.tsx
+++ b/app/components/fire-sheet/.test.tsx
@@ -1,0 +1,242 @@
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+
+import type { ZoneSummary } from '@/api/types/zones';
+import { FireSheet } from '.';
+
+function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
+    return {
+        id: 'z-1',
+        slug: 'north',
+        name: 'North',
+        isEnabled: true,
+        grassType: { name: 'Kentucky Bluegrass' },
+        soilType: { name: 'Loam' },
+        areaM2: 100,
+        rootDepthM: 0.3,
+        allowableDepletionFraction: 0.5,
+        irrigationEfficiency: 0.8,
+        microclimateFactor: 1.05,
+        precipitationRateMmPerHr: 14,
+        currentDepletionMm: 5,
+        rawMm: 22.5,
+        lastFiredAt: null,
+        lastAppliedMm: null,
+        homeAssistantEntityId: 'switch.north_zone',
+        patch: 'a',
+        ...overrides,
+    };
+}
+
+function pressTimes(label: string, times: number) {
+    for (let i = 0; i < times; i++) {
+        fireEvent.press(screen.getByLabelText(label));
+    }
+}
+
+describe('FireSheet', () => {
+    it('renders the zone name and grass · area subtitle in the header.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Run North')).toBeOnTheScreen();
+        expect(screen.getByText('Kentucky Bluegrass · 100 m²')).toBeOnTheScreen();
+    });
+
+    it('starts the duration stepper at 5 minutes.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('5')).toBeOnTheScreen();
+        expect(screen.getByText('minutes')).toBeOnTheScreen();
+    });
+
+    it('decrements the readout by 1 when the minus button is pressed.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('Decrease minutes'));
+
+        expect(screen.getByText('4')).toBeOnTheScreen();
+    });
+
+    it('increments the readout by 1 when the plus button is pressed.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('Increase minutes'));
+
+        expect(screen.getByText('6')).toBeOnTheScreen();
+    });
+
+    it('uses the singular "minute" label at 1 and "minutes" everywhere else.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        // Plural at the default (5).
+        expect(screen.getByText('minutes')).toBeOnTheScreen();
+
+        // Step down to 1 — minus is pressed 4 times.
+        pressTimes('Decrease minutes', 4);
+
+        expect(screen.getByText('1')).toBeOnTheScreen();
+        expect(screen.getByText('minute')).toBeOnTheScreen();
+        expect(screen.queryByText('minutes')).toBeNull();
+    });
+
+    it('clamps at the minimum of 1 minute and disables the minus button.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        // Step down past the floor; extra presses must be no-ops.
+        pressTimes('Decrease minutes', 10);
+
+        expect(screen.getByText('1')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Decrease minutes').props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it('clamps at the maximum of 60 minutes and disables the plus button.', () => {
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        // Step up past the ceiling; extra presses must be no-ops.
+        pressTimes('Increase minutes', 80);
+
+        expect(screen.getByText('60')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Increase minutes').props.accessibilityState).toMatchObject({ disabled: true });
+    });
+
+    it('fires onCancel — and not onRun — when Cancel is tapped.', () => {
+        const onCancel = jest.fn();
+        const onRun = jest.fn();
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={onCancel}
+                onRun={onRun}
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Cancel'));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(onRun).not.toHaveBeenCalled();
+    });
+
+    it('fires onRun with the currently displayed minute count when Run now is tapped.', () => {
+        const onRun = jest.fn();
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={onRun}
+            />,
+        );
+
+        // Bump to 12.
+        pressTimes('Increase minutes', 7);
+        fireEvent.press(screen.getByText('Run now'));
+
+        expect(onRun).toHaveBeenCalledTimes(1);
+        expect(onRun).toHaveBeenCalledWith(12);
+    });
+
+    it('disables Run now while the caller marks the mutation as submitting.', () => {
+        const onRun = jest.fn();
+        render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={onRun}
+                isSubmitting
+            />,
+        );
+
+        fireEvent.press(screen.getByText('Run now'));
+
+        expect(onRun).not.toHaveBeenCalled();
+    });
+
+    it('resets the readout to 5 each time the sheet is re-opened.', () => {
+        const { rerender } = render(
+            <FireSheet
+                visible
+                zone={buildZone()}
+                onCancel={jest.fn()}
+                onRun={jest.fn()}
+            />,
+        );
+
+        // User picks 20 in the first opening.
+        pressTimes('Increase minutes', 15);
+        expect(screen.getByText('20')).toBeOnTheScreen();
+
+        // Close and re-open.
+        act(() => {
+            rerender(
+                <FireSheet
+                    visible={false}
+                    zone={buildZone()}
+                    onCancel={jest.fn()}
+                    onRun={jest.fn()}
+                />,
+            );
+        });
+        act(() => {
+            rerender(
+                <FireSheet
+                    visible
+                    zone={buildZone()}
+                    onCancel={jest.fn()}
+                    onRun={jest.fn()}
+                />,
+            );
+        });
+
+        expect(screen.getByText('5')).toBeOnTheScreen();
+    });
+});

--- a/app/components/fire-sheet/index.tsx
+++ b/app/components/fire-sheet/index.tsx
@@ -12,7 +12,7 @@ const colors = config.theme.extend.colors;
 
 const MIN_MINUTES = 1;
 const MAX_MINUTES = 60;
-const DEFAULT_MINUTES = 5;
+const DEFAULT_MINUTES = 1;
 
 /**
  * Props for the manual zone-run confirmation sheet.
@@ -52,14 +52,12 @@ export function FireSheet({ visible, zone, onCancel, onRun, isSubmitting = false
     const canIncrement = minutes < MAX_MINUTES;
 
     return (
-        <Sheet
-            visible={visible}
-            onRequestClose={onCancel}
-            accessibilityLabel={`Run ${zone.name}`}
-        >
+        <Sheet visible={visible} onRequestClose={onCancel} accessibilityLabel={`Run ${zone.name}`}>
             <View style={styles.header}>
                 <Text style={styles.title}>Run {zone.name}</Text>
-                <Text style={styles.subtitle}>{zone.grassType.name} · {zone.areaM2} m²</Text>
+                <Text style={styles.subtitle}>
+                    {zone.grassType.name} · {zone.areaM2} m²
+                </Text>
             </View>
 
             <View style={styles.stepperCard}>
@@ -96,14 +94,12 @@ export function FireSheet({ visible, zone, onCancel, onRun, isSubmitting = false
 
             <View style={styles.footer}>
                 <View style={styles.footerSlot}>
-                    <Button variant='secondary' onPress={onCancel}>Cancel</Button>
+                    <Button variant='secondary' onPress={onCancel}>
+                        Cancel
+                    </Button>
                 </View>
                 <View style={styles.footerSlot}>
-                    <Button
-                        variant='primary'
-                        onPress={() => onRun(minutes)}
-                        disabled={isSubmitting}
-                    >
+                    <Button variant='primary' onPress={() => onRun(minutes)} disabled={isSubmitting}>
                         Run now
                     </Button>
                 </View>

--- a/app/components/fire-sheet/index.tsx
+++ b/app/components/fire-sheet/index.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+
+import type { ZoneSummary } from '@/api/types/zones';
+import { Button } from '@/components/button';
+import { Sheet } from '@/components/sheet';
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+const MIN_MINUTES = 1;
+const MAX_MINUTES = 60;
+const DEFAULT_MINUTES = 5;
+
+/**
+ * Props for the manual zone-run confirmation sheet.
+ */
+export type FireSheetProps = {
+    /** Required. Whether the sheet is visible. */
+    visible: boolean;
+
+    /** Required. The zone whose manual run is being confirmed. */
+    zone: ZoneSummary;
+
+    /** Required. Fires when the user taps Cancel or the backdrop. */
+    onCancel: () => void;
+
+    /** Required. Fires with the chosen duration (minutes) when Run now is tapped. */
+    onRun: (durationMin: number) => void;
+
+    /** Optional. Disables the Run now button while the caller's mutation is in flight. Defaults to false. */
+    isSubmitting?: boolean;
+};
+
+/**
+ * Bottom sheet that confirms a manual run for a zone. Header shows the zone
+ * name + grass · area, body owns a 1–60 minute stepper (default 5), footer
+ * splits Cancel · Run now. Re-opening (visible flips false → true) resets
+ * the readout to the default so a previous opening's choice doesn't bleed
+ * in. RN port of `FireSheet` from `app/design/ui_kit/Mobile.jsx`.
+ */
+export function FireSheet({ visible, zone, onCancel, onRun, isSubmitting = false }: FireSheetProps) {
+    const [minutes, setMinutes] = useState<number>(DEFAULT_MINUTES);
+
+    useEffect(() => {
+        if (visible) setMinutes(DEFAULT_MINUTES);
+    }, [visible]);
+
+    const canDecrement = minutes > MIN_MINUTES;
+    const canIncrement = minutes < MAX_MINUTES;
+
+    return (
+        <Sheet
+            visible={visible}
+            onRequestClose={onCancel}
+            accessibilityLabel={`Run ${zone.name}`}
+        >
+            <View style={styles.header}>
+                <Text style={styles.title}>Run {zone.name}</Text>
+                <Text style={styles.subtitle}>{zone.grassType.name} · {zone.areaM2} m²</Text>
+            </View>
+
+            <View style={styles.stepperCard}>
+                <Text style={styles.eyebrow}>Duration</Text>
+                <View style={styles.stepperRow}>
+                    <Button
+                        variant='secondary'
+                        size='lg'
+                        iconOnly
+                        disabled={!canDecrement}
+                        onPress={() => setMinutes(m => Math.max(MIN_MINUTES, m - 1))}
+                        accessibilityLabel='Decrease minutes'
+                    >
+                        <MinusGlyph />
+                    </Button>
+
+                    <View style={styles.readout}>
+                        <Text style={styles.readoutValue}>{minutes}</Text>
+                        <Text style={styles.readoutLabel}>{minutes === 1 ? 'minute' : 'minutes'}</Text>
+                    </View>
+
+                    <Button
+                        variant='secondary'
+                        size='lg'
+                        iconOnly
+                        disabled={!canIncrement}
+                        onPress={() => setMinutes(m => Math.min(MAX_MINUTES, m + 1))}
+                        accessibilityLabel='Increase minutes'
+                    >
+                        <PlusGlyph />
+                    </Button>
+                </View>
+            </View>
+
+            <View style={styles.footer}>
+                <View style={styles.footerSlot}>
+                    <Button variant='secondary' onPress={onCancel}>Cancel</Button>
+                </View>
+                <View style={styles.footerSlot}>
+                    <Button
+                        variant='primary'
+                        onPress={() => onRun(minutes)}
+                        disabled={isSubmitting}
+                    >
+                        Run now
+                    </Button>
+                </View>
+            </View>
+        </Sheet>
+    );
+}
+
+function MinusGlyph() {
+    return (
+        <Svg width={16} height={16} viewBox='0 0 16 16' fill='none'>
+            <Path d='M3 8 H 13' stroke={colors.fg} strokeWidth={1.75} strokeLinecap='square' />
+        </Svg>
+    );
+}
+
+function PlusGlyph() {
+    return (
+        <Svg width={16} height={16} viewBox='0 0 16 16' fill='none'>
+            <Path d='M3 8 H 13 M8 3 V 13' stroke={colors.fg} strokeWidth={1.75} strokeLinecap='square' />
+        </Svg>
+    );
+}
+
+const styles = StyleSheet.create({
+    header: {
+        marginBottom: 20,
+    },
+    title: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 32,
+        lineHeight: 34,
+        letterSpacing: -0.8,
+        color: colors.fg,
+    },
+    subtitle: {
+        marginTop: 4,
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+    stepperCard: {
+        backgroundColor: colors['ink-200'],
+        borderWidth: 1,
+        borderColor: colors.hairline,
+        borderRadius: 6,
+        paddingTop: 18,
+        paddingHorizontal: 14,
+        paddingBottom: 16,
+        marginBottom: 14,
+    },
+    eyebrow: {
+        textAlign: 'center',
+        marginBottom: 12,
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 10,
+        lineHeight: 12,
+        letterSpacing: 1.4,
+        textTransform: 'uppercase',
+        color: colors['fg-muted'],
+    },
+    stepperRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+    },
+    readout: {
+        flex: 1,
+        alignItems: 'center',
+        gap: 2,
+    },
+    readoutValue: {
+        fontFamily: FontFamily.monoMedium,
+        fontSize: 56,
+        lineHeight: 56,
+        color: colors.fg,
+    },
+    readoutLabel: {
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 17,
+        color: colors['fg-muted'],
+    },
+    footer: {
+        flexDirection: 'row',
+        gap: 10,
+    },
+    footerSlot: {
+        flex: 1,
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-28](http://192.168.2.100:7123/home/browse/APP-28/) Manual zone-run sheet — duration stepper

## Summary

- New `FireSheet` component at `app/components/fire-sheet/` — bottom sheet with header (`Run {zone.name}` + grass · area), a 1–60 minute duration stepper (default 5) with minus/plus buttons that disable at the bounds, and a Cancel · Run now footer.
- Wired into the zone-detail route ([app/app/zone/[slug].tsx](app/app/zone/[slug].tsx)): tapping Run now opens the sheet; confirming POSTs `/zones/:id/run` via the existing `useRunZone` mutation, which closes the sheet on settle and invalidates the zones + next-run caches.
- Stepper resets to 5 each time the sheet is reopened so the previous choice doesn't bleed in.
- 11 behavior-driven tests for the FireSheet (header, default duration, increment/decrement, singular/plural suffix, min/max clamping with disabled-state assertions, Cancel isolation, onRun argument, isSubmitting disable, reset-on-reopen).

## Test plan

- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 79 suites, 615 tests passing
- [ ] Device verification: tap a zone tile → tap Run now → confirm the sheet opens with the zone name/grass/area + stepper at 5 min → bounds clamp at 1 and 60 → Cancel closes without firing → Run now POSTs with the displayed duration, closes the sheet, refreshes the zone list / next run.