### PR TITLE
[API-81] Expose active manual-fire state on GET /zones

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -893,6 +893,8 @@ describe('buildApp GET /zones', () => {
             lastAppliedMm: 14,
             homeAssistantEntityId: 'switch.sprinkler_controller_north_zone',
             patch: 'a',
+            isRunning: false,
+            willCloseAt: null,
             ...overrides,
         };
     }

--- a/api/index.ts
+++ b/api/index.ts
@@ -852,7 +852,7 @@ if (import.meta.main) {
         zoneById: zoneId => getZoneById(zoneId),
         schedule: wrapScheduleWithReplan(baseSchedule, () => daemon.rePlan()),
         replan: () => daemon.rePlan(),
-        zonesSummary: () => getZoneSummaries(),
+        zonesSummary: () => getZoneSummaries(manual.getActiveZone()),
         alerts: {
             list: () => listActiveAlerts(alertsDb),
             ack: id => acknowledgeAlert(alertsDb, id),

--- a/api/models/manual.ts
+++ b/api/models/manual.ts
@@ -4,12 +4,15 @@ import type { Notifier } from '@/notifications';
 
 /**
  * Snapshot of the active manual fire (if any). Drives the HTTP status the
- * mobile app shows on the Zone detail screen.
+ * mobile app shows on the Zone detail screen. `willCloseAt` is the scheduled
+ * auto-close instant set by `run()`; `null` after the bare `open()` path,
+ * which has no auto-close.
  */
 export type ActiveManualSnapshot = {
     zoneId: string;
     zoneName: string;
     since: Date;
+    willCloseAt: Date | null;
 };
 
 /**

--- a/api/models/zone.ts
+++ b/api/models/zone.ts
@@ -24,6 +24,8 @@ export type ZoneSummary = {
     lastAppliedMm: number | null;
     homeAssistantEntityId: string | null;
     patch: string;
+    isRunning: boolean;
+    willCloseAt: string | null;
 };
 
 /**

--- a/api/service/manual/.test.ts
+++ b/api/service/manual/.test.ts
@@ -139,7 +139,7 @@ describe('manual controller — open', () => {
         expect(opens).toHaveLength(1);
         expect(opens[0]?.id).toBe('zone-001');
         expect(result.since.getTime()).toBe(NOW.getTime());
-        expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-001', zoneName: 'Front Lawn', since: NOW });
+        expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-001', zoneName: 'Front Lawn', since: NOW, willCloseAt: null });
         const started = calls.find(c => c.event === 'watering-started');
         expect(started?.context).toEqual({ zoneName: 'Front Lawn', reason: 'manual' });
         // `open` alone doesn't write — the write happens at close (or up-front in `run`).
@@ -522,7 +522,25 @@ describe('manual controller — getActiveZone and shutdown', () => {
 
         await controller.open(buildZone({ id: 'zone-007', name: 'Side Strip' }));
 
-        expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-007', zoneName: 'Side Strip', since: NOW });
+        expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-007', zoneName: 'Side Strip', since: NOW, willCloseAt: null });
+    });
+
+    it('getActiveZone surfaces willCloseAt as openedAt + durationMin after run()', async () => {
+        const { clock } = createFakeClock(NOW);
+        const controller = createManualController({
+            clock,
+            openZone: async () => {},
+            closeZone: async () => {},
+            notifier: async () => {},
+            isAnyScheduledInFlight: () => false,
+            isIrrigationEnabled: async () => true,
+        });
+
+        await controller.run(buildZone({ id: 'zone-007', name: 'Side Strip' }), 12);
+
+        const snapshot = controller.getActiveZone();
+        expect(snapshot?.zoneId).toBe('zone-007');
+        expect(snapshot?.willCloseAt).toEqual(new Date(NOW.getTime() + 12 * 60_000));
     });
 
     it('shutdown closes any active manual zone and cancels the close timer', async () => {

--- a/api/service/manual/index.ts
+++ b/api/service/manual/index.ts
@@ -65,6 +65,7 @@ function getRepo(): ManualRepository {
 type ActiveManualFire = {
     zone: Zone;
     openedAt: Date;
+    willCloseAt: Date | null;
     closeHandle?: TimerHandle;
     cycleId?: string;
     runDurationMin?: number;
@@ -114,7 +115,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         }
 
         const openedAt = clock.now();
-        current = { zone, openedAt };
+        current = { zone, openedAt, willCloseAt: null };
         console.log(`manual: opened zone ${zone.id} at ${openedAt.toISOString()}.`);
         await notifier('watering-started', { zoneName: zone.name, reason: 'manual' });
 
@@ -217,7 +218,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
             });
         }, durationMin * 60_000);
 
-        current = { zone, openedAt, closeHandle, cycleId: cycleId ?? undefined, runDurationMin: durationMin };
+        current = { zone, openedAt, willCloseAt, closeHandle, cycleId: cycleId ?? undefined, runDurationMin: durationMin };
         console.log(`manual: opened zone ${zone.id} at ${openedAt.toISOString()} for ${durationMin} min (auto-close).`);
         await notifier('watering-started', { zoneName: zone.name, durationMin, reason: 'manual' });
 
@@ -226,7 +227,12 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
 
     const getActiveZone: ManualController['getActiveZone'] = () => {
         if (current === null) return null;
-        return { zoneId: current.zone.id, zoneName: current.zone.name, since: current.openedAt };
+        return {
+            zoneId: current.zone.id,
+            zoneName: current.zone.name,
+            since: current.openedAt,
+            willCloseAt: current.willCloseAt,
+        };
     };
 
     const shutdown: ManualController['shutdown'] = async () => {

--- a/api/service/zones/.test.ts
+++ b/api/service/zones/.test.ts
@@ -67,7 +67,7 @@ describe('mapJoinedRowToSummary', () => {
             soilType: { availableWaterHoldingCapacityMmPerM: 140 },
         });
 
-        const summary = mapJoinedRowToSummary(row, null);
+        const summary = mapJoinedRowToSummary(row, null, null);
 
         expect(summary.rawMm).toBe(21);
     });
@@ -78,13 +78,13 @@ describe('mapJoinedRowToSummary', () => {
             soilType: { availableWaterHoldingCapacityMmPerM: 137 },
         });
 
-        const summary = mapJoinedRowToSummary(row, null);
+        const summary = mapJoinedRowToSummary(row, null, null);
 
         expect(summary.rawMm).toBe(16.65);
     });
 
     it('emits null lastFiredAt and lastAppliedMm when no fire entry is supplied', () => {
-        const summary = mapJoinedRowToSummary(summaryRow(), null);
+        const summary = mapJoinedRowToSummary(summaryRow(), null, null);
 
         expect(summary.lastFiredAt).toBeNull();
         expect(summary.lastAppliedMm).toBeNull();
@@ -95,14 +95,14 @@ describe('mapJoinedRowToSummary', () => {
             zoneId: 'zone-001',
             firedAt: new Date('2026-05-13T05:00:00.000Z'),
             appliedDepthMm: 14,
-        });
+        }, null);
 
         expect(summary.lastFiredAt).toBe('2026-05-13T05:00:00.000Z');
         expect(summary.lastAppliedMm).toBe(14);
     });
 
     it('passes the patch variant through from the zone row', () => {
-        const summary = mapJoinedRowToSummary(summaryRow({ zone: { patch: 'b' } }), null);
+        const summary = mapJoinedRowToSummary(summaryRow({ zone: { patch: 'b' } }), null, null);
 
         expect(summary.patch).toBe('b');
     });
@@ -111,7 +111,7 @@ describe('mapJoinedRowToSummary', () => {
         const summary = mapJoinedRowToSummary(summaryRow({
             grassType: { name: 'Bermudagrass' },
             soilType: { name: 'Sandy Loam' },
-        }), null);
+        }), null, null);
 
         expect(summary.grassType).toEqual({ name: 'Bermudagrass' });
         expect(summary.soilType).toEqual({ name: 'Sandy Loam' });
@@ -128,7 +128,7 @@ describe('mapJoinedRowToSummary', () => {
                 homeAssistantEntityId: 'switch.back_yard',
                 precipitationRateMmPerHr: 12.5,
             },
-        }), null);
+        }), null, null);
 
         expect(summary.id).toBe('zone-007');
         expect(summary.slug).toBe('back-yard');
@@ -142,10 +142,53 @@ describe('mapJoinedRowToSummary', () => {
     it('emits null for missing homeAssistantEntityId and precipitationRateMmPerHr', () => {
         const summary = mapJoinedRowToSummary(summaryRow({
             zone: { homeAssistantEntityId: null, precipitationRateMmPerHr: null },
-        }), null);
+        }), null, null);
 
         expect(summary.homeAssistantEntityId).toBeNull();
         expect(summary.precipitationRateMmPerHr).toBeNull();
+    });
+
+    it('emits isRunning: false and willCloseAt: null when no manual fire is active', () => {
+        const summary = mapJoinedRowToSummary(summaryRow(), null, null);
+
+        expect(summary.isRunning).toBe(false);
+        expect(summary.willCloseAt).toBeNull();
+    });
+
+    it('emits isRunning: false and willCloseAt: null when a different zone is firing', () => {
+        const summary = mapJoinedRowToSummary(summaryRow({ zone: { id: 'zone-001' } }), null, {
+            zoneId: 'zone-other',
+            zoneName: 'Other',
+            since: new Date('2026-05-13T05:00:00.000Z'),
+            willCloseAt: new Date('2026-05-13T05:15:00.000Z'),
+        });
+
+        expect(summary.isRunning).toBe(false);
+        expect(summary.willCloseAt).toBeNull();
+    });
+
+    it('emits isRunning: true and the ISO willCloseAt when the row matches a timed run', () => {
+        const summary = mapJoinedRowToSummary(summaryRow({ zone: { id: 'zone-001' } }), null, {
+            zoneId: 'zone-001',
+            zoneName: 'Front Lawn',
+            since: new Date('2026-05-13T05:00:00.000Z'),
+            willCloseAt: new Date('2026-05-13T05:15:00.000Z'),
+        });
+
+        expect(summary.isRunning).toBe(true);
+        expect(summary.willCloseAt).toBe('2026-05-13T05:15:00.000Z');
+    });
+
+    it('emits isRunning: true and willCloseAt: null when the row matches a bare open (no auto-close)', () => {
+        const summary = mapJoinedRowToSummary(summaryRow({ zone: { id: 'zone-001' } }), null, {
+            zoneId: 'zone-001',
+            zoneName: 'Front Lawn',
+            since: new Date('2026-05-13T05:00:00.000Z'),
+            willCloseAt: null,
+        });
+
+        expect(summary.isRunning).toBe(true);
+        expect(summary.willCloseAt).toBeNull();
     });
 });
 
@@ -171,7 +214,7 @@ describe('getZoneSummaries', () => {
             }),
         });
 
-        const result = await getZoneSummaries();
+        const result = await getZoneSummaries(null);
 
         expect(result).toHaveLength(2);
         expect(result[0]?.name).toBe('North');
@@ -191,7 +234,7 @@ describe('getZoneSummaries', () => {
             }),
         });
 
-        const result = await getZoneSummaries();
+        const result = await getZoneSummaries(null);
 
         expect(result).toEqual([]);
     });
@@ -204,10 +247,34 @@ describe('getZoneSummaries', () => {
             }),
         });
 
-        const result = await getZoneSummaries();
+        const result = await getZoneSummaries(null);
 
         expect(result).toHaveLength(1);
         expect(result[0]?.lastFiredAt).toBeNull();
         expect(result[0]?.lastAppliedMm).toBeNull();
+    });
+
+    it('flips isRunning on the matching zone and leaves siblings untouched when a snapshot is passed', async () => {
+        bootZonesService({
+            repo: fakeRepo({
+                loadJoinedRowsForSummary: async () => [
+                    summaryRow({ zone: { id: 'zone-1', name: 'North' } }),
+                    summaryRow({ zone: { id: 'zone-2', name: 'South' } }),
+                ],
+                loadLatestFires: async () => [],
+            }),
+        });
+
+        const result = await getZoneSummaries({
+            zoneId: 'zone-2',
+            zoneName: 'South',
+            since: new Date('2026-05-13T05:00:00.000Z'),
+            willCloseAt: new Date('2026-05-13T05:15:00.000Z'),
+        });
+
+        expect(result[0]?.isRunning).toBe(false);
+        expect(result[0]?.willCloseAt).toBeNull();
+        expect(result[1]?.isRunning).toBe(true);
+        expect(result[1]?.willCloseAt).toBe('2026-05-13T05:15:00.000Z');
     });
 });

--- a/api/service/zones/index.ts
+++ b/api/service/zones/index.ts
@@ -1,4 +1,5 @@
 import type { Database } from '@/db';
+import type { ActiveManualSnapshot } from '@/models/manual';
 import type { Zone } from '@/models';
 import type { LatestZoneFire, ZoneSummary } from '@/models/zone';
 import {
@@ -52,33 +53,51 @@ export async function getZoneCounts(): Promise<ZoneCountResult> {
  * Loads the full `ZoneSummary` list for the mobile app's Home screen and Zone
  * detail header. Fans out two queries via the repository, then merges them in
  * JS by zone id. `rawMm` is computed here (service-tier DTO concern).
+ *
+ * @param activeFire - Snapshot of the active manual fire from
+ *   `ManualController.getActiveZone()`, or `null` when nothing is firing. Used
+ *   to set `isRunning` / `willCloseAt` on the matching zone. Sourced at the
+ *   composition root so this function stays pure.
  */
-export async function getZoneSummaries(): Promise<ZoneSummary[]> {
+export async function getZoneSummaries(activeFire: ActiveManualSnapshot | null): Promise<ZoneSummary[]> {
     const r = getRepo();
     const [rows, latest] = await Promise.all([
         r.loadJoinedRowsForSummary(),
         r.loadLatestFires(),
     ]);
     const latestByZone = new Map<string, LatestZoneFire>(latest.map(entry => [entry.zoneId, entry]));
-    const summaries = rows.map(row => mapJoinedRowToSummary(row, latestByZone.get(row.zone.id) ?? null));
+    const summaries = rows.map(row => mapJoinedRowToSummary(row, latestByZone.get(row.zone.id) ?? null, activeFire));
     console.log(`zones: getZoneSummaries returned ${summaries.length} zone(s).`);
     return summaries;
 }
 
 /**
  * Pure mapping: turns a joined zones × grass × soil row plus an optional
- * latest-fire entry into the `ZoneSummary` DTO. Computes `rawMm` and rounds
- * to two decimals so the wire payload stays compact and stable.
+ * latest-fire entry and the active-manual-fire snapshot into the
+ * `ZoneSummary` DTO. Computes `rawMm` and rounds to two decimals so the wire
+ * payload stays compact and stable.
+ *
+ * `isRunning` is true only when `activeFire?.zoneId === row.zone.id`.
+ * `willCloseAt` is the ISO of the snapshot's auto-close instant for the
+ * matching zone — `null` for any non-matching zone, and `null` for the
+ * matching zone when it was opened via the bare `open()` path (no
+ * auto-close).
  */
 export function mapJoinedRowToSummary(
     row: SummaryJoinedRow,
     lastFire: LatestZoneFire | null,
+    activeFire: ActiveManualSnapshot | null,
 ): ZoneSummary {
     const rawMmRaw =
         row.soilType.availableWaterHoldingCapacityMmPerM *
         row.zone.rootDepthM *
         row.zone.allowableDepletionFraction;
     const rawMm = Math.round(rawMmRaw * 100) / 100;
+
+    const isRunning = activeFire?.zoneId === row.zone.id;
+    const willCloseAt = isRunning && activeFire?.willCloseAt
+        ? activeFire.willCloseAt.toISOString()
+        : null;
 
     return {
         id: row.zone.id,
@@ -99,5 +118,7 @@ export function mapJoinedRowToSummary(
         lastAppliedMm: lastFire ? lastFire.appliedDepthMm : null,
         homeAssistantEntityId: row.zone.homeAssistantEntityId,
         patch: row.zone.patch,
+        isRunning,
+        willCloseAt,
     };
 }

--- a/app/api/types/zones.ts
+++ b/app/api/types/zones.ts
@@ -21,4 +21,8 @@ export type ZoneSummary = {
     lastAppliedMm: number | null;
     homeAssistantEntityId: string | null;
     patch: string;
+    /** True when this zone is currently watering via a manual fire. APP-69 / API-81. */
+    isRunning: boolean;
+    /** ISO-8601 instant when the active manual fire will auto-close. `null` for bare opens (no auto-close) and for non-running zones. */
+    willCloseAt: string | null;
 };

--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -36,6 +36,8 @@ function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
         lastAppliedMm: null,
         homeAssistantEntityId: 'switch.zone_north',
         patch: 'a',
+        isRunning: false,
+        willCloseAt: null,
         ...overrides,
     };
 }

--- a/app/components/fire-sheet/.test.tsx
+++ b/app/components/fire-sheet/.test.tsx
@@ -23,6 +23,8 @@ function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
         lastAppliedMm: null,
         homeAssistantEntityId: 'switch.north_zone',
         patch: 'a',
+        isRunning: false,
+        willCloseAt: null,
         ...overrides,
     };
 }
@@ -48,7 +50,7 @@ describe('FireSheet', () => {
         expect(screen.getByText('Kentucky Bluegrass · 100 m²')).toBeOnTheScreen();
     });
 
-    it('starts the duration stepper at 5 minutes.', () => {
+    it('starts the duration stepper at 1 minute.', () => {
         render(
             <FireSheet
                 visible
@@ -58,8 +60,8 @@ describe('FireSheet', () => {
             />,
         );
 
-        expect(screen.getByText('5')).toBeOnTheScreen();
-        expect(screen.getByText('minutes')).toBeOnTheScreen();
+        expect(screen.getByText('1')).toBeOnTheScreen();
+        expect(screen.getByText('minute')).toBeOnTheScreen();
     });
 
     it('decrements the readout by 1 when the minus button is pressed.', () => {
@@ -72,9 +74,11 @@ describe('FireSheet', () => {
             />,
         );
 
+        // Step up past the floor so decrement has somewhere to go.
+        pressTimes('Increase minutes', 3);
         fireEvent.press(screen.getByLabelText('Decrease minutes'));
 
-        expect(screen.getByText('4')).toBeOnTheScreen();
+        expect(screen.getByText('3')).toBeOnTheScreen();
     });
 
     it('increments the readout by 1 when the plus button is pressed.', () => {
@@ -89,7 +93,7 @@ describe('FireSheet', () => {
 
         fireEvent.press(screen.getByLabelText('Increase minutes'));
 
-        expect(screen.getByText('6')).toBeOnTheScreen();
+        expect(screen.getByText('2')).toBeOnTheScreen();
     });
 
     it('uses the singular "minute" label at 1 and "minutes" everywhere else.', () => {
@@ -102,15 +106,15 @@ describe('FireSheet', () => {
             />,
         );
 
-        // Plural at the default (5).
-        expect(screen.getByText('minutes')).toBeOnTheScreen();
-
-        // Step down to 1 — minus is pressed 4 times.
-        pressTimes('Decrease minutes', 4);
-
-        expect(screen.getByText('1')).toBeOnTheScreen();
+        // Singular at the default (1).
         expect(screen.getByText('minute')).toBeOnTheScreen();
         expect(screen.queryByText('minutes')).toBeNull();
+
+        // Step up to 2 — plural takes over.
+        fireEvent.press(screen.getByLabelText('Increase minutes'));
+
+        expect(screen.getByText('2')).toBeOnTheScreen();
+        expect(screen.getByText('minutes')).toBeOnTheScreen();
     });
 
     it('clamps at the minimum of 1 minute and disables the minus button.', () => {
@@ -176,12 +180,12 @@ describe('FireSheet', () => {
             />,
         );
 
-        // Bump to 12.
+        // Bump from the default of 1 up to 8.
         pressTimes('Increase minutes', 7);
         fireEvent.press(screen.getByText('Run now'));
 
         expect(onRun).toHaveBeenCalledTimes(1);
-        expect(onRun).toHaveBeenCalledWith(12);
+        expect(onRun).toHaveBeenCalledWith(8);
     });
 
     it('disables Run now while the caller marks the mutation as submitting.', () => {
@@ -201,7 +205,7 @@ describe('FireSheet', () => {
         expect(onRun).not.toHaveBeenCalled();
     });
 
-    it('resets the readout to 5 each time the sheet is re-opened.', () => {
+    it('resets the readout to 1 minute each time the sheet is re-opened.', () => {
         const { rerender } = render(
             <FireSheet
                 visible
@@ -212,7 +216,7 @@ describe('FireSheet', () => {
         );
 
         // User picks 20 in the first opening.
-        pressTimes('Increase minutes', 15);
+        pressTimes('Increase minutes', 19);
         expect(screen.getByText('20')).toBeOnTheScreen();
 
         // Close and re-open.
@@ -237,6 +241,6 @@ describe('FireSheet', () => {
             );
         });
 
-        expect(screen.getByText('5')).toBeOnTheScreen();
+        expect(screen.getByText('1')).toBeOnTheScreen();
     });
 });

--- a/app/components/home-view/.test.tsx
+++ b/app/components/home-view/.test.tsx
@@ -62,6 +62,8 @@ const SAMPLE_ZONES: ZoneSummary[] = [
         lastAppliedMm: 14,
         homeAssistantEntityId: 'switch.zone_north',
         patch: 'a',
+        isRunning: false,
+        willCloseAt: null,
     },
     {
         id: 'zone-002',
@@ -82,6 +84,8 @@ const SAMPLE_ZONES: ZoneSummary[] = [
         lastAppliedMm: 9,
         homeAssistantEntityId: 'switch.zone_south',
         patch: 'b',
+        isRunning: false,
+        willCloseAt: null,
     },
 ];
 

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -25,6 +25,8 @@ function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
         lastAppliedMm: null,
         homeAssistantEntityId: 'switch.north_zone',
         patch: 'a',
+        isRunning: false,
+        willCloseAt: null,
         ...overrides,
     };
 }

--- a/app/components/zone-detail/zone-status.test.ts
+++ b/app/components/zone-detail/zone-status.test.ts
@@ -22,6 +22,8 @@ function buildZone(overrides?: Partial<ZoneSummary>): ZoneSummary {
         lastAppliedMm: null,
         homeAssistantEntityId: 'switch.north_zone',
         patch: 'a',
+        isRunning: false,
+        willCloseAt: null,
         ...overrides,
     };
 }

--- a/app/components/zone-tile/.test.tsx
+++ b/app/components/zone-tile/.test.tsx
@@ -31,6 +31,8 @@ const HEALTHY_ZONE: ZoneSummary = {
     lastAppliedMm: 14,
     homeAssistantEntityId: 'switch.zone_north',
     patch: 'a',
+    isRunning: false,
+    willCloseAt: null,
 };
 
 const PAST_RAW_ZONE: ZoneSummary = {


### PR DESCRIPTION
## Ticket

[API-81](http://192.168.2.100:7123/home/browse/API-81/) Expose active manual-fire state on GET /zones

## Summary

- `ZoneSummary` (and the mirrored client DTO) grows two new fields: `isRunning: boolean` and `willCloseAt: string | null`. Both are set from the existing in-memory `ManualController` state — `isRunning` is true when the snapshot's `zoneId` matches the row; `willCloseAt` is the ISO of the snapshot's auto-close instant (`null` for non-matching zones and for the bare `open()` path which has no auto-close).
- `ActiveManualSnapshot` (`api/models/manual.ts`) grows a `willCloseAt: Date | null` field; the controller sets it in `run()` and leaves it `null` in `open()`. `getActiveZone()` surfaces it.
- `getZoneSummaries()` and `mapJoinedRowToSummary()` (`api/service/zones/index.ts`) take an `activeFire: ActiveManualSnapshot | null` argument. The composition root (`api/index.ts`) wires `manual.getActiveZone()` through on each request — the function stays pure, the snapshot is request-scoped.
- New tests: 4 cases on `mapJoinedRowToSummary` (null / mismatch / match-with-willCloseAt / match-without-willCloseAt), 1 case on `getZoneSummaries`, 1 case on `manualController.getActiveZone` after `run()`. Existing snapshot-equality assertions on `getActiveZone()` widened to include the new field.
- Drive-by: pre-existing failures in `app/components/fire-sheet/.test.tsx` (broken by an APP-28 follow-up that changed `DEFAULT_MINUTES` from 5 to 1 without updating the tests — commit `8c70a82`) are fixed in this PR so the app suite is green again.

## Test plan

- [x] `bun --cwd=./api run type-check` clean
- [x] `bun --cwd=./api test` — 907 passed, 0 fail
- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 615 passed, 79 suites
- [ ] Smoke: `curl http://localhost:9753/zones` while a manual run is in flight — confirm `isRunning: true` + `willCloseAt: <ISO>` on the firing zone and `isRunning: false` / `willCloseAt: null` on siblings.

## Follow-on

APP-69 consumes these fields to swap the Run-now button for Stop watering on the zone detail screen.