### PR TITLE
[APP-85] Add the /schedules route

### DIFF
--- a/app/app/schedules.test.tsx
+++ b/app/app/schedules.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import type { ScheduleListItem } from '@/api/types/schedules';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
+}));
+
+import SchedulesScreen from './schedules';
+
+const ACTIVE_SCHEDULE: ScheduleListItem = {
+    id: 'sched-active',
+    slug: 'maintenance',
+    name: 'Maintenance',
+    isActive: true,
+    allowedDays: [1, 3, 5],
+    allowedTimeWindows: [{ start: '22:00', end: '06:00' }],
+    rootDepthMOverride: 0.18,
+    allowableDepletionFractionOverride: 0.5,
+    endBySunrise: true,
+    nextRun: { inLabel: '4h 32m', whenLabel: 'tonight at 10:23pm', zonesLabel: 'North + East' },
+    skippedTonight: false,
+};
+
+const WEEKEND_SCHEDULE: ScheduleListItem = {
+    id: 'sched-weekend',
+    slug: 'weekend',
+    name: 'Weekend',
+    isActive: false,
+    allowedDays: [6, 7],
+    allowedTimeWindows: [{ start: '20:00', end: '04:00' }],
+    rootDepthMOverride: null,
+    allowableDepletionFractionOverride: null,
+    endBySunrise: null,
+};
+
+const ALL_SCHEDULES = [ACTIVE_SCHEDULE, WEEKEND_SCHEDULE];
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('SchedulesScreen route', () => {
+    it('resolves the /schedules route and renders the Schedules screen body.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse(ALL_SCHEDULES));
+
+        render(<SchedulesScreen />, { wrapper: buildApiWrapper().wrapper });
+
+        // The route renders the real ScheduleListView (not a dead-end): the
+        // screen title and the active schedule's name both appear.
+        expect(screen.getByText('Schedules')).toBeOnTheScreen();
+        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
+    });
+
+    it('fetches the schedules list from /schedules when the route mounts.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse(ALL_SCHEDULES));
+
+        render(<SchedulesScreen />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(([url]) => String(url));
+            expect(urls).toContain('http://test.local:9753/schedules');
+        });
+    });
+});

--- a/app/app/schedules.tsx
+++ b/app/app/schedules.tsx
@@ -1,0 +1,29 @@
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
+import { ScheduleListView } from '@/components/schedule-list-view';
+
+/**
+ * Schedules route — the destination for the Home active-profile chip and the
+ * drawer's Schedules / "Switch profile" entry points. `ScheduleListView` owns
+ * no scroll container by design, so the route wraps it in a
+ * `RefreshableScrollView` (the screen-level pull-to-refresh convention).
+ * File-based route at `/schedules` (APP-85).
+ */
+export default function SchedulesScreen() {
+    const insets = useSafeAreaInsets();
+    return (
+        <RefreshableScrollView
+            contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 32 }]}
+        >
+            <ScheduleListView />
+        </RefreshableScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    content: {
+        paddingTop: 16,
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-85](http://192.168.2.100:7123/home/browse/APP-85/) Home active-profile chip navigates to non-existent /schedules route

## Summary

- The Home "On profile" tile (`ActiveScheduleChip`) and the drawer's Schedules / "Switch profile" entry points push `/schedules`, but no `app/app/schedules.tsx` route file existed, so expo-router couldn't resolve it and the screen dead-ended.
- Adds `app/app/schedules.tsx` — a thin route rendering the existing `<ScheduleListView />` body inside a `RefreshableScrollView` (the screen-level pull-to-refresh convention), mirroring the `zone/[slug].tsx` pattern. No `_layout.tsx` change needed — routes are auto-discovered.
- Adds `app/app/schedules.test.tsx` route-resolution coverage — the gap the ticket flagged (prior tests only asserted `router.push('/schedules')` was called, not that the route resolves): verifies the route renders the Schedules screen body and fetches `/schedules` on mount.