### PR TITLE
[API-83] Surface startedAt on the Activity DTO

### DIFF
--- a/api/activity/.test.ts
+++ b/api/activity/.test.ts
@@ -13,6 +13,7 @@ type JoinedRow = {
     entry: EntryRow;
     zone: { id: string; name: string; slug: string };
     durationMin: number;
+    startedAt: Date | null;
 };
 
 const NOW = new Date('2026-05-21T12:00:00.000Z');
@@ -37,6 +38,7 @@ function buildJoinedRow(overrides?: {
     entry?: Partial<EntryRow>;
     zone?: Partial<{ id: string; name: string; slug: string }>;
     durationMin?: number;
+    startedAt?: Date | null;
 }): JoinedRow {
     return {
         entry: buildEntry(overrides?.entry),
@@ -47,6 +49,7 @@ function buildJoinedRow(overrides?: {
             ...overrides?.zone,
         },
         durationMin: overrides?.durationMin ?? 0,
+        startedAt: overrides?.startedAt !== undefined ? overrides.startedAt : new Date('2026-05-20T05:00:00.000Z'),
     };
 }
 
@@ -111,6 +114,7 @@ describe('listActivity', () => {
                 entry: { id: 'e-1', appliedDepthMm: 7.5, depletionBeforeMm: 11.2, depletionAfterMm: 0.3, date: '2026-05-19' },
                 zone: { id: 'zone-7', name: 'Back Strip', slug: 'back-strip' },
                 durationMin: 42,
+                startedAt: new Date('2026-05-19T05:00:00.000Z'),
             }),
         ]);
 
@@ -122,10 +126,42 @@ describe('listActivity', () => {
             zone: { id: 'zone-7', name: 'Back Strip', slug: 'back-strip' },
             appliedDepthMm: 7.5,
             durationMin: 42,
+            startedAt: '2026-05-19T05:00:00.000Z',
             depletionBeforeMm: 11.2,
             depletionAfterMm: 0.3,
             source: 'planner',
         });
+    });
+
+    it('serialises startedAt as an ISO string when the joined row carries a fired-at instant', async () => {
+        const { db } = recordingDb([
+            buildJoinedRow({ entry: { id: 'fired' }, startedAt: new Date('2026-05-20T03:14:15.000Z') }),
+        ]);
+
+        const { activity } = await listActivity(db, { limit: 10 });
+
+        expect(activity[0]?.startedAt).toBe('2026-05-20T03:14:15.000Z');
+    });
+
+    it('serialises startedAt when the value comes from the planned start_time fallback', async () => {
+        // Same JS path as `firedAt`, but the DB-side COALESCE picked the
+        // planned `startTime`. Verifies the field flows through regardless of
+        // upstream source.
+        const { db } = recordingDb([
+            buildJoinedRow({ entry: { id: 'unfired' }, startedAt: new Date('2026-05-20T11:00:00.000Z') }),
+        ]);
+
+        const { activity } = await listActivity(db, { limit: 10 });
+
+        expect(activity[0]?.startedAt).toBe('2026-05-20T11:00:00.000Z');
+    });
+
+    it('emits startedAt: null when the entry has no associated cycles', async () => {
+        const { db } = recordingDb([buildJoinedRow({ entry: { id: 'deferred' }, startedAt: null })]);
+
+        const { activity } = await listActivity(db, { limit: 10 });
+
+        expect(activity[0]?.startedAt).toBeNull();
     });
 
     it('returns durationMin = 0 when the entry has no associated cycles', async () => {

--- a/api/activity/index.ts
+++ b/api/activity/index.ts
@@ -17,6 +17,13 @@ export type ActivitySource = 'planner' | 'manual';
  * `durationMin` is the SUM of associated `irrigation_cycles.duration_min`
  * rows (0 when an entry has no cycles, e.g. a planner entry that was deferred
  * by restrictions).
+ *
+ * `startedAt` is the ISO-8601 instant of the earliest cycle for this entry —
+ * `MIN(COALESCE(fired_at, start_time))` across the joined irrigation_cycles.
+ * `firedAt` first so the wire reports the actual HA-ack instant when present;
+ * falls back to the planned `startTime` for cycles that haven't fired yet.
+ * `null` when the entry has no cycles at all (deferred planner entries). The
+ * sibling `date` field stays the calendar-day cursor key. APP-71 / APP-78.
  */
 export type ActivityDto = {
     id: string;
@@ -24,6 +31,7 @@ export type ActivityDto = {
     zone: { id: string; name: string; slug: string };
     appliedDepthMm: number;
     durationMin: number;
+    startedAt: string | null;
     depletionBeforeMm: number;
     depletionAfterMm: number;
     source: ActivitySource;
@@ -60,6 +68,7 @@ type ActivityJoinedRow = {
     entry: typeof scheduleEntries.$inferSelect;
     zone: { id: string; name: string; slug: string };
     durationMin: number;
+    startedAt: Date | null;
 };
 
 /**
@@ -71,6 +80,7 @@ export type ActivityDb = {
         entry: typeof scheduleEntries;
         zone: { id: typeof zones.id; name: typeof zones.name; slug: typeof zones.slug };
         durationMin: unknown;
+        startedAt: unknown;
     }) => {
         from: (table: typeof scheduleEntries) => {
             innerJoin: (table: typeof zones, on: unknown) => {
@@ -128,6 +138,7 @@ export async function listActivity(db: ActivityDb, params: ActivityListParams): 
             entry: scheduleEntries,
             zone: { id: zones.id, name: zones.name, slug: zones.slug },
             durationMin: sql<number>`COALESCE(SUM(${irrigationCycles.durationMin}), 0)`,
+            startedAt: sql<Date | null>`MIN(COALESCE(${irrigationCycles.firedAt}, ${irrigationCycles.startTime}))`,
         })
         .from(scheduleEntries)
         .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
@@ -154,6 +165,7 @@ function rowToDto(row: ActivityJoinedRow): ActivityDto {
         zone: row.zone,
         appliedDepthMm: row.entry.appliedDepthMm,
         durationMin: row.durationMin,
+        startedAt: row.startedAt !== null ? row.startedAt.toISOString() : null,
         depletionBeforeMm: row.entry.depletionBeforeMm,
         depletionAfterMm: row.entry.depletionAfterMm,
         source: row.entry.source === 'manual' ? 'manual' : 'planner',

--- a/app/api/types/activity.ts
+++ b/app/api/types/activity.ts
@@ -10,6 +10,8 @@ export type ActivityDto = {
     zone: { id: string; name: string; slug: string };
     appliedDepthMm: number;
     durationMin: number;
+    /** ISO-8601 instant of the earliest cycle for this entry — MIN(COALESCE(firedAt, startTime)) on the api. `null` when the entry has no cycles. APP-78 / API-83. */
+    startedAt: string | null;
     depletionBeforeMm: number;
     depletionAfterMm: number;
     source: ActivitySource;

--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -69,6 +69,7 @@ function buildActivity(overrides?: Partial<ActivityDto>): ActivityDto {
         zone: { id: 'z-1', name: 'North', slug: 'north' },
         appliedDepthMm: 14,
         durationMin: 62,
+        startedAt: null,
         depletionBeforeMm: 30,
         depletionAfterMm: 16,
         source: 'planner',

--- a/app/components/fire-log/.test.tsx
+++ b/app/components/fire-log/.test.tsx
@@ -16,6 +16,7 @@ function buildActivity(overrides?: Partial<ActivityDto>): ActivityDto {
         zone: { id: 'z-1', name: 'North', slug: 'north' },
         appliedDepthMm: 14,
         durationMin: 62,
+        startedAt: null,
         depletionBeforeMm: 30,
         depletionAfterMm: 16,
         source: 'planner',

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -38,6 +38,7 @@ function buildActivity(overrides?: Partial<ActivityDto>): ActivityDto {
         zone: { id: 'z-1', name: 'North', slug: 'north' },
         appliedDepthMm: 9,
         durationMin: 30,
+        startedAt: null,
         depletionBeforeMm: 22,
         depletionAfterMm: 0,
         source: 'planner',


### PR DESCRIPTION
## Ticket

[API-83](http://192.168.2.100:7123/home/browse/API-83/) Activity DTO — add startedAt (real start instant) alongside the day-only date

## Summary

- `ActivityDto` gains `startedAt: string | null` (ISO-8601 UTC) on both the api (`api/activity/index.ts`) and the mirrored client type (`app/api/types/activity.ts`).
- Sourced from the existing `irrigation_cycles` left-join via `MIN(COALESCE(${irrigationCycles.firedAt}, ${irrigationCycles.startTime}))` — `firedAt` first so the wire reports the actual HA-ack instant when present, falls back to the planned `startTime` for unfired cycles, and is `null` when an entry has no cycles at all (deferred planner entries). `rowToDto` `.toISOString()`s the value.
- `ActivityJoinedRow` and the `ActivityDb` stub interface gain a matching `startedAt: Date | null` field so the recording test stubs compile.
- `date` stays the calendar-day cursor key — unchanged.
- 3 new tests in `api/activity/.test.ts` covering the `fired_at`, `start_time`-fallback, and no-cycles paths.
- Cascading client fixture updates: `buildActivity` defaults in `zone-detail`, `fire-log`, and `activity-view` test files add `startedAt: null` to satisfy the DTO contract honestly.

## Test plan

- [x] `bun --cwd=./api run type-check` clean
- [x] `bun --cwd=./api test` — 910 passed, 0 fail (3 new)
- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 624 / 80 suites green
- [ ] Smoke (post-merge, post-container-restart): `curl http://192.168.2.100:9753/activity?limit=3` and confirm each row has a `startedAt` ISO timestamp that differs across rows that actually fired at different times today.

## Unblocks

APP-78 — client-side formatter swaps from `date` to `startedAt` for the time-of-day portion of activity rows.