### PR TITLE
[API-84] Parse startedAt sql aggregate as a string, not a Date

### DIFF
--- a/api/activity/.test.ts
+++ b/api/activity/.test.ts
@@ -13,7 +13,7 @@ type JoinedRow = {
     entry: EntryRow;
     zone: { id: string; name: string; slug: string };
     durationMin: number;
-    startedAt: Date | null;
+    startedAt: string | null;
 };
 
 const NOW = new Date('2026-05-21T12:00:00.000Z');
@@ -38,7 +38,7 @@ function buildJoinedRow(overrides?: {
     entry?: Partial<EntryRow>;
     zone?: Partial<{ id: string; name: string; slug: string }>;
     durationMin?: number;
-    startedAt?: Date | null;
+    startedAt?: string | null;
 }): JoinedRow {
     return {
         entry: buildEntry(overrides?.entry),
@@ -49,7 +49,7 @@ function buildJoinedRow(overrides?: {
             ...overrides?.zone,
         },
         durationMin: overrides?.durationMin ?? 0,
-        startedAt: overrides?.startedAt !== undefined ? overrides.startedAt : new Date('2026-05-20T05:00:00.000Z'),
+        startedAt: overrides?.startedAt !== undefined ? overrides.startedAt : '2026-05-20T05:00:00.000Z',
     };
 }
 
@@ -114,7 +114,7 @@ describe('listActivity', () => {
                 entry: { id: 'e-1', appliedDepthMm: 7.5, depletionBeforeMm: 11.2, depletionAfterMm: 0.3, date: '2026-05-19' },
                 zone: { id: 'zone-7', name: 'Back Strip', slug: 'back-strip' },
                 durationMin: 42,
-                startedAt: new Date('2026-05-19T05:00:00.000Z'),
+                startedAt: '2026-05-19T05:00:00.000Z',
             }),
         ]);
 
@@ -135,7 +135,7 @@ describe('listActivity', () => {
 
     it('serialises startedAt as an ISO string when the joined row carries a fired-at instant', async () => {
         const { db } = recordingDb([
-            buildJoinedRow({ entry: { id: 'fired' }, startedAt: new Date('2026-05-20T03:14:15.000Z') }),
+            buildJoinedRow({ entry: { id: 'fired' }, startedAt: '2026-05-20T03:14:15.000Z' }),
         ]);
 
         const { activity } = await listActivity(db, { limit: 10 });
@@ -148,12 +148,27 @@ describe('listActivity', () => {
         // planned `startTime`. Verifies the field flows through regardless of
         // upstream source.
         const { db } = recordingDb([
-            buildJoinedRow({ entry: { id: 'unfired' }, startedAt: new Date('2026-05-20T11:00:00.000Z') }),
+            buildJoinedRow({ entry: { id: 'unfired' }, startedAt: '2026-05-20T11:00:00.000Z' }),
         ]);
 
         const { activity } = await listActivity(db, { limit: 10 });
 
         expect(activity[0]?.startedAt).toBe('2026-05-20T11:00:00.000Z');
+    });
+
+    it('normalises a raw Postgres timestamptz text value into canonical ISO (API-84 regression)', async () => {
+        // The `startedAt` aggregate is a raw `sql<>` expression, so the driver
+        // returns the libpq text form — space-separated, no `T`, no trailing `Z`
+        // — rather than an auto-deserialized Date. rowToDto must parse and
+        // normalize it; the original bug called `.toISOString()` on the string
+        // and threw `row.startedAt.toISOString is not a function`.
+        const { db } = recordingDb([
+            buildJoinedRow({ entry: { id: 'pg-text' }, startedAt: '2026-05-30 06:06:00+00' }),
+        ]);
+
+        const { activity } = await listActivity(db, { limit: 10 });
+
+        expect(activity[0]?.startedAt).toBe('2026-05-30T06:06:00.000Z');
     });
 
     it('emits startedAt: null when the entry has no associated cycles', async () => {

--- a/api/activity/index.ts
+++ b/api/activity/index.ts
@@ -68,7 +68,7 @@ type ActivityJoinedRow = {
     entry: typeof scheduleEntries.$inferSelect;
     zone: { id: string; name: string; slug: string };
     durationMin: number;
-    startedAt: Date | null;
+    startedAt: string | null;
 };
 
 /**
@@ -138,7 +138,7 @@ export async function listActivity(db: ActivityDb, params: ActivityListParams): 
             entry: scheduleEntries,
             zone: { id: zones.id, name: zones.name, slug: zones.slug },
             durationMin: sql<number>`COALESCE(SUM(${irrigationCycles.durationMin}), 0)`,
-            startedAt: sql<Date | null>`MIN(COALESCE(${irrigationCycles.firedAt}, ${irrigationCycles.startTime}))`,
+            startedAt: sql<string | null>`MIN(COALESCE(${irrigationCycles.firedAt}, ${irrigationCycles.startTime}))`,
         })
         .from(scheduleEntries)
         .innerJoin(zones, eq(scheduleEntries.zoneId, zones.id))
@@ -165,7 +165,12 @@ function rowToDto(row: ActivityJoinedRow): ActivityDto {
         zone: row.zone,
         appliedDepthMm: row.entry.appliedDepthMm,
         durationMin: row.durationMin,
-        startedAt: row.startedAt !== null ? row.startedAt.toISOString() : null,
+        // `startedAt` is a raw `sql<>` aggregate, so the driver hands back the
+        // libpq text form (e.g. `2026-05-30 06:06:00+00`), not an auto-deserialized
+        // Date like a plain timestamptz column would be. `new Date()` parses both
+        // that space-separated form and canonical ISO; `.toISOString()` normalizes
+        // to the canonical wire form the client expects. See API-84.
+        startedAt: row.startedAt !== null ? new Date(row.startedAt).toISOString() : null,
         depletionBeforeMm: row.entry.depletionBeforeMm,
         depletionAfterMm: row.entry.depletionAfterMm,
         source: row.entry.source === 'manual' ? 'manual' : 'planner',


### PR DESCRIPTION
## Ticket

[API-84](http://192.168.2.100:7123/home/browse/API-84/) — /activity 500s — startedAt sql aggregate returns a string, not a Date

## Summary

- Regression from API-83: `GET /activity` 500s with `row.startedAt.toISOString is not a function`.
- Root cause: the `startedAt` `MIN(COALESCE(...))` aggregate is a raw `sql<>` expression, so the driver returns the libpq text form (`2026-05-30 06:06:00+00`), not an auto-deserialized `Date`. The `sql<Date | null>` annotation lied; `.toISOString()` threw at runtime.
- Re-annotated the aggregate and `ActivityJoinedRow.startedAt` as `string | null`, and `rowToDto` now parses via `new Date(row.startedAt).toISOString()` to normalize to canonical ISO.
- Updated the test stub (`buildJoinedRow` + call sites) to return strings, matching wire reality, and added a regression test feeding Postgres text-format timestamptz that asserts canonical ISO output.