### PR TITLE
[API-86] Use precipitation_sum for the daily forecast

### DIFF
--- a/api/data/weather/.test.ts
+++ b/api/data/weather/.test.ts
@@ -27,14 +27,14 @@ describe('Weather Data', () => {
             time: 'iso8601',
             sunrise: 'iso8601',
             sunset: 'iso8601',
-            rain_sum: 'mm',
+            precipitation_sum: 'mm',
             et0_fao_evapotranspiration: 'mm',
         },
         daily: {
             time: ['2025-10-20', '2025-10-21', '2025-10-22'],
             sunrise: ['2025-10-20T05:41', '2025-10-21T05:43', '2025-10-22T05:45'],
             sunset: ['2025-10-20T18:10', '2025-10-21T18:08', '2025-10-22T18:06'],
-            rain_sum: [0.2, 0.5, 0.0],
+            precipitation_sum: [0.2, 0.5, 0.0],
             et0_fao_evapotranspiration: [1.63, 1.62, 1.04],
         },
         hourly: {
@@ -80,7 +80,7 @@ describe('Weather Data', () => {
         expect(calledUrl.searchParams.get('longitude')).toBe('13.41');
         expect(calledUrl.searchParams.get('forecast_days')).toBe('7');
         expect(calledUrl.searchParams.get('past_days')).toBe('1');
-        expect(calledUrl.searchParams.get('daily')).toBe('sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
+        expect(calledUrl.searchParams.get('daily')).toBe('sunrise,sunset,precipitation_sum,et0_fao_evapotranspiration');
         expect(calledUrl.searchParams.get('hourly')).toBe('precipitation,et0_fao_evapotranspiration');
         expect(calledUrl.searchParams.get('timezone')).toBeNull();
     });
@@ -142,6 +142,31 @@ describe('Weather Data', () => {
         expect(hourly[0]!.evapotranspirationMm).toBe(0.02);
         expect(hourly[2]!.precipitationMm).toBe(0.2);
         expect(hourly[2]!.evapotranspirationMm).toBe(0.05);
+    });
+
+    it('credits showers-dominated precipitation as rainfall (precipitation_sum, not rain-only)', async () => {
+        // Open-Meteo's `precipitation_sum` is the all-inclusive total (rain +
+        // showers + snow water-equivalent). A day whose precipitation is
+        // entirely convective showers — `rain_sum` would report 0 — must still
+        // surface as rainfall the planner can act on (API-86).
+        const showersResponse = {
+            ...mockWeatherResponse,
+            daily: {
+                time: ['2025-10-20'],
+                sunrise: ['2025-10-20T05:41'],
+                sunset: ['2025-10-20T18:10'],
+                precipitation_sum: [8.0],
+                et0_fao_evapotranspiration: [1.63],
+            },
+        };
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => showersResponse,
+        } as Response);
+
+        const { daily } = await getWeatherData({ latitude: 52.52, longitude: 13.41 });
+
+        expect(daily[0]!.rainfallMm).toBe(8.0);
     });
 
     it('should throw immediately on a 4xx response without retrying', async () => {
@@ -207,7 +232,7 @@ describe('Weather Data', () => {
             daily: {
                 time: [],
                 sunrise: [],
-                rain_sum: [],
+                precipitation_sum: [],
                 et0_fao_evapotranspiration: [],
             },
             hourly: {
@@ -259,7 +284,7 @@ describe('Weather Data', () => {
             daily: {
                 // Missing time array
                 sunrise: ['2025-10-20T05:41'],
-                rain_sum: [0.2],
+                precipitation_sum: [0.2],
                 et0_fao_evapotranspiration: [1.63],
             },
         };
@@ -353,14 +378,14 @@ describe('Weather caching', () => {
             time: 'iso8601',
             sunrise: 'iso8601',
             sunset: 'iso8601',
-            rain_sum: 'mm',
+            precipitation_sum: 'mm',
             et0_fao_evapotranspiration: 'mm',
         },
         daily: {
             time: ['2026-05-24', '2026-05-25'],
             sunrise: ['2026-05-24T05:41', '2026-05-25T05:40'],
             sunset: ['2026-05-24T21:24', '2026-05-25T21:25'],
-            rain_sum: [0, 0],
+            precipitation_sum: [0, 0],
             et0_fao_evapotranspiration: [4.0, 4.0],
         },
         hourly: {

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -19,14 +19,14 @@ type OpenMeteoResponse = {
         time: string;
         sunrise: string;
         sunset: string;
-        rain_sum: string;
+        precipitation_sum: string;
         et0_fao_evapotranspiration: string;
     };
     daily: {
         time: string[];
         sunrise: string[];
         sunset: string[];
-        rain_sum: number[];
+        precipitation_sum: number[];
         et0_fao_evapotranspiration: number[];
     };
     hourly: {
@@ -207,7 +207,7 @@ export async function getWeatherData(
     const url = new URL(baseUrl);
     url.searchParams.set('latitude', latitude.toString());
     url.searchParams.set('longitude', longitude.toString());
-    url.searchParams.set('daily', 'sunrise,sunset,rain_sum,et0_fao_evapotranspiration');
+    url.searchParams.set('daily', 'sunrise,sunset,precipitation_sum,et0_fao_evapotranspiration');
     url.searchParams.set('hourly', 'precipitation,et0_fao_evapotranspiration');
     url.searchParams.set('forecast_days', forecastDays.toString());
     url.searchParams.set('past_days', pastDays.toString());
@@ -234,7 +234,7 @@ export async function getWeatherData(
             date: parseTime(time),
             sunrise: parseTime(data.daily.sunrise[index]!),
             sunset: parseTime(data.daily.sunset[index]!),
-            rainfallMm: data.daily.rain_sum[index],
+            rainfallMm: data.daily.precipitation_sum[index],
             evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
         }));
 

--- a/api/models.ts
+++ b/api/models.ts
@@ -7,7 +7,7 @@ export type DailyWeather = {
     /** Optional. The reference evapotranspiration. */
     evapotranspirationMmPerDay?: number;
 
-    /** Optional. The total daily rainfall. */
+    /** Optional. The total daily precipitation (rain + showers + snow water-equivalent), per Open-Meteo's `precipitation_sum`. */
     rainfallMm?: number;
 
     /** Optional. The local sunrise time as Dayjs object. */

--- a/api/schedules/.test.ts
+++ b/api/schedules/.test.ts
@@ -19,7 +19,7 @@ const stubWeatherResponse = {
         time: 'iso8601',
         sunrise: 'iso8601',
         sunset: 'iso8601',
-        rain_sum: 'mm',
+        precipitation_sum: 'mm',
         et0_fao_evapotranspiration: 'mm',
     },
     daily: {
@@ -28,7 +28,7 @@ const stubWeatherResponse = {
         time: ['2025-10-20', '2025-10-21', '2025-10-22', '2025-10-23'],
         sunrise: ['2025-10-20T07:30', '2025-10-21T07:31', '2025-10-22T07:33', '2025-10-23T07:34'],
         sunset: ['2025-10-20T18:10', '2025-10-21T18:08', '2025-10-22T18:06', '2025-10-23T18:04'],
-        rain_sum: [0, 0, 0, 0],
+        precipitation_sum: [0, 0, 0, 0],
         et0_fao_evapotranspiration: [4.0, 4.0, 4.0, 4.0],
     },
     hourly: {
@@ -211,7 +211,7 @@ describe('runScheduleForZone', () => {
                 daily: {
                     time: [],
                     sunrise: [],
-                    rain_sum: [],
+                    precipitation_sum: [],
                     et0_fao_evapotranspiration: [],
                 },
                 hourly: {

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -35,8 +35,8 @@ const emptyOpenMeteoResponse = {
     timezone: 'GMT',
     timezone_abbreviation: 'GMT',
     elevation: 0,
-    daily_units: { time: 'iso8601', sunrise: 'iso8601', sunset: 'iso8601', rain_sum: 'mm', et0_fao_evapotranspiration: 'mm' },
-    daily: { time: [], sunrise: [], sunset: [], rain_sum: [], et0_fao_evapotranspiration: [] },
+    daily_units: { time: 'iso8601', sunrise: 'iso8601', sunset: 'iso8601', precipitation_sum: 'mm', et0_fao_evapotranspiration: 'mm' },
+    daily: { time: [], sunrise: [], sunset: [], precipitation_sum: [], et0_fao_evapotranspiration: [] },
     hourly: { time: [], precipitation: [], et0_fao_evapotranspiration: [] },
 };
 const mockFetch = mock(() => Promise.resolve({

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -47,7 +47,7 @@ dayjs.extend(timezone);
 
 /**
  * Default hour-of-day (site-local) for the daily re-plan. 20:00 is chosen
- * so Open-Meteo's day-0 `rain_sum` reflects ~20 hours of *observed* rain by
+ * so Open-Meteo's day-0 `precipitation_sum` reflects ~20 hours of *observed* rain by
  * the time the planner places tonight's cycles — same-day rainfall lands in
  * the depletion balance before it can influence cycle placement. Forecast
  * rain after 20:00 still flows through day-0's remaining forecast hours and


### PR DESCRIPTION
## Ticket

[API-86](http://192.168.2.100:7123/home/browse/API-86/) Planner under-counts precipitation: daily uses rain_sum (excludes showers/snow), hourly uses precipitation

## Summary

- **Root cause:** the daily Open-Meteo request asked for `rain_sum`, which is rain-only — it excludes `showers_sum` (convective/summer storms) and `snowfall_sum`. When incoming precipitation is classified as showers, the planner credited **zero** rainfall and watered anyway. It was also inconsistent with the hourly reconciler, which already uses the all-inclusive `precipitation` field.
- **Fix:** switched the daily request to `precipitation_sum` (rain + showers + snow water-equivalent — the daily analogue of hourly `precipitation`) in the `OpenMeteoResponse` type, the `daily` query param, and the `DailyWeather.rainfallMm` mapping in `api/data/weather/index.ts`. Planning and reconciliation now agree on what counts as precipitation.
- `DailyWeather.rainfallMm` keeps its name and the planner math is unchanged — it's now simply fed the *total* precipitation figure. Tightened the field's doc comment and a related daemon comment.
- **Tests:** added a showers-dominated test (a `precipitation_sum` of 8mm with 0 rain surfaces as `rainfallMm === 8`); updated the daily-request URL assertion to expect `precipitation_sum`; updated the Open-Meteo stub shapes in the weather, schedules, and daemon suites. Full api suite green (924 tests).

This is the sibling fix to API-85's rain-skip lookahead — together the planner now both *sees* total forecast precipitation and *defers* watering ahead of it.