### PR TITLE
[API-85] Forecast rain-skip in the planner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,15 @@ PORT=9753
 # commands to Home Assistant. Useful for testing plan generation.
 DRY_RUN=false
 
+# --- Planner ---
+# Forecast rain-skip lookahead, in days (starting tomorrow). Before committing
+# a night's irrigation the planner sums the effective rainfall forecast over
+# this many days; if that rain would by itself bring soil depletion back below
+# the watering trigger, the night is deferred (standard smart-controller "rain
+# delay"). The daemon re-plans every evening, so a skip is reconsidered the
+# next day if the rain doesn't arrive. Set to 0 to disable the rain-skip.
+RAIN_SKIP_LOOKAHEAD_DAYS=3
+
 # --- VS Code Dev Container ---
 # UID/GID inside the container must match your host user so bind-mounted
 # files retain the correct ownership. UID/GID 1000 matches a typical

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
-import { runScheduleForZone } from '.';
+import { runScheduleForZone, resolveRainSkipLookaheadDays } from '.';
+import { DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS } from './dynamic';
 import { __resetWeatherCacheForTests } from '../data/weather';
 import { createTestZone } from '../mock/zone';
 
@@ -230,5 +231,27 @@ describe('runScheduleForZone', () => {
         const { entries: schedule } = await runScheduleForZone(zone);
 
         expect(schedule).toHaveLength(0);
+    });
+});
+
+describe('resolveRainSkipLookaheadDays', () => {
+    it('falls back to the default when the env var is unset', () => {
+        expect(resolveRainSkipLookaheadDays(undefined)).toBe(DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS);
+    });
+
+    it('parses a positive integer', () => {
+        expect(resolveRainSkipLookaheadDays('5')).toBe(5);
+    });
+
+    it('accepts 0 to disable the rain-skip', () => {
+        expect(resolveRainSkipLookaheadDays('0')).toBe(0);
+    });
+
+    it('falls back to the default on non-numeric input', () => {
+        expect(resolveRainSkipLookaheadDays('soon')).toBe(DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS);
+    });
+
+    it('falls back to the default on a negative value', () => {
+        expect(resolveRainSkipLookaheadDays('-2')).toBe(DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS);
     });
 });

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -129,7 +129,10 @@ describe('planZoneSchedule', () => {
             expect(schedule).toHaveLength(0);
         });
 
-        it('should handle rainfall after scheduled irrigation', () => {
+        it('should defer irrigation when significant rain is forecast the next day (rain-skip)', () => {
+            // Above the 22.5mm trigger on day 0, but 10mm rain (8mm effective)
+            // is forecast for day 1 — enough to bring depletion below trigger,
+            // so the planner should rain-skip rather than water then overflow.
             const zone = createTestZone({ currentDepletionMm: 23 });
             const weather = createWeatherDays([
                 { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
@@ -139,7 +142,7 @@ describe('planZoneSchedule', () => {
 
             const { entries: schedule } = planZoneSchedule(zone, weather);
 
-            expect(schedule.length).toBeGreaterThan(0);
+            expect(schedule).toHaveLength(0);
         });
 
         it('should handle intermittent rainfall pattern', () => {
@@ -172,6 +175,130 @@ describe('planZoneSchedule', () => {
             // 2mm * 0.8 = 1.6mm effective rainfall, less than 2mm ET.
             // Depletion: 20 + 2 - 1.6 = 20.4mm (still below 22.5mm threshold).
             expect(schedule).toHaveLength(0);
+        });
+    });
+
+    // Forecast rain-skip lookahead (API-85).
+    describe('Forecast rain-skip lookahead', () => {
+        it('defers tonight when rain within the lookahead window will cover the deficit', () => {
+            // Day 0 is above the 22.5mm trigger, but 12mm rain (9.6mm effective)
+            // is forecast two days out — inside the 3-day lookahead — so the
+            // planner should defer rather than water then let the rain overflow.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 12.0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule } = planZoneSchedule(zone, weather);
+
+            expect(schedule).toHaveLength(0);
+        });
+
+        it('still waters when forecast rain is too small to cover the deficit', () => {
+            // 3mm rain (2.4mm effective) doesn't bring 30mm depletion below the
+            // 22.5mm trigger, so the planner waters tonight as usual.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 3.0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule } = planZoneSchedule(zone, weather);
+
+            expect(schedule.length).toBeGreaterThan(0);
+            expect(schedule[0]!.date.format('YYYY-MM-DD')).toBe(weather[0]!.date.format('YYYY-MM-DD'));
+        });
+
+        it('still waters when rain falls beyond the lookahead window', () => {
+            // Heavy rain on day 5 is outside the 3-day lookahead from day 0, so
+            // it must not suppress tonight's watering.
+            const zone = createTestZone({ currentDepletionMm: 25 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 20.0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule } = planZoneSchedule(zone, weather);
+
+            expect(schedule.length).toBeGreaterThan(0);
+            expect(schedule[0]!.date.format('YYYY-MM-DD')).toBe(weather[0]!.date.format('YYYY-MM-DD'));
+        });
+
+        it('ignores sub-2mm forecast rain when deciding whether to skip', () => {
+            // Drizzle (<2mm) is treated as zero effective rain, so it can't
+            // trigger a rain-skip — the planner waters tonight.
+            const zone = createTestZone({ currentDepletionMm: 25 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 1.5 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 1.9 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule } = planZoneSchedule(zone, weather);
+
+            expect(schedule.length).toBeGreaterThan(0);
+            expect(schedule[0]!.date.format('YYYY-MM-DD')).toBe(weather[0]!.date.format('YYYY-MM-DD'));
+        });
+
+        it('honors a narrowed lookahead window — rain beyond it no longer suppresses watering', () => {
+            // 12mm rain (9.6mm effective) two days out would trigger a skip
+            // under the default 3-day window, but with a 1-day lookahead it sits
+            // outside the window, so the planner waters tonight.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 12.0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule } = planZoneSchedule(zone, weather, [], undefined, undefined, 1);
+
+            expect(schedule.length).toBeGreaterThan(0);
+            expect(schedule[0]!.date.format('YYYY-MM-DD')).toBe(weather[0]!.date.format('YYYY-MM-DD'));
+        });
+
+        it('disables the rain-skip entirely when the lookahead is 0', () => {
+            // Even heavy imminent rain can't defer watering when the lookahead
+            // window is zero days — the escape hatch for `RAIN_SKIP_LOOKAHEAD_DAYS=0`.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 20.0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule } = planZoneSchedule(zone, weather, [], undefined, undefined, 0);
+
+            expect(schedule.length).toBeGreaterThan(0);
+            expect(schedule[0]!.date.format('YYYY-MM-DD')).toBe(weather[0]!.date.format('YYYY-MM-DD'));
+        });
+
+        it('carries depletion forward unchanged after a day-0 rain-skip', () => {
+            // Skipping day 0 must leave the projected next-day depletion at the
+            // un-watered value so tomorrow's re-plan starts from reality.
+            const zone = createTestZone({ currentDepletionMm: 24 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 20.0 },
+                { evapotranspirationMmPerDay: 0, rainfallMm: 0 },
+            ]);
+
+            const { entries: schedule, projectedNextDepletionMm } = planZoneSchedule(zone, weather);
+
+            expect(schedule).toHaveLength(0);
+            expect(projectedNextDepletionMm).toBeCloseTo(24, 1);
         });
     });
 

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -22,6 +22,53 @@ export type ScheduleOverrides = {
 const NO_OVERRIDES: ScheduleOverrides = {};
 
 /**
+ * Default forecast horizon (in days, starting tomorrow) the planner looks
+ * ahead for rain before committing a night's irrigation. When the effective
+ * rainfall forecast over this window would by itself bring depletion back
+ * below the trigger, the night is skipped and depletion carries forward — the
+ * standard smart-controller "rain delay". Conservative by design: the daemon
+ * re-plans every evening, so a skip is reconsidered the next day if the rain
+ * fails to materialise.
+ *
+ * Overridable per planning run via `planZoneSchedule`'s `rainSkipLookaheadDays`
+ * argument, which the daemon sources from the `RAIN_SKIP_LOOKAHEAD_DAYS`
+ * environment variable. A value of 0 disables the rain-skip entirely. Pairs
+ * with the precipitation-source accuracy work tracked separately. API-85.
+ */
+export const DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS = 3;
+
+/**
+ * Converts gross daily rainfall into the depth that actually counts against
+ * soil depletion: rain under 2 mm is treated as zero (intercepted / evaporated
+ * before it infiltrates), and the rest is discounted to 80% to approximate
+ * runoff and canopy interception. Used both for the day-by-day soil balance
+ * and the forward-looking rain-skip lookahead so the credit math is identical.
+ */
+function effectiveRainfall(rainfallMm: number): number {
+    return rainfallMm < 2 ? 0 : 0.8 * rainfallMm;
+}
+
+/**
+ * Sums the effective forecast rainfall over the `lookaheadDays` days that
+ * follow `dayIndex` (the window starts at the *next* day — `dayIndex`'s own
+ * rain is already folded into the running depletion before this is consulted).
+ * The window is clamped to the end of `weatherHistory`, so a short forecast
+ * tail simply contributes fewer days. Drives the planner's rain-skip decision.
+ */
+function forecastEffectiveRainfall(
+    weatherHistory: DailyWeather[],
+    dayIndex: number,
+    lookaheadDays: number,
+): number {
+    let total = 0;
+    const lastIndex = Math.min(dayIndex + lookaheadDays, weatherHistory.length - 1);
+    for (let i = dayIndex + 1; i <= lastIndex; i++) {
+        total += effectiveRainfall(weatherHistory[i]!.rainfallMm ?? 0);
+    }
+    return total;
+}
+
+/**
  * A time interval the planner must avoid placing cycles inside. Used by the
  * daemon's sequential per-zone planning to prevent cross-zone overlap: each
  * zone's persisted cycles become busy windows for subsequent zones.
@@ -61,6 +108,11 @@ export type PlanZoneScheduleResult = {
  *   the planner uses these in place of the zone's own `rootDepthM` /
  *   `allowableDepletionFraction`. Zone rows stay untouched — overrides
  *   express the temporary planning mode (e.g. overseeding vs. maintenance).
+ * @param rainSkipLookaheadDays - Forecast horizon (days, starting tomorrow)
+ *   for the rain-skip. When forecast effective rain over this window would by
+ *   itself bring depletion below the trigger, the night is deferred. 0 disables
+ *   the rain-skip. Defaults to `DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS`; the daemon
+ *   sources it from the `RAIN_SKIP_LOOKAHEAD_DAYS` env var. API-85.
  * @returns Per-day entries plus the projected next-day starting depletion.
  */
 export function planZoneSchedule(
@@ -69,6 +121,7 @@ export function planZoneSchedule(
     busyWindows: ReadonlyArray<BusyWindow> = [],
     restrictions: ScheduleRestrictions = NO_RESTRICTIONS,
     overrides: ScheduleOverrides = NO_OVERRIDES,
+    rainSkipLookaheadDays: number = DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS,
 ): PlanZoneScheduleResult {
     const effectiveRootDepthM = overrides.rootDepthM ?? zone.rootDepthM,
         effectiveAllowableDepletionFraction = overrides.allowableDepletionFraction ?? zone.allowableDepletionFraction;
@@ -116,7 +169,7 @@ export function planZoneSchedule(
             microclimateFactor = zone.microclimateFactor ?? 1,
             cropEvapotranspiration = cropCoefficient * microclimateFactor * referenceEvapotranspiration,
             rainfallMillimeters = weatherDay.rainfallMm ?? 0,
-            effectiveRainfallMillimeters = rainfallMillimeters < 2 ? 0 : 0.8 * rainfallMillimeters; // If rainfall is less than 2mm, treat as zero.
+            effectiveRainfallMillimeters = effectiveRainfall(rainfallMillimeters);
 
         // Update soil depletion based on ET and rainfall.
         currentDepletionMillimeters = clampValue(
@@ -127,56 +180,72 @@ export function planZoneSchedule(
 
         // Check if irrigation is needed.
         if (currentDepletionMillimeters >= readilyAvailableWaterMillimeters) {
-            // Anchor each planning day's overnight block to the *next* day's
-            // sunrise — i.e. the block runs [midnight day i+1, sunrise day i+1],
-            // the overnight starting tonight and ending tomorrow morning. The
-            // last day of the horizon has no successor and is therefore dropped
-            // (no anchor). See API-76.
-            const nextDay = weatherHistory[dayIndex + 1];
-            if (nextDay === undefined) {
-                console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} is the last weather day — no next-day sunrise to anchor to, deferring irrigation.`);
-                continue;
-            }
-            const sunrise = nextDay.sunrise ?? nextDay.date.hour(6).minute(0).second(0).millisecond(0);
+            // Forward-looking rain-skip (API-85). Before committing tonight's
+            // cycles, look ahead at the forecast: if the effective rainfall over
+            // the next few days would by itself bring depletion back below the
+            // trigger, skip tonight and carry depletion forward. Watering now
+            // would only refill the soil for the rain to overflow — pure waste.
+            // The daemon re-plans every evening, so this skip is reconsidered
+            // tomorrow if the forecast rain doesn't arrive.
+            const upcomingEffectiveRainfallMillimeters = forecastEffectiveRainfall(weatherHistory, dayIndex, rainSkipLookaheadDays);
+            const rainWillCoverDeficit = currentDepletionMillimeters - upcomingEffectiveRainfallMillimeters < readilyAvailableWaterMillimeters;
 
-            const irrigationOutcome = tryPlaceIrrigationForDay({
-                date,
-                sunrise,
-                zone,
-                currentDepletionMillimeters,
-                totalAvailableWaterMillimeters,
-                precipitationRateMillimetersPerHour,
-                infiltrationRateMillimetersPerHour,
-                soakTimeMinutes,
-                busyWindowsSoFar,
-                restrictions,
-            });
+            if (rainWillCoverDeficit) {
+                console.log(`planner: zone ${zone.id} (${zone.name}): rain-skip on ${date.format('YYYY-MM-DD')} — depletion ${currentDepletionMillimeters.toFixed(1)} mm ≥ trigger ${readilyAvailableWaterMillimeters.toFixed(1)} mm, but ${upcomingEffectiveRainfallMillimeters.toFixed(1)} mm effective rain forecast over the next ${rainSkipLookaheadDays} day(s) will bring it below trigger — deferring irrigation.`);
+                // Fall through: depletion carries forward unchanged and the
+                // day-0 projection is still captured below.
+            } else {
+                // Anchor each planning day's overnight block to the *next* day's
+                // sunrise — i.e. the block runs [midnight day i+1, sunrise day i+1],
+                // the overnight starting tonight and ending tomorrow morning. The
+                // last day of the horizon has no successor and is therefore dropped
+                // (no anchor). See API-76.
+                const nextDay = weatherHistory[dayIndex + 1];
+                if (nextDay === undefined) {
+                    console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} is the last weather day — no next-day sunrise to anchor to, deferring irrigation.`);
+                } else {
+                    const sunrise = nextDay.sunrise ?? nextDay.date.hour(6).minute(0).second(0).millisecond(0);
 
-            if (irrigationOutcome !== null) {
-                // Each placed cycle becomes a busy window for the rest of
-                // the planning horizon.
-                for (const cycle of irrigationOutcome.cycles) {
-                    busyWindowsSoFar.push({
-                        start: cycle.startTime,
-                        end: cycle.startTime.add(cycle.durationMin, 'minute'),
+                    const irrigationOutcome = tryPlaceIrrigationForDay({
+                        date,
+                        sunrise,
+                        zone,
+                        currentDepletionMillimeters,
+                        totalAvailableWaterMillimeters,
+                        precipitationRateMillimetersPerHour,
+                        infiltrationRateMillimetersPerHour,
+                        soakTimeMinutes,
+                        busyWindowsSoFar,
+                        restrictions,
                     });
+
+                    if (irrigationOutcome !== null) {
+                        // Each placed cycle becomes a busy window for the rest of
+                        // the planning horizon.
+                        for (const cycle of irrigationOutcome.cycles) {
+                            busyWindowsSoFar.push({
+                                start: cycle.startTime,
+                                end: cycle.startTime.add(cycle.durationMin, 'minute'),
+                            });
+                        }
+
+                        irrigationSchedule.push(irrigationOutcome.entry);
+
+                        // Start the post-irrigation portion from the entry's residual
+                        // depletion (zero on a full refill, positive on a partial
+                        // refill clamped by the overnight window — see API-75), then
+                        // re-apply the day's net ET for the post-irrigation hours.
+                        currentDepletionMillimeters = clampValue(
+                            irrigationOutcome.entry.depletionAfterMm + cropEvapotranspiration - effectiveRainfallMillimeters,
+                            0,
+                            totalAvailableWaterMillimeters
+                        );
+                    }
+                    // When `irrigationOutcome === null`, the day was skipped due to
+                    // restrictions. Depletion carries forward unchanged — the next
+                    // allowed day will see the larger accumulated value.
                 }
-
-                irrigationSchedule.push(irrigationOutcome.entry);
-
-                // Start the post-irrigation portion from the entry's residual
-                // depletion (zero on a full refill, positive on a partial
-                // refill clamped by the overnight window — see API-75), then
-                // re-apply the day's net ET for the post-irrigation hours.
-                currentDepletionMillimeters = clampValue(
-                    irrigationOutcome.entry.depletionAfterMm + cropEvapotranspiration - effectiveRainfallMillimeters,
-                    0,
-                    totalAvailableWaterMillimeters
-                );
             }
-            // When `irrigationOutcome === null`, the day was skipped due to
-            // restrictions. Depletion carries forward unchanged — the next
-            // allowed day will see the larger accumulated value.
         }
 
         // Ensure depletion stays within valid bounds.

--- a/api/schedules/index.ts
+++ b/api/schedules/index.ts
@@ -1,8 +1,21 @@
 import dayjs from 'dayjs';
 import { getWeatherData } from '../data/weather';
 import type { Zone } from '../models';
-import { planZoneSchedule, type BusyWindow, type PlanZoneScheduleResult, type ScheduleOverrides } from './dynamic';
+import { DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS, planZoneSchedule, type BusyWindow, type PlanZoneScheduleResult, type ScheduleOverrides } from './dynamic';
 import type { ScheduleRestrictions } from './dynamic/restrictions';
+
+/**
+ * Resolves the planner's rain-skip lookahead horizon from the
+ * `RAIN_SKIP_LOOKAHEAD_DAYS` environment variable. Accepts any non-negative
+ * integer (0 disables the rain-skip); falls back to
+ * `DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS` when unset, non-numeric, or negative.
+ * Exported for direct testing.
+ */
+export function resolveRainSkipLookaheadDays(raw: string | undefined): number {
+    if (raw === undefined) return DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_RAIN_SKIP_LOOKAHEAD_DAYS;
+}
 
 export type RunScheduleForZoneOptions = {
     /** Optional. Number of days of forecast weather to plan against. Default 7. */
@@ -66,5 +79,7 @@ export async function runScheduleForZone(
         end: dayjs(w.end),
     }));
 
-    return planZoneSchedule(zone, daily, busyWindows, options?.restrictions, options?.overrides);
+    const rainSkipLookaheadDays = resolveRainSkipLookaheadDays(process.env.RAIN_SKIP_LOOKAHEAD_DAYS);
+
+    return planZoneSchedule(zone, daily, busyWindows, options?.restrictions, options?.overrides, rainSkipLookaheadDays);
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
             NOTIFY_ON_WATERING_END: ${NOTIFY_ON_WATERING_END}
             NOTIFY_ON_ERROR: ${NOTIFY_ON_ERROR}
             DRY_RUN: ${DRY_RUN}
+            RAIN_SKIP_LOOKAHEAD_DAYS: ${RAIN_SKIP_LOOKAHEAD_DAYS}
             EXPO_ACCESS_TOKEN: ${EXPO_ACCESS_TOKEN}
         ports:
             - "${PORT}:9753"


### PR DESCRIPTION
## Ticket

[API-85](http://192.168.2.100:7123/home/browse/API-85/) Planner ignores forecast rain — waters the night before a rain event (no rain skip)

## Summary

- **Root cause:** `planZoneSchedule` is a sequential soil-moisture simulation whose nightly watering trigger only saw depletion up to *that same day's* rain. Forecast rain on subsequent days never suppressed an earlier night's watering, so the planner would water, refill the soil to full, and let the next day's rain overflow — pure waste.
- **Fix:** added a forward-looking **rain-skip** (standard smart-controller "rain delay"). Before placing a night's cycles, the planner sums *effective* forecast rainfall over the next `RAIN_SKIP_LOOKAHEAD_DAYS` days; if that rain would by itself bring depletion below the trigger, it defers the night and carries depletion forward. The daily evening re-plan reconsiders, so a skip self-corrects if the rain doesn't arrive.
- **Configurable:** the lookahead horizon is the `RAIN_SKIP_LOOKAHEAD_DAYS` env var (default 3; `0` disables the rain-skip), read at the `runScheduleForZone` boundary and threaded into the planner. Plumbed through `.env.example` and `docker-compose.yml` (and the local, gitignored `.env`).
- Extracted a shared `effectiveRainfall` helper (the `<2mm → 0`, else `0.8×` rule) used by both the day-by-day balance and the lookahead so the credit math stays identical.
- **Tests:** updated the one test that encoded the old buggy behaviour; added rain-skip coverage (defer within window, insufficient rain still waters, rain beyond the window still waters, sub-2mm ignored, depletion carried forward on skip, custom/zero lookahead honored) and `resolveRainSkipLookaheadDays` env-parsing tests. Full api suite green (923 tests).

Out of scope: surfacing the reserved `'skipped-rain'` TonightState, and the sibling precipitation-source accuracy fix.