### PR TITLE
[APP-71] Show start time alongside the date on activity rows

### DIFF
--- a/app/app/zone/[slug].tsx
+++ b/app/app/zone/[slug].tsx
@@ -57,6 +57,7 @@ export default function ZoneScreen() {
                 nextRun={nextRun.data}
                 activity={flattened}
                 isActivityLoading={activity.isPending}
+                siteTimezone={nextRun.data?.timezone ?? 'UTC'}
                 onRunNow={() => setFireSheetOpen(true)}
                 onStopWatering={() => closeZone.mutate(zone.id)}
                 isStopping={closeZone.isPending}

--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -175,7 +175,7 @@ describe('ActivityView', () => {
             if (url.includes('/activity')) {
                 return jsonResponse(activityResult([
                     // 03:00 UTC on 2026-05-14 — same instant is 21:00 May 13
-                    // in Edmonton. A UTC fallback renders it as 'May 14'.
+                    // in Edmonton. A UTC fallback renders it as 'May 14 · 3:00 am'.
                     buildActivity({ id: 'a-1', date: '2026-05-14T03:00:00.000Z' }),
                 ]));
             }
@@ -184,7 +184,7 @@ describe('ActivityView', () => {
 
         render(<ActivityView />, { wrapper });
 
-        await waitFor(() => expect(screen.getByText('May 14')).toBeOnTheScreen());
+        await waitFor(() => expect(screen.getByText('May 14 · 3:00 am')).toBeOnTheScreen());
     });
 
     it('flattens multi-page infinite-query results into a single visible list.', () => {

--- a/app/components/fire-log/.test.tsx
+++ b/app/components/fire-log/.test.tsx
@@ -67,8 +67,8 @@ describe('FireLog', () => {
         expect(screen.getByText('30 → 16 mm')).toBeOnTheScreen();
     });
 
-    it('formats the date label via formatActivityDate (site-local MMM D).', () => {
-        // 2026-05-13T15:00Z = 09:00 MDT on 2026-05-13 → 'May 13'.
+    it('formats the date label via formatActivityDate (site-local MMM D · h:mm a).', () => {
+        // 2026-05-13T15:00Z = 09:00 MDT on 2026-05-13 → 'May 13 · 9:00 am'.
         render(
             <FireLog
                 rows={[buildActivity({ date: '2026-05-13T15:00:00.000Z' })]}
@@ -76,7 +76,7 @@ describe('FireLog', () => {
             />,
         );
 
-        expect(screen.getByText('May 13')).toBeOnTheScreen();
+        expect(screen.getByText('May 13 · 9:00 am')).toBeOnTheScreen();
     });
 
     it('inserts hairline dividers between rows but not before the first.', () => {

--- a/app/components/fire-log/index.tsx
+++ b/app/components/fire-log/index.tsx
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
         paddingHorizontal: 14,
     },
     date: {
-        width: 64,
+        width: 120,
         fontFamily: FontFamily.monoMedium,
         fontSize: 11,
         lineHeight: 13,

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -73,6 +73,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -91,6 +92,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -120,6 +122,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -136,6 +139,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -151,6 +155,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -158,9 +163,10 @@ describe('ZoneDetail', () => {
     });
 
     it('renders the recent-runs rows from the supplied activity.', () => {
+        // 2026-05-03T15:00Z = 09:00 MDT on May 3; 2026-05-02T15:00Z = 09:00 MDT on May 2.
         const activity = [
-            buildActivity({ id: 'a-1', date: '2026-05-03T05:00:00.000Z', appliedDepthMm: 9, durationMin: 30, depletionBeforeMm: 22, depletionAfterMm: 0 }),
-            buildActivity({ id: 'a-2', date: '2026-05-02T05:00:00.000Z', appliedDepthMm: 4.5, durationMin: 15, depletionBeforeMm: 13, depletionAfterMm: 0 }),
+            buildActivity({ id: 'a-1', date: '2026-05-03T15:00:00.000Z', appliedDepthMm: 9, durationMin: 30, depletionBeforeMm: 22, depletionAfterMm: 0 }),
+            buildActivity({ id: 'a-2', date: '2026-05-02T15:00:00.000Z', appliedDepthMm: 4.5, durationMin: 15, depletionBeforeMm: 13, depletionAfterMm: 0 }),
         ];
 
         render(
@@ -171,13 +177,38 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
+        expect(screen.getByText('May 3 · 9:00 am')).toBeOnTheScreen();
         expect(screen.getByText('9.0 mm · 30 min')).toBeOnTheScreen();
         expect(screen.getByText('22.0 → 0.0 mm')).toBeOnTheScreen();
+        expect(screen.getByText('May 2 · 9:00 am')).toBeOnTheScreen();
         expect(screen.getByText('4.5 mm · 15 min')).toBeOnTheScreen();
         expect(screen.getByText('13.0 → 0.0 mm')).toBeOnTheScreen();
+    });
+
+    it('formats recent-run dates in the supplied site timezone, not UTC (APP-71).', () => {
+        // 2026-05-14T05:30Z = 23:30 MDT on 2026-05-13 — still May 13 locally,
+        // and the time should read 11:30 pm site-local.
+        const activity = [
+            buildActivity({ id: 'a-1', date: '2026-05-14T05:30:00.000Z' }),
+        ];
+
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={activity}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+                onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
+            />,
+        );
+
+        expect(screen.getByText('May 13 · 11:30 pm')).toBeOnTheScreen();
     });
 
     it('renders an empty state when activity is empty and not loading.', () => {
@@ -189,6 +220,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -204,6 +236,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -220,6 +253,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={onRunNow}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -238,6 +272,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
                 onViewActivity={onViewActivity}
             />,
         );
@@ -256,6 +291,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -271,6 +307,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -287,6 +324,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -305,6 +343,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={onRunNow}
                 onStopWatering={onStopWatering}
+                siteTimezone='America/Edmonton'
             />,
         );
 
@@ -324,6 +363,7 @@ describe('ZoneDetail', () => {
                 isActivityLoading={false}
                 onRunNow={jest.fn()}
                 onStopWatering={onStopWatering}
+                siteTimezone='America/Edmonton'
                 isStopping
             />,
         );

--- a/app/components/zone-detail/index.tsx
+++ b/app/components/zone-detail/index.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import type { ActivityDto } from '@/api/types/activity';
@@ -8,6 +7,7 @@ import { Battery, computeBatteryGeometry } from '@/components/battery';
 import { Button } from '@/components/button';
 import { LawnPatch, type LawnPatchSlug } from '@/components/lawn-patch';
 import { FontFamily } from '@/constants/fonts';
+import { formatActivityDate } from '@/lib/relative-time';
 import config from '@/tailwind.config';
 
 import { computeZoneStatusCopy } from './zone-status';
@@ -36,6 +36,9 @@ export type ZoneDetailProps = {
     /** Required. Whether the activity query is still in its first load. The component renders a hint when this is true and `activity` is empty. */
     isActivityLoading: boolean;
 
+    /** Required. IANA timezone used to format each recent-run row's date and start time. Sourced from `useNextRun().data?.timezone` by the route. APP-71. */
+    siteTimezone: string;
+
     /** Required. Fires when the user taps "Run now". Hidden when `zone.isRunning` is true (the Stop-watering button takes its place). */
     onRunNow: () => void;
 
@@ -60,6 +63,7 @@ export function ZoneDetail({
     nextRun,
     activity,
     isActivityLoading,
+    siteTimezone,
     onRunNow,
     onStopWatering,
     isStopping = false,
@@ -145,7 +149,7 @@ export function ZoneDetail({
                     <Text style={styles.emptyState}>No runs recorded yet.</Text>
                 :   <View style={styles.fireLog}>
                         {activity.map(row => (
-                            <RecentRunRow key={row.id} row={row} />
+                            <RecentRunRow key={row.id} row={row} siteTimezone={siteTimezone} />
                         ))}
                     </View>
                 }
@@ -163,10 +167,10 @@ function AttrRow({ label, value, mono = false }: { label: string; value: string;
     );
 }
 
-function RecentRunRow({ row }: { row: ActivityDto }) {
+function RecentRunRow({ row, siteTimezone }: { row: ActivityDto; siteTimezone: string }) {
     return (
         <View style={styles.fireRow}>
-            <Text style={styles.fireDate}>{dayjs(row.date).format('MMM D')}</Text>
+            <Text style={styles.fireDate}>{formatActivityDate(row.date, siteTimezone)}</Text>
             <Text style={styles.fireApplied}>
                 {row.appliedDepthMm.toFixed(1)} mm · {row.durationMin} min
             </Text>
@@ -341,7 +345,7 @@ const styles = StyleSheet.create({
         fontSize: 13,
         lineHeight: 17,
         color: colors.fg,
-        width: 64,
+        width: 130,
     },
     fireApplied: {
         flex: 1,

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -79,15 +79,15 @@ describe('formatTimeOfDay', () => {
 });
 
 describe('formatActivityDate', () => {
-    it(`formats an iso instant as 'MMM D' in the supplied site timezone.`, () => {
-        // 2026-05-13T15:00:00Z = 09:00 MDT on 2026-05-13. Locally May 13.
-        expect(formatActivityDate('2026-05-13T15:00:00.000Z', TZ)).toBe('May 13');
+    it(`formats an iso instant as 'MMM D · h:mm a' in the supplied site timezone.`, () => {
+        // 2026-05-13T15:00:00Z = 09:00 MDT on 2026-05-13.
+        expect(formatActivityDate('2026-05-13T15:00:00.000Z', TZ)).toBe('May 13 · 9:00 am');
     });
 
-    it(`uses the site timezone for the calendar-day, not UTC.`, () => {
-        // 2026-05-14T05:30:00Z = 23:30 MDT on 2026-05-13 (still May 13 locally).
-        // A UTC-anchored format would slip to May 14.
-        expect(formatActivityDate('2026-05-14T05:30:00.000Z', TZ)).toBe('May 13');
+    it(`uses the site timezone for both the calendar-day and the time-of-day, not UTC.`, () => {
+        // 2026-05-14T05:30:00Z = 23:30 MDT on 2026-05-13 — still May 13 locally,
+        // and the time should read 11:30 pm site-local, not 5:30 am UTC.
+        expect(formatActivityDate('2026-05-14T05:30:00.000Z', TZ)).toBe('May 13 · 11:30 pm');
     });
 });
 

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -62,13 +62,14 @@ export function formatTimeOfDay(iso: string, timezoneName: string): string {
 }
 
 /**
- * Formats `iso` as a short month-day label (`'May 13'`) in the supplied
- * IANA timezone. Used by the Activity screen's FireLog. Site-local so a
- * UTC-late instant that still lands on "today" locally doesn't slip to
- * the next calendar day.
+ * Formats `iso` as `'MMM D · h:mm a'` (e.g. `'May 13 · 9:00 am'`) in the
+ * supplied IANA timezone. Used by the Activity screen's FireLog and the
+ * Zone detail "Recent runs" rows. Site-local so a UTC-late instant that
+ * still lands on "today" locally doesn't slip to the next calendar day,
+ * and so the time-of-day reads correctly to the operator. APP-71.
  */
 export function formatActivityDate(iso: string, timezoneName: string): string {
-    return dayjs(iso).tz(timezoneName).format('MMM D');
+    return dayjs(iso).tz(timezoneName).format('MMM D · h:mm a');
 }
 
 /**


### PR DESCRIPTION
## Ticket

[APP-71](http://192.168.2.100:7123/home/browse/APP-71/) Activity rows — show start time alongside the date

## Summary

- `formatActivityDate` now returns `MMM D · h:mm a` (e.g. `"May 13 · 9:00 am"`) in the site timezone. Both consumers (Activity screen's `FireLog`, Zone detail's "Recent runs") pick up the new format through the same call site.
- `RecentRunRow` swapped its inline `dayjs(row.date).format('MMM D')` for the shared `formatActivityDate(row.date, siteTimezone)` — unified formatting + site-local instead of device-local.
- `ZoneDetail` gains a required `siteTimezone: string` prop; the slug route sources it from `useNextRun().data?.timezone ?? 'UTC'`, mirroring `activity-view`.
- Date column widened to 120 px (FireLog) / 130 px (RecentRunRow) to fit the longer combined string at the existing font sizes.
- 1 new test in `zone-detail/.test.tsx` for the timezone edge case (a UTC instant past local midnight still renders the previous local day's date and local time-of-day). Updated assertions in `relative-time/.test.ts`, `fire-log/.test.tsx`, and `activity-view/.test.tsx` for the new combined string.

## Test plan

- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 623 passed, 79 suites
- [ ] Device:
  - Open the **Activity** screen → each row reads `"<MMM D> · <h:mm am/pm>"` in site time.
  - Open a zone's detail page → the "Recent runs" rows use the same combined label.
  - Both columns are wide enough that nothing truncates.