### PR TITLE
[APP-78] Format activity-row time from startedAt instead of day-only date

### DIFF
--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -177,7 +177,7 @@ describe('ActivityView', () => {
                 return jsonResponse(activityResult([
                     // 03:00 UTC on 2026-05-14 — same instant is 21:00 May 13
                     // in Edmonton. A UTC fallback renders it as 'May 14 · 3:00 am'.
-                    buildActivity({ id: 'a-1', date: '2026-05-14T03:00:00.000Z' }),
+                    buildActivity({ id: 'a-1', date: '2026-05-14', startedAt: '2026-05-14T03:00:00.000Z' }),
                 ]));
             }
             return jsonResponse({ error: 'unhandled' }, 500);

--- a/app/components/fire-log/.test.tsx
+++ b/app/components/fire-log/.test.tsx
@@ -12,11 +12,12 @@ const TZ = 'America/Edmonton';
 function buildActivity(overrides?: Partial<ActivityDto>): ActivityDto {
     return {
         id: 'a-1',
-        date: '2026-05-13T15:00:00.000Z',
+        date: '2026-05-13',
         zone: { id: 'z-1', name: 'North', slug: 'north' },
         appliedDepthMm: 14,
         durationMin: 62,
-        startedAt: null,
+        // 09:00 MDT on 2026-05-13 → 'May 13 · 9:00 am'.
+        startedAt: '2026-05-13T15:00:00.000Z',
         depletionBeforeMm: 30,
         depletionAfterMm: 16,
         source: 'planner',
@@ -68,16 +69,27 @@ describe('FireLog', () => {
         expect(screen.getByText('30 → 16 mm')).toBeOnTheScreen();
     });
 
-    it('formats the date label via formatActivityDate (site-local MMM D · h:mm a).', () => {
+    it('formats the date label via formatActivityRowDate (site-local MMM D · h:mm a) when startedAt is present.', () => {
         // 2026-05-13T15:00Z = 09:00 MDT on 2026-05-13 → 'May 13 · 9:00 am'.
         render(
             <FireLog
-                rows={[buildActivity({ date: '2026-05-13T15:00:00.000Z' })]}
+                rows={[buildActivity({ date: '2026-05-13', startedAt: '2026-05-13T15:00:00.000Z' })]}
                 siteTimezone={TZ}
             />,
         );
 
         expect(screen.getByText('May 13 · 9:00 am')).toBeOnTheScreen();
+    });
+
+    it('falls back to date-only `MMM D` when startedAt is null (APP-78).', () => {
+        render(
+            <FireLog
+                rows={[buildActivity({ date: '2026-05-13', startedAt: null })]}
+                siteTimezone={TZ}
+            />,
+        );
+
+        expect(screen.getByText('May 13')).toBeOnTheScreen();
     });
 
     it('inserts hairline dividers between rows but not before the first.', () => {

--- a/app/components/fire-log/index.tsx
+++ b/app/components/fire-log/index.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import type { ActivityDto } from '@/api/types/activity';
 import { FontFamily } from '@/constants/fonts';
-import { formatActivityDate } from '@/lib/relative-time';
+import { formatActivityRowDate } from '@/lib/relative-time';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
@@ -42,7 +42,7 @@ export function FireLog({ rows, siteTimezone }: FireLogProps) {
 }
 
 function FireLogRow({ row, siteTimezone }: { row: ActivityDto; siteTimezone: string }) {
-    const date = formatActivityDate(row.date, siteTimezone);
+    const date = formatActivityRowDate(row.date, row.startedAt, siteTimezone);
     const headline = `${row.appliedDepthMm.toFixed(1)} mm · ${row.durationMin} min`;
     const sub = `${row.depletionBeforeMm} → ${row.depletionAfterMm} mm`;
 

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -166,8 +166,8 @@ describe('ZoneDetail', () => {
     it('renders the recent-runs rows from the supplied activity.', () => {
         // 2026-05-03T15:00Z = 09:00 MDT on May 3; 2026-05-02T15:00Z = 09:00 MDT on May 2.
         const activity = [
-            buildActivity({ id: 'a-1', date: '2026-05-03T15:00:00.000Z', appliedDepthMm: 9, durationMin: 30, depletionBeforeMm: 22, depletionAfterMm: 0 }),
-            buildActivity({ id: 'a-2', date: '2026-05-02T15:00:00.000Z', appliedDepthMm: 4.5, durationMin: 15, depletionBeforeMm: 13, depletionAfterMm: 0 }),
+            buildActivity({ id: 'a-1', date: '2026-05-03', startedAt: '2026-05-03T15:00:00.000Z', appliedDepthMm: 9, durationMin: 30, depletionBeforeMm: 22, depletionAfterMm: 0 }),
+            buildActivity({ id: 'a-2', date: '2026-05-02', startedAt: '2026-05-02T15:00:00.000Z', appliedDepthMm: 4.5, durationMin: 15, depletionBeforeMm: 13, depletionAfterMm: 0 }),
         ];
 
         render(
@@ -190,11 +190,13 @@ describe('ZoneDetail', () => {
         expect(screen.getByText('13.0 → 0.0 mm')).toBeOnTheScreen();
     });
 
-    it('formats recent-run dates in the supplied site timezone, not UTC (APP-71).', () => {
+    it('formats recent-run dates in the supplied site timezone from startedAt (APP-71 / APP-78).', () => {
         // 2026-05-14T05:30Z = 23:30 MDT on 2026-05-13 — still May 13 locally,
-        // and the time should read 11:30 pm site-local.
+        // and the time should read 11:30 pm site-local. The `date` field
+        // says May 14 (planner's scheduled-night bucket); the formatter
+        // prefers `startedAt` and shows the actual local day.
         const activity = [
-            buildActivity({ id: 'a-1', date: '2026-05-14T05:30:00.000Z' }),
+            buildActivity({ id: 'a-1', date: '2026-05-14', startedAt: '2026-05-14T05:30:00.000Z' }),
         ];
 
         render(
@@ -210,6 +212,26 @@ describe('ZoneDetail', () => {
         );
 
         expect(screen.getByText('May 13 · 11:30 pm')).toBeOnTheScreen();
+    });
+
+    it('falls back to date-only `MMM D` on recent-run rows when startedAt is null (APP-78).', () => {
+        const activity = [
+            buildActivity({ id: 'a-1', date: '2026-05-13', startedAt: null }),
+        ];
+
+        render(
+            <ZoneDetail
+                zone={buildZone()}
+                nextRun={undefined}
+                activity={activity}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+                onStopWatering={jest.fn()}
+                siteTimezone='America/Edmonton'
+            />,
+        );
+
+        expect(screen.getByText('May 13')).toBeOnTheScreen();
     });
 
     it('renders an empty state when activity is empty and not loading.', () => {

--- a/app/components/zone-detail/index.tsx
+++ b/app/components/zone-detail/index.tsx
@@ -7,7 +7,7 @@ import { Battery, computeBatteryGeometry } from '@/components/battery';
 import { Button } from '@/components/button';
 import { LawnPatch, type LawnPatchSlug } from '@/components/lawn-patch';
 import { FontFamily } from '@/constants/fonts';
-import { formatActivityDate } from '@/lib/relative-time';
+import { formatActivityRowDate } from '@/lib/relative-time';
 import config from '@/tailwind.config';
 
 import { computeZoneStatusCopy } from './zone-status';
@@ -170,7 +170,7 @@ function AttrRow({ label, value, mono = false }: { label: string; value: string;
 function RecentRunRow({ row, siteTimezone }: { row: ActivityDto; siteTimezone: string }) {
     return (
         <View style={styles.fireRow}>
-            <Text style={styles.fireDate}>{formatActivityDate(row.date, siteTimezone)}</Text>
+            <Text style={styles.fireDate}>{formatActivityRowDate(row.date, row.startedAt, siteTimezone)}</Text>
             <Text style={styles.fireApplied}>
                 {row.appliedDepthMm.toFixed(1)} mm · {row.durationMin} min
             </Text>

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -1,4 +1,4 @@
-import { formatActivityDate, formatCountdown, formatEndsAt, formatLastRan, formatNextRunDate, formatRelativeTime, formatTimeOfDay } from '.';
+import { formatActivityRowDate, formatCountdown, formatEndsAt, formatLastRan, formatNextRunDate, formatRelativeTime, formatTimeOfDay } from '.';
 
 const TZ = 'America/Edmonton';
 // 2026-05-23T15:00:00Z = 09:00 MDT on 2026-05-23 (Saturday).
@@ -78,16 +78,29 @@ describe('formatTimeOfDay', () => {
     });
 });
 
-describe('formatActivityDate', () => {
-    it(`formats an iso instant as 'MMM D · h:mm a' in the supplied site timezone.`, () => {
+describe('formatActivityRowDate', () => {
+    it(`formats both the day and the time-of-day from startedAt in the supplied site timezone.`, () => {
         // 2026-05-13T15:00:00Z = 09:00 MDT on 2026-05-13.
-        expect(formatActivityDate('2026-05-13T15:00:00.000Z', TZ)).toBe('May 13 · 9:00 am');
+        expect(formatActivityRowDate('2026-05-13', '2026-05-13T15:00:00.000Z', TZ)).toBe('May 13 · 9:00 am');
     });
 
-    it(`uses the site timezone for both the calendar-day and the time-of-day, not UTC.`, () => {
-        // 2026-05-14T05:30:00Z = 23:30 MDT on 2026-05-13 — still May 13 locally,
-        // and the time should read 11:30 pm site-local, not 5:30 am UTC.
-        expect(formatActivityDate('2026-05-14T05:30:00.000Z', TZ)).toBe('May 13 · 11:30 pm');
+    it(`keys both the day and the time off startedAt — so a UTC instant that rolls back to the previous local day renders on that local day.`, () => {
+        // 2026-05-14T05:30:00Z = 23:30 MDT on 2026-05-13. The bare 'date'
+        // field says May 14 (the planner's scheduled-night bucket); the
+        // formatter prefers startedAt and shows the actual local day.
+        expect(formatActivityRowDate('2026-05-14', '2026-05-14T05:30:00.000Z', TZ)).toBe('May 13 · 11:30 pm');
+    });
+
+    it(`falls back to date-only 'MMM D' when startedAt is null.`, () => {
+        expect(formatActivityRowDate('2026-05-13', null, TZ)).toBe('May 13');
+    });
+
+    it(`formats the date-only fallback verbatim without timezone math.`, () => {
+        // No matter what site timezone the caller supplies, a null startedAt
+        // returns the same calendar-day label — the bare YYYY-MM-DD string
+        // never shifts. Pass UTC here to prove no .tz() conversion happens.
+        expect(formatActivityRowDate('2026-05-13', null, 'UTC')).toBe('May 13');
+        expect(formatActivityRowDate('2026-05-13', null, TZ)).toBe('May 13');
     });
 });
 

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -62,14 +62,21 @@ export function formatTimeOfDay(iso: string, timezoneName: string): string {
 }
 
 /**
- * Formats `iso` as `'MMM D · h:mm a'` (e.g. `'May 13 · 9:00 am'`) in the
- * supplied IANA timezone. Used by the Activity screen's FireLog and the
- * Zone detail "Recent runs" rows. Site-local so a UTC-late instant that
- * still lands on "today" locally doesn't slip to the next calendar day,
- * and so the time-of-day reads correctly to the operator. APP-71.
+ * Formats an activity-row label using the real start instant when available
+ * and falling back to the entry's calendar day when not.
+ *
+ * When `startedAt` is non-null, both the day and the time-of-day come from
+ * the real instant (`'May 13 · 9:00 am'`) in the supplied IANA timezone —
+ * the label stays internally consistent across midnight-rollover edge
+ * cases. When `startedAt` is null (deferred planner entries with no
+ * cycles), falls back to date-only (`'May 13'`) formatted directly from
+ * the day-only `date` string without timezone math. APP-71 / APP-78.
  */
-export function formatActivityDate(iso: string, timezoneName: string): string {
-    return dayjs(iso).tz(timezoneName).format('MMM D · h:mm a');
+export function formatActivityRowDate(date: string, startedAt: string | null, timezoneName: string): string {
+    if (startedAt !== null) {
+        return dayjs(startedAt).tz(timezoneName).format('MMM D · h:mm a');
+    }
+    return dayjs(date).format('MMM D');
 }
 
 /**


### PR DESCRIPTION
## Ticket

[APP-78](http://192.168.2.100:7123/home/browse/APP-78/) Activity rows — format the start time from startedAt instead of the day-only date

## Summary

- Renamed `formatActivityDate(iso, tz)` → `formatActivityRowDate(date, startedAt, tz)` in `app/lib/relative-time/index.ts`.
  - `startedAt !== null` → format both day and time from the real instant: `'MMM D · h:mm a'` in the site timezone. Keeps the label internally consistent across midnight rollover (a fire that opened at 23:00 site-local renders on its actual local day, not the planner's scheduled-night bucket).
  - `startedAt === null` → fall back to date-only `'MMM D'` from the bare `date` string. No timezone math so the calendar day never shifts.
- Swapped both call sites: `FireLog` (Activity screen) and `RecentRunRow` (Zone detail).
- Tests: 4 new cases for `formatActivityRowDate` (replacing the two old `formatActivityDate` cases), 1 new null-fallback case in `fire-log`, 1 new null-fallback case in `zone-detail`. Existing assertions updated to feed real `startedAt` fixtures.

## Test plan

- [x] `bun --cwd=./app run typecheck` clean
- [x] `bun --cwd=./app run test` — 628 / 80 suites green (624 + 4 new)
- [ ] Device (after merge): Activity screen rows now show distinct times for multiple cycles on the same day (e.g. `May 29 · 12:06 am` planner vs `May 29 · 1:42 pm` manual fire), not the constant `6:00 am` from before. Same on the Zone detail "Recent runs" rows. A planner-deferred entry with no cycles shows date-only (`May 29`).

## Closes the APP-71 hole

APP-71 incorrectly assumed `ActivityDto.date` was a full ISO instant. API-83 added the real `startedAt` field; this PR consumes it.