### PR TITLE
[API-82] Run api container with bun run dev for hot reload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
             EXPO_ACCESS_TOKEN: ${EXPO_ACCESS_TOKEN}
         ports:
             - "${PORT}:9753"
-        command: sh -c "bun run start"
+        command: sh -c "bun run dev"
         networks:
             - backend
             - frontend


### PR DESCRIPTION
## Ticket

[API-82](http://192.168.2.100:7123/home/browse/API-82/) api container: swap `bun run start` for `bun run dev` so source changes auto-reload

## Summary

- Changed the api service's compose `command` from `bun run start` (= `bun index.ts`, no watcher) to `bun run dev` (= `bun --watch index.ts`).
- Edits under `./api` now trigger an automatic Bun restart through the existing bind mount — no more `docker compose restart api` after every change.
- Right call for the single-instance local-dev deploy; if a prod compose file is ever added, it can override `command` back to `start`.