### PR TITLE
[APP-73] Extend drawer background to bottom of screen

### DIFF
--- a/app/components/nav-drawer/.test.tsx
+++ b/app/components/nav-drawer/.test.tsx
@@ -1,5 +1,5 @@
-import { StyleSheet } from 'react-native';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { BackHandler, StyleSheet } from 'react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
 import { keys } from '@/api/query-keys';
@@ -186,23 +186,7 @@ describe('NavDrawer', () => {
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('draws the modal edge-to-edge under the top and bottom system bars.', () => {
-        const { wrapper, client } = buildApiWrapper();
-        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
-
-        const { root } = render(
-            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
-            { wrapper },
-        );
-
-        // The modal must extend under both the status bar and the navigation
-        // bar so its background fills the full viewport (APP-73).
-        const modal = root.find(node => node.props.navigationBarTranslucent !== undefined);
-        expect(modal.props.navigationBarTranslucent).toBe(true);
-        expect(modal.props.statusBarTranslucent).toBe(true);
-    });
-
-    it('insets the panel background by the bottom safe-area so the footer clears the nav bar.', () => {
+    it('stretches the panel from the top to the bottom of the window so its background fills the viewport.', () => {
         const { wrapper, client } = buildApiWrapper();
         client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
 
@@ -211,13 +195,45 @@ describe('NavDrawer', () => {
             { wrapper },
         );
 
-        // The safe-area inset is mocked at 34; the panel pads its bottom by
-        // that amount while its background still fills to the screen edge.
+        // The panel is pinned top:0 / bottom:0 within the full-height overlay,
+        // so its background spans the whole window — including under the system
+        // bars — rather than stopping short at the nav bar (APP-73).
         const panel = screen.getByLabelText('Navigation');
         const flat = StyleSheet.flatten(panel.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
-            | { paddingBottom?: number }
+            | { top?: number; bottom?: number; paddingBottom?: number }
             | undefined;
+        expect(flat?.top).toBe(0);
+        expect(flat?.bottom).toBe(0);
+        // The safe-area inset is mocked at 34; the panel pads its bottom by that
+        // amount so the footer clears the nav bar while the background still
+        // fills to the screen edge (padding sits inside the painted box).
         expect(flat?.paddingBottom).toBe(34);
+    });
+
+    it('dismisses on Android hardware back while the drawer is open.', () => {
+        const onClose = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        const addListener = jest.spyOn(BackHandler, 'addEventListener');
+        render(
+            <NavDrawer visible onClose={onClose} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        const backPress = addListener.mock.calls.find(([event]) => event === 'hardwareBackPress')?.[1];
+        expect(backPress).toBeDefined();
+
+        // Simulate the hardware back press; the drawer should request dismissal
+        // and swallow the event so it doesn't also pop the route.
+        let handled: boolean | null | undefined;
+        act(() => {
+            handled = backPress?.();
+        });
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(handled).toBe(true);
+
+        addListener.mockRestore();
     });
 
 });

--- a/app/components/nav-drawer/.test.tsx
+++ b/app/components/nav-drawer/.test.tsx
@@ -1,9 +1,14 @@
+import { StyleSheet } from 'react-native';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
 import { keys } from '@/api/query-keys';
 import type { ScheduleListItem } from '@/api/types/schedules';
 import { NavDrawer } from '.';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
 
 const mockFetch = jest.fn();
 
@@ -179,6 +184,40 @@ describe('NavDrawer', () => {
 
         expect(onSelect).toHaveBeenCalledWith('schedules');
         expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('draws the modal edge-to-edge under the top and bottom system bars.', () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        const { root } = render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        // The modal must extend under both the status bar and the navigation
+        // bar so its background fills the full viewport (APP-73).
+        const modal = root.find(node => node.props.navigationBarTranslucent !== undefined);
+        expect(modal.props.navigationBarTranslucent).toBe(true);
+        expect(modal.props.statusBarTranslucent).toBe(true);
+    });
+
+    it('insets the panel background by the bottom safe-area so the footer clears the nav bar.', () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={jest.fn()} />,
+            { wrapper },
+        );
+
+        // The safe-area inset is mocked at 34; the panel pads its bottom by
+        // that amount while its background still fills to the screen edge.
+        const panel = screen.getByLabelText('Navigation');
+        const flat = StyleSheet.flatten(panel.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+            | { paddingBottom?: number }
+            | undefined;
+        expect(flat?.paddingBottom).toBe(34);
     });
 
 });

--- a/app/components/nav-drawer/index.tsx
+++ b/app/components/nav-drawer/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import {
-    Modal as RNModal,
+    BackHandler,
     Pressable,
     StyleSheet,
     Text,
@@ -128,6 +128,20 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
         if (visible) setMounted(true);
     }, [visible]);
 
+    // The drawer is no longer an RN Modal (whose separate OS window negotiates
+    // its own system-bar insets and wouldn't reliably extend under the Android
+    // navigation bar — APP-73). Rendering it as an in-tree overlay means it
+    // fills the edge-to-edge activity window, but we lose Modal's automatic
+    // hardware-back dismissal, so wire it up explicitly while the drawer is open.
+    useEffect(() => {
+        if (!visible) return;
+        const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+            onClose();
+            return true;
+        });
+        return () => subscription.remove();
+    }, [visible, onClose]);
+
     const handleSelect = useCallback((id: NavItemId) => {
         onSelect(id);
         onClose();
@@ -156,16 +170,13 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
         .duration(Duration.default)
         .easing(REANIMATED_EASING_STANDARD);
 
+    // While the drawer is fully closed nothing is mounted; `mounted` stays true
+    // through the slide-out so the exit animation can play, then the Reanimated
+    // exit callback flips it back to false.
+    if (!mounted) return null;
+
     return (
-        <RNModal
-            visible={mounted}
-            onRequestClose={onClose}
-            transparent
-            animationType='none'
-            statusBarTranslucent
-            navigationBarTranslucent
-        >
-            <View style={styles.overlay}>
+        <View style={styles.overlay} pointerEvents={visible ? 'auto' : 'none'}>
                 {visible && <Animated.View
                     entering={backdropEnter}
                     exiting={backdropExit}
@@ -226,8 +237,7 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
                         />
                     </View>
                 </Animated.View>}
-            </View>
-        </RNModal>
+        </View>
     );
 }
 
@@ -287,7 +297,18 @@ const ActiveScheduleCard = memo(function ActiveScheduleCard({
 
 const styles = StyleSheet.create({
     overlay: {
-        flex: 1,
+        // Absolutely fills the parent (the edge-to-edge root view in
+        // `app/_layout.tsx`), so the drawer spans the full window height —
+        // including under the status bar and navigation bar — without the
+        // separate-window inset problems an RN Modal had (APP-73). `zIndex` +
+        // `elevation` keep it above the header and routed screens it overlays.
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        zIndex: 50,
+        elevation: 50,
     },
     scrim: {
         position: 'absolute',

--- a/app/components/nav-drawer/index.tsx
+++ b/app/components/nav-drawer/index.tsx
@@ -15,6 +15,7 @@ import Animated, {
     SlideOutLeft,
 } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurView } from 'expo-blur';
 
 import { BrandGlyph } from '@/components/brand-glyph';
@@ -118,6 +119,11 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
     // unmount is synchronized with the slide finishing.
     const [mounted, setMounted] = useState(visible);
 
+    // Bottom safe-area inset pads the panel so the footer card clears the
+    // system navigation bar once `navigationBarTranslucent` lets the modal
+    // draw underneath it (APP-73).
+    const insets = useSafeAreaInsets();
+
     useEffect(() => {
         if (visible) setMounted(true);
     }, [visible]);
@@ -157,6 +163,7 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
             transparent
             animationType='none'
             statusBarTranslucent
+            navigationBarTranslucent
         >
             <View style={styles.overlay}>
                 {visible && <Animated.View
@@ -178,7 +185,7 @@ export function NavDrawer({ visible, onClose, activeId, onSelect }: NavDrawerPro
                 {visible && <Animated.View
                     entering={enterAnimation}
                     exiting={exitAnimation}
-                    style={styles.panel}
+                    style={[styles.panel, { paddingBottom: insets.bottom }]}
                     accessibilityViewIsModal
                     accessibilityLabel='Navigation'
                 >


### PR DESCRIPTION
## Ticket

[APP-73](http://192.168.2.100:7123/home/browse/APP-73/) Drawer background doesn't extend to bottom of screen

## Summary

- The nav drawer is a `transparent` `statusBarTranslucent` modal. On Android edge-to-edge, that lets it draw under the top status bar but **not** the bottom system navigation bar — so the panel/scrim (`bottom: 0`) stopped at the top of the nav bar, leaving a visible gap below the drawer.
- Added `navigationBarTranslucent` to the modal so it goes edge-to-edge at the bottom too; the existing `bottom: 0` panel/scrim now fill the full viewport height.
- Padded the panel's bottom by the safe-area inset (`useSafeAreaInsets`) so the "Switch profile" footer card clears the now-overlapped nav bar; the background still paints full-height since padding sits inside the box.
- Tests: mocked `react-native-safe-area-context`; added coverage asserting the edge-to-edge modal flags and the bottom-inset panel padding.