### PR TITLE
[API-88] Record scheduling-decision provenance for retrospectives

### DIFF
--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -3,6 +3,7 @@ export { grassTypes } from './grass-types';
 export { irrigationCycles } from './irrigation-cycles';
 export { pushTokens } from './push-tokens';
 export { scheduleEntries } from './schedule-entries';
+export { schedulingDecisions } from './scheduling-decisions';
 export { schedules } from './schedules';
 export { sites } from './sites';
 export { soilTypes } from './soil-types';

--- a/api/db/schema/scheduling-decisions.ts
+++ b/api/db/schema/scheduling-decisions.ts
@@ -1,0 +1,33 @@
+import { date, pgTable, real, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+import { schedules } from './schedules';
+import { weatherSnapshots } from './weather-snapshots';
+import { zones } from './zones';
+
+/**
+ * One row per zone, per replan, capturing the planner's decision for *tonight*
+ * (day 0 of the planning horizon): whether it watered, skipped, or deferred,
+ * the reason, the depletion before/after, the trigger threshold that gated the
+ * decision, and a reference to the weather snapshot that drove it. Answers the
+ * retrospective question "why didn't zone X water on night Y?" — the executed
+ * plan (`schedule_entries`) only records the nights that *did* water. API-88.
+ *
+ * Append-only: a fresh row is written on every replan and old rows are pruned
+ * to a retention window by the recorder. `weatherSnapshotId` is nullable with
+ * `ON DELETE SET NULL` so the weather-snapshot retention prune (API-87) never
+ * FK-fails and a decision outlives the snapshot it referenced.
+ */
+export const schedulingDecisions = pgTable('scheduling_decisions', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    zoneId: uuid('zone_id').notNull().references(() => zones.id),
+    scheduleId: uuid('schedule_id').references(() => schedules.id),
+    date: date('date').notNull(),
+    replanAt: timestamp('replan_at', { withTimezone: true }).notNull(),
+    outcome: text('outcome').notNull(),
+    reason: text('reason').notNull(),
+    depletionBeforeMm: real('depletion_before_mm').notNull(),
+    depletionAfterMm: real('depletion_after_mm').notNull(),
+    triggerThresholdMm: real('trigger_threshold_mm').notNull(),
+    weatherSnapshotId: uuid('weather_snapshot_id').references(() => weatherSnapshots.id, { onDelete: 'set null' }),
+    ...auditColumns,
+});

--- a/api/drizzle/0017_thick_romulus.sql
+++ b/api/drizzle/0017_thick_romulus.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "scheduling_decisions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"zone_id" uuid NOT NULL,
+	"schedule_id" uuid,
+	"date" date NOT NULL,
+	"replan_at" timestamp with time zone NOT NULL,
+	"outcome" text NOT NULL,
+	"reason" text NOT NULL,
+	"depletion_before_mm" real NOT NULL,
+	"depletion_after_mm" real NOT NULL,
+	"trigger_threshold_mm" real NOT NULL,
+	"weather_snapshot_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "scheduling_decisions" ADD CONSTRAINT "scheduling_decisions_zone_id_zones_id_fk" FOREIGN KEY ("zone_id") REFERENCES "public"."zones"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "scheduling_decisions" ADD CONSTRAINT "scheduling_decisions_schedule_id_schedules_id_fk" FOREIGN KEY ("schedule_id") REFERENCES "public"."schedules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "scheduling_decisions" ADD CONSTRAINT "scheduling_decisions_weather_snapshot_id_weather_snapshots_id_fk" FOREIGN KEY ("weather_snapshot_id") REFERENCES "public"."weather_snapshots"("id") ON DELETE set null ON UPDATE no action;

--- a/api/drizzle/meta/0017_snapshot.json
+++ b/api/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1383 @@
+{
+  "id": "272a59ec-bafe-457e-aa00-0b1f78d9bf78",
+  "prevId": "cbd6ab19-6bd3-48ac-9ea9-895c3a9825c7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_at": {
+          "name": "when_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack": {
+          "name": "ack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_zone_id_zones_id_fk": {
+          "name": "alerts_zone_id_zones_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alerts_class_check": {
+          "name": "alerts_class_check",
+          "value": "\"alerts\".\"class\" in ('weather-stale', 'ha-call-failed', 'missed-close', 'actuation-stale')"
+        },
+        "alerts_tone_check": {
+          "name": "alerts_tone_check",
+          "value": "\"alerts\".\"tone\" in ('warn', 'danger')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_token_unique": {
+          "name": "push_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "sunrise_at": {
+          "name": "sunrise_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_night_date": {
+          "name": "skipped_night_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduling_decisions": {
+      "name": "scheduling_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replan_at": {
+          "name": "replan_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_threshold_mm": {
+          "name": "trigger_threshold_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weather_snapshot_id": {
+          "name": "weather_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduling_decisions_zone_id_zones_id_fk": {
+          "name": "scheduling_decisions_zone_id_zones_id_fk",
+          "tableFrom": "scheduling_decisions",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scheduling_decisions_schedule_id_schedules_id_fk": {
+          "name": "scheduling_decisions_schedule_id_schedules_id_fk",
+          "tableFrom": "scheduling_decisions",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scheduling_decisions_weather_snapshot_id_weather_snapshots_id_fk": {
+          "name": "scheduling_decisions_weather_snapshot_id_weather_snapshots_id_fk",
+          "tableFrom": "scheduling_decisions",
+          "tableTo": "weather_snapshots",
+          "columnsFrom": [
+            "weather_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_state": {
+      "name": "system_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "irrigation_enabled": {
+          "name": "irrigation_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_daily_snapshots": {
+      "name": "weather_daily_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sunrise_at": {
+          "name": "sunrise_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sunset_at": {
+          "name": "sunset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "et0_mm_per_day": {
+          "name": "et0_mm_per_day",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_daily_snapshots_snapshot_id_weather_snapshots_id_fk": {
+          "name": "weather_daily_snapshots_snapshot_id_weather_snapshots_id_fk",
+          "tableFrom": "weather_daily_snapshots",
+          "tableTo": "weather_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_hourly_snapshots": {
+      "name": "weather_hourly_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "et0_mm": {
+          "name": "et0_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_hourly_snapshots_snapshot_id_weather_snapshots_id_fk": {
+          "name": "weather_hourly_snapshots_snapshot_id_weather_snapshots_id_fk",
+          "tableFrom": "weather_hourly_snapshots",
+          "tableTo": "weather_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_snapshots": {
+      "name": "weather_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_snapshots_zone_id_zones_id_fk": {
+          "name": "weather_snapshots_zone_id_zones_id_fk",
+          "tableFrom": "weather_snapshots",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_state": {
+      "name": "weather_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_fetch_at": {
+          "name": "last_successful_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_depletion_reconciled_at": {
+          "name": "current_depletion_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780238204977,
       "tag": "0016_nice_onslaught",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1780259459819,
+      "tag": "0017_thick_romulus",
+      "breakpoints": true
     }
   ]
 }

--- a/api/models/decision.ts
+++ b/api/models/decision.ts
@@ -1,0 +1,56 @@
+import type dayjs from 'dayjs';
+
+/**
+ * The three terminal outcomes the planner can reach for a given night.
+ *
+ *  - `watered`  — cycles were placed and will fire tonight.
+ *  - `skipped`  — the planner deliberately chose not to water (no need, rain
+ *    coming, day not allowed, operator skip-marker). Depletion carries forward.
+ *  - `deferred` — the planner *wanted* to water but couldn't place the cycles
+ *    (no sunrise anchor, overnight window too short, no cycle count fit, all
+ *    cycles already past). Depletion carries forward and is reconsidered next
+ *    replan.
+ */
+export type SchedulingOutcome = 'watered' | 'skipped' | 'deferred';
+
+/**
+ * The specific reason behind a `SchedulingOutcome`. One-to-one with the
+ * planner's decision branches so a retrospective can name exactly why a night
+ * went the way it did.
+ */
+export type SchedulingDecisionReason =
+    // skipped
+    | 'below-threshold'
+    | 'rain-forecast'
+    | 'day-not-allowed'
+    | 'operator-skip'
+    // deferred
+    | 'no-anchor'
+    | 'window-too-short'
+    | 'no-cycle-fit'
+    | 'past-window'
+    // watered
+    | 'full-refill'
+    | 'partial-refill';
+
+/**
+ * The planner's decision for a single zone on a single night (day 0 of the
+ * planning horizon). Captures the outcome, its reason, the depletion before
+ * and after, and the trigger threshold that gated the decision — everything
+ * needed (alongside the weather snapshot) to reconstruct why the night went
+ * the way it did. The daemon persists this into `scheduling_decisions`. API-88.
+ */
+export type SchedulingDecision = {
+    /** The planning day the decision applies to (day 0 of the horizon). */
+    date: dayjs.Dayjs;
+    /** The terminal outcome. */
+    outcome: SchedulingOutcome;
+    /** The specific reason for the outcome. */
+    reason: SchedulingDecisionReason;
+    /** Soil depletion (mm) at the moment the decision was made. */
+    depletionBeforeMm: number;
+    /** Soil depletion (mm) after the decision (== before, except on `watered`). */
+    depletionAfterMm: number;
+    /** The trigger threshold (readily-available water, mm) that gated the decision. */
+    triggerThresholdMm: number;
+};

--- a/api/repositories/scheduling-decisions/.test.ts
+++ b/api/repositories/scheduling-decisions/.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'bun:test';
+import dayjs from 'dayjs';
+import type { Database } from '@/db';
+import { schedulingDecisions } from '@/db/schema';
+import {
+    createSchedulingDecisionsRepository,
+    DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS,
+    resolveSchedulingDecisionRetentionDays,
+    type RecordSchedulingDecisionInput,
+} from '.';
+
+type InsertCall = { table: unknown; rows: unknown };
+type DeleteCall = { table: unknown; condition: unknown };
+
+/**
+ * Recording-stub Drizzle client. `insert().values()` is awaitable;
+ * `delete().where()` records the prune.
+ */
+function makeStub() {
+    const inserts: InsertCall[] = [];
+    const deletes: DeleteCall[] = [];
+    const db = {
+        insert: (table: unknown) => ({
+            values: (rows: unknown) => {
+                inserts.push({ table, rows });
+                return Promise.resolve();
+            },
+        }),
+        delete: (table: unknown) => ({
+            where: (condition: unknown) => {
+                deletes.push({ table, condition });
+                return Promise.resolve();
+            },
+        }),
+    } as unknown as Database;
+    return { db, inserts, deletes };
+}
+
+/** Walks a Drizzle condition tree and returns the first Date value it carries. */
+function findDate(node: unknown, seen = new WeakSet<object>()): Date | undefined {
+    if (node instanceof Date) return node;
+    if (typeof node !== 'object' || node === null) return undefined;
+    if (seen.has(node)) return undefined;
+    seen.add(node);
+    for (const value of Object.values(node as Record<string, unknown>)) {
+        const found = findDate(value, seen);
+        if (found) return found;
+    }
+    return undefined;
+}
+
+const REPLAN_AT = new Date('2026-05-30T20:00:00.000Z');
+
+const baseInput = (overrides?: Partial<RecordSchedulingDecisionInput>): RecordSchedulingDecisionInput => ({
+    zoneId: 'zone-001',
+    scheduleId: 'sched-001',
+    date: '2026-05-30',
+    replanAt: REPLAN_AT,
+    outcome: 'skipped',
+    reason: 'rain-forecast',
+    depletionBeforeMm: 18.4,
+    depletionAfterMm: 18.4,
+    triggerThresholdMm: 15.0,
+    weatherSnapshotId: 'snapshot-001',
+    ...overrides,
+});
+
+describe('createSchedulingDecisionsRepository', () => {
+    it('inserts a row carrying the decision, inputs, and snapshot reference', async () => {
+        const { db, inserts } = makeStub();
+        const repo = createSchedulingDecisionsRepository(db, 28);
+
+        await repo.record(baseInput());
+
+        const insert = inserts.find(c => c.table === schedulingDecisions);
+        expect(insert).toBeDefined();
+        expect(insert!.rows).toMatchObject({
+            zoneId: 'zone-001',
+            scheduleId: 'sched-001',
+            date: '2026-05-30',
+            replanAt: REPLAN_AT,
+            outcome: 'skipped',
+            reason: 'rain-forecast',
+            depletionBeforeMm: 18.4,
+            depletionAfterMm: 18.4,
+            triggerThresholdMm: 15.0,
+            weatherSnapshotId: 'snapshot-001',
+        });
+    });
+
+    it('persists a null snapshot reference when the snapshot write failed', async () => {
+        const { db, inserts } = makeStub();
+        const repo = createSchedulingDecisionsRepository(db, 28);
+
+        await repo.record(baseInput({ weatherSnapshotId: null }));
+
+        const insert = inserts.find(c => c.table === schedulingDecisions);
+        expect((insert!.rows as Record<string, unknown>)['weatherSnapshotId']).toBeNull();
+    });
+
+    it('prunes decisions older than the retention window, measured from the replan time', async () => {
+        const { db, deletes } = makeStub();
+        const repo = createSchedulingDecisionsRepository(db, 28);
+
+        await repo.record(baseInput());
+
+        const prune = deletes.find(c => c.table === schedulingDecisions);
+        expect(prune).toBeDefined();
+        const cutoff = findDate(prune!.condition);
+        expect(cutoff).toEqual(dayjs(REPLAN_AT).subtract(28, 'day').toDate());
+    });
+
+    it('does not prune when retention is 0 (keep everything)', async () => {
+        const { db, deletes } = makeStub();
+        const repo = createSchedulingDecisionsRepository(db, 0);
+
+        await repo.record(baseInput());
+
+        expect(deletes).toHaveLength(0);
+    });
+});
+
+describe('resolveSchedulingDecisionRetentionDays', () => {
+    it('falls back to the default when unset', () => {
+        expect(resolveSchedulingDecisionRetentionDays(undefined)).toBe(DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS);
+    });
+
+    it('parses a positive integer', () => {
+        expect(resolveSchedulingDecisionRetentionDays('14')).toBe(14);
+    });
+
+    it('accepts 0 to disable pruning', () => {
+        expect(resolveSchedulingDecisionRetentionDays('0')).toBe(0);
+    });
+
+    it('falls back to the default on non-numeric input', () => {
+        expect(resolveSchedulingDecisionRetentionDays('forever')).toBe(DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS);
+    });
+
+    it('falls back to the default on a negative value', () => {
+        expect(resolveSchedulingDecisionRetentionDays('-5')).toBe(DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS);
+    });
+});

--- a/api/repositories/scheduling-decisions/index.ts
+++ b/api/repositories/scheduling-decisions/index.ts
@@ -1,0 +1,106 @@
+import { lt } from 'drizzle-orm';
+import dayjs from 'dayjs';
+import type { Database } from '@/db';
+import { schedulingDecisions } from '@/db/schema';
+
+/**
+ * Default retention window (days) for persisted scheduling decisions. Old rows
+ * are pruned on each write so the append-only log stays bounded. Matches the
+ * weather-snapshot retention (API-87): a decision can't be reconstructed past
+ * the snapshot that drove it, so keeping decisions longer buys nothing.
+ * Overridable via the `SCHEDULING_DECISION_RETENTION_DAYS` environment
+ * variable. A value of 0 disables pruning. API-88.
+ */
+export const DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS = 28;
+
+/**
+ * Resolves the decision retention window from the
+ * `SCHEDULING_DECISION_RETENTION_DAYS` environment variable. Accepts any
+ * non-negative integer (0 disables pruning); falls back to
+ * `DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS` when unset, non-numeric, or
+ * negative. Exported for direct testing.
+ */
+export function resolveSchedulingDecisionRetentionDays(raw: string | undefined): number {
+    if (raw === undefined) return DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_SCHEDULING_DECISION_RETENTION_DAYS;
+}
+
+/**
+ * A single planning decision to persist. `outcome` / `reason` are the domain
+ * `SchedulingOutcome` / `SchedulingDecisionReason` values (stored as text);
+ * `date` is the planning day (`YYYY-MM-DD`); `replanAt` is when the replan ran.
+ * `weatherSnapshotId` ties the decision to the forecast that drove it — null
+ * when the snapshot write failed (best-effort, API-87) or was pruned.
+ */
+export type RecordSchedulingDecisionInput = {
+    /** The zone the decision was made for. */
+    zoneId: string;
+    /** The active schedule that planned the zone, or null if none. */
+    scheduleId: string | null;
+    /** The planning day the decision applies to (`YYYY-MM-DD`). */
+    date: string;
+    /** When the replan that produced this decision ran. */
+    replanAt: Date;
+    /** `'watered' | 'skipped' | 'deferred'`. */
+    outcome: string;
+    /** The specific reason for the outcome. */
+    reason: string;
+    /** Soil depletion before the decision. */
+    depletionBeforeMm: number;
+    /** Soil depletion after the decision. */
+    depletionAfterMm: number;
+    /** The trigger threshold (readily-available water) that gated the decision. */
+    triggerThresholdMm: number;
+    /** The weather snapshot that drove the decision, or null. */
+    weatherSnapshotId: string | null;
+};
+
+/**
+ * Domain interface for the append-only `scheduling_decisions` log.
+ */
+export interface SchedulingDecisionsRepository {
+    /**
+     * Appends one decision row, then prunes decisions older than the retention
+     * window (measured from `replanAt`). Best-effort by contract — callers
+     * treat a rejection as non-fatal so a failed write never stops planning.
+     */
+    record(input: RecordSchedulingDecisionInput): Promise<void>;
+}
+
+/**
+ * Builds the production `SchedulingDecisionsRepository` bound to a Drizzle
+ * client. `retentionDays` defaults to the resolved
+ * `SCHEDULING_DECISION_RETENTION_DAYS` env value; pass an explicit value in
+ * tests.
+ */
+export function createSchedulingDecisionsRepository(
+    db: Database,
+    retentionDays: number = resolveSchedulingDecisionRetentionDays(process.env.SCHEDULING_DECISION_RETENTION_DAYS),
+): SchedulingDecisionsRepository {
+    return {
+        record: async (input) => {
+            await db.insert(schedulingDecisions).values({
+                zoneId: input.zoneId,
+                scheduleId: input.scheduleId,
+                date: input.date,
+                replanAt: input.replanAt,
+                outcome: input.outcome,
+                reason: input.reason,
+                depletionBeforeMm: input.depletionBeforeMm,
+                depletionAfterMm: input.depletionAfterMm,
+                triggerThresholdMm: input.triggerThresholdMm,
+                weatherSnapshotId: input.weatherSnapshotId,
+            });
+
+            // Prune the append-only log to the retention window. A retention of
+            // 0 disables pruning entirely (keep everything).
+            if (retentionDays > 0) {
+                const cutoff = dayjs(input.replanAt).subtract(retentionDays, 'day').toDate();
+                await db.delete(schedulingDecisions).where(lt(schedulingDecisions.replanAt, cutoff));
+            }
+
+            console.log(`scheduling-decisions: recorded ${input.outcome}/${input.reason} for zone ${input.zoneId} on ${input.date} (snapshot ${input.weatherSnapshotId ?? 'none'}).`);
+        },
+    };
+}

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -2075,4 +2075,110 @@ describe('planZoneSchedule', () => {
             expect(entries[0]?.sunriseAt?.isSame(day1Sunrise)).toBe(true);
         });
     });
+
+    // Day-0 decision provenance surfaced for `scheduling_decisions` (API-88).
+    describe('day-0 decision (API-88)', () => {
+        // Default loam zone: total available water = 150 × 0.3 = 45 mm,
+        // trigger = 0.5 × 45 = 22.5 mm.
+        const TRIGGER = 22.5;
+
+        it('reports a below-threshold skip when depletion never reaches the trigger', () => {
+            const zone = createTestZone({ currentDepletionMm: 5, allowableDepletionFraction: 0.5 });
+            const weather = createDryPeriod(7, 1.0);
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('skipped');
+            expect(decision!.reason).toBe('below-threshold');
+            expect(decision!.triggerThresholdMm).toBe(TRIGGER);
+            // No watering — depletion is unchanged across the decision.
+            expect(decision!.depletionAfterMm).toBe(decision!.depletionBeforeMm);
+            expect(decision!.depletionBeforeMm).toBeLessThan(TRIGGER);
+            expect(decision!.date.format('YYYY-MM-DD')).toBe(weather[0]!.date.format('YYYY-MM-DD'));
+        });
+
+        it('reports a full-refill watered decision when tonight waters to capacity', () => {
+            const zone = createTestZone({ currentDepletionMm: 25, allowableDepletionFraction: 0.5 });
+            const weather = createDryPeriod(7, 1.5);
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('watered');
+            expect(decision!.reason).toBe('full-refill');
+            expect(decision!.triggerThresholdMm).toBe(TRIGGER);
+            expect(decision!.depletionBeforeMm).toBeGreaterThanOrEqual(TRIGGER);
+            // A full refill drives residual depletion to zero.
+            expect(decision!.depletionAfterMm).toBe(0);
+        });
+
+        it('reports a partial-refill watered decision when the overnight window clamps the refill', () => {
+            // Clay soil (slow infiltration 4 mm/hr) with a deep deficit: the
+            // [midnight, sunrise] window can't fit a full refill, so the planner
+            // applies a partial refill and the residual carries forward (API-75).
+            const zone = createTestZone({
+                soil: { name: 'Clay', availableWaterHoldingCapacityMmPerM: 200, infiltrationRateMmPerHr: 4 },
+                currentDepletionMm: 55,
+                allowableDepletionFraction: 0.5,
+            });
+            const weather = createDryPeriod(3, 0);
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('watered');
+            expect(decision!.reason).toBe('partial-refill');
+            // Partial refill leaves residual depletion above zero.
+            expect(decision!.depletionAfterMm).toBeGreaterThan(0);
+            expect(decision!.depletionAfterMm).toBeLessThan(decision!.depletionBeforeMm);
+        });
+
+        it('reports a rain-forecast skip when imminent rain will cover the deficit', () => {
+            const zone = createTestZone({ currentDepletionMm: 23 });
+            const weather = createWeatherDays([
+                { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                { evapotranspirationMmPerDay: 2.0, rainfallMm: 10.0 },
+                { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+            ]);
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('skipped');
+            expect(decision!.reason).toBe('rain-forecast');
+            expect(decision!.depletionBeforeMm).toBeGreaterThanOrEqual(TRIGGER);
+            expect(decision!.depletionAfterMm).toBe(decision!.depletionBeforeMm);
+        });
+
+        it('reports a day-not-allowed skip when the schedule disallows day 0', () => {
+            // Monday 2026-05-04 → isoWeekday 1, disallowed for [Wed, Fri, Sun].
+            const zone = createTestZone({ currentDepletionMm: 25 });
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                ],
+                dayjs('2026-05-04'),
+            );
+
+            const { decision } = planZoneSchedule(zone, weather, [], {
+                allowedDays: [3, 5, 7],
+                allowedTimeWindows: null,
+            });
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('skipped');
+            expect(decision!.reason).toBe('day-not-allowed');
+        });
+
+        it('omits the decision when the zone is disabled and planning short-circuits', () => {
+            const zone = createTestZone({ isEnabled: false, currentDepletionMm: 30 });
+            const weather = createDryPeriod(7, 2.0);
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeUndefined();
+        });
+    });
 });

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -2180,5 +2180,104 @@ describe('planZoneSchedule', () => {
 
             expect(decision).toBeUndefined();
         });
+
+        it('reports an operator-skip when day 0 carries a skip-tonight marker', () => {
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                ],
+                dayjs('2026-05-04'),
+            );
+
+            const { decision } = planZoneSchedule(zone, weather, [], {
+                allowedDays: null,
+                allowedTimeWindows: null,
+                skippedNightDate: '2026-05-04',
+            });
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('skipped');
+            expect(decision!.reason).toBe('operator-skip');
+        });
+
+        it('reports a no-anchor deferral when day 0 is the last forecast day', () => {
+            // A single-day forecast above the trigger has no next-day sunrise to
+            // anchor the overnight block to, so the planner defers (API-76).
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createDryPeriod(1, 2.0);
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('deferred');
+            expect(decision!.reason).toBe('no-anchor');
+        });
+
+        it('reports a window-too-short deferral when the overnight window can not fit one cycle', () => {
+            // Day 1's sunrise is 00:30, leaving a 30-minute [midnight, sunrise]
+            // window — too short for even one infiltration-capped cycle.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0, sunrise: dayjs('2026-05-05').hour(0).minute(30).second(0).millisecond(0) },
+                ],
+                dayjs('2026-05-04'),
+            );
+
+            const { decision } = planZoneSchedule(zone, weather);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('deferred');
+            expect(decision!.reason).toBe('window-too-short');
+        });
+
+        it('reports a no-cycle-fit deferral when busy windows leave no room for any cycle', () => {
+            // A cross-zone busy window covering the entire [midnight, sunrise]
+            // block leaves no residual gap, so no cycle count fits.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                ],
+                dayjs('2026-05-04'),
+            );
+            const fullNight = {
+                start: dayjs('2026-05-05').hour(0).minute(0).second(0).millisecond(0),
+                end: dayjs('2026-05-05').hour(6).minute(0).second(0).millisecond(0),
+            };
+
+            const { decision } = planZoneSchedule(zone, weather, [fullNight]);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('deferred');
+            expect(decision!.reason).toBe('no-cycle-fit');
+        });
+
+        it('reports a past-window deferral when every placed cycle has already passed', () => {
+            // An in-flight replan whose past window (epoch → now) extends beyond
+            // the anchor sunrise drops every placed cycle as already-fired.
+            const zone = createTestZone({ currentDepletionMm: 30 });
+            const weather = createWeatherDays(
+                [
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                    { evapotranspirationMmPerDay: 2.0, rainfallMm: 0 },
+                ],
+                dayjs('2026-05-04'),
+            );
+            const pastWindow = {
+                start: dayjs(0),
+                end: dayjs('2026-05-05').hour(7).minute(0).second(0).millisecond(0),
+            };
+
+            const { decision } = planZoneSchedule(zone, weather, [pastWindow]);
+
+            expect(decision).toBeDefined();
+            expect(decision!.outcome).toBe('deferred');
+            expect(decision!.reason).toBe('past-window');
+        });
     });
 });

--- a/api/schedules/dynamic/index.ts
+++ b/api/schedules/dynamic/index.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import type { Zone, DailyWeather, IrrigationScheduleEntry, IrrigationCycle } from '@/models';
+import type { SchedulingDecision, SchedulingDecisionReason, SchedulingOutcome } from '@/models/decision';
 import {
     isDayAllowed,
     isNightSkipped,
@@ -88,6 +89,15 @@ export type BusyWindow = {
 export type PlanZoneScheduleResult = {
     entries: IrrigationScheduleEntry[];
     projectedNextDepletionMm: number;
+
+    /**
+     * The planner's decision for day 0 of the horizon — i.e. *tonight's*
+     * decision (watered / skipped / deferred + reason + depletion + threshold).
+     * The daemon persists it into `scheduling_decisions` for retrospectives.
+     * Undefined when no day was evaluated (empty forecast, or the zone is
+     * disabled and planning short-circuited). API-88.
+     */
+    decision?: SchedulingDecision;
 };
 
 /**
@@ -151,6 +161,12 @@ export function planZoneSchedule(
     let currentDepletionMillimeters = clampedStartingDepletion;
     let projectedNextDepletionMm = clampedStartingDepletion;
 
+    // The decision the planner reaches for day 0 of the horizon — tonight's
+    // outcome. Captured for `scheduling_decisions` so retrospectives can see
+    // why a night went the way it did (API-88). Stays undefined for an empty
+    // forecast.
+    let day0Decision: SchedulingDecision | undefined;
+
     const irrigationSchedule: IrrigationScheduleEntry[] = [];
 
     // Running set of intervals this zone (and any earlier zones in the batch)
@@ -178,6 +194,11 @@ export function planZoneSchedule(
             totalAvailableWaterMillimeters
         );
 
+        // The decision reached for this day. Only day 0's is surfaced on the
+        // result, but it's built uniformly in every branch so the logic stays
+        // in one place. API-88.
+        let decision: SchedulingDecision;
+
         // Check if irrigation is needed.
         if (currentDepletionMillimeters >= readilyAvailableWaterMillimeters) {
             // Forward-looking rain-skip (API-85). Before committing tonight's
@@ -194,6 +215,7 @@ export function planZoneSchedule(
                 console.log(`planner: zone ${zone.id} (${zone.name}): rain-skip on ${date.format('YYYY-MM-DD')} — depletion ${currentDepletionMillimeters.toFixed(1)} mm ≥ trigger ${readilyAvailableWaterMillimeters.toFixed(1)} mm, but ${upcomingEffectiveRainfallMillimeters.toFixed(1)} mm effective rain forecast over the next ${rainSkipLookaheadDays} day(s) will bring it below trigger — deferring irrigation.`);
                 // Fall through: depletion carries forward unchanged and the
                 // day-0 projection is still captured below.
+                decision = buildDecision(date, 'skipped', 'rain-forecast', currentDepletionMillimeters, currentDepletionMillimeters, readilyAvailableWaterMillimeters);
             } else {
                 // Anchor each planning day's overnight block to the *next* day's
                 // sunrise — i.e. the block runs [midnight day i+1, sunrise day i+1],
@@ -203,6 +225,7 @@ export function planZoneSchedule(
                 const nextDay = weatherHistory[dayIndex + 1];
                 if (nextDay === undefined) {
                     console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} is the last weather day — no next-day sunrise to anchor to, deferring irrigation.`);
+                    decision = buildDecision(date, 'deferred', 'no-anchor', currentDepletionMillimeters, currentDepletionMillimeters, readilyAvailableWaterMillimeters);
                 } else {
                     const sunrise = nextDay.sunrise ?? nextDay.date.hour(6).minute(0).second(0).millisecond(0);
 
@@ -219,7 +242,7 @@ export function planZoneSchedule(
                         restrictions,
                     });
 
-                    if (irrigationOutcome !== null) {
+                    if (irrigationOutcome.kind === 'placed') {
                         // Each placed cycle becomes a busy window for the rest of
                         // the planning horizon.
                         for (const cycle of irrigationOutcome.cycles) {
@@ -240,23 +263,64 @@ export function planZoneSchedule(
                             0,
                             totalAvailableWaterMillimeters
                         );
+
+                        decision = buildDecision(
+                            date,
+                            'watered',
+                            irrigationOutcome.partial ? 'partial-refill' : 'full-refill',
+                            irrigationOutcome.entry.depletionBeforeMm,
+                            irrigationOutcome.entry.depletionAfterMm,
+                            readilyAvailableWaterMillimeters,
+                        );
+                    } else {
+                        // The day was skipped or deferred (restriction, window
+                        // too short, no cycle count fit, …). Depletion carries
+                        // forward unchanged — the next allowed day will see the
+                        // larger accumulated value.
+                        decision = buildDecision(date, irrigationOutcome.kind, irrigationOutcome.reason, currentDepletionMillimeters, currentDepletionMillimeters, readilyAvailableWaterMillimeters);
                     }
-                    // When `irrigationOutcome === null`, the day was skipped due to
-                    // restrictions. Depletion carries forward unchanged — the next
-                    // allowed day will see the larger accumulated value.
                 }
             }
+        } else {
+            decision = buildDecision(date, 'skipped', 'below-threshold', currentDepletionMillimeters, currentDepletionMillimeters, readilyAvailableWaterMillimeters);
         }
 
         // Ensure depletion stays within valid bounds.
         currentDepletionMillimeters = clampValue(currentDepletionMillimeters, 0, totalAvailableWaterMillimeters);
 
         // Capture the projected end-of-day-0 depletion — this becomes the
-        // starting depletion that tomorrow's re-plan should treat as 'now'.
-        if (dayIndex === 0) projectedNextDepletionMm = currentDepletionMillimeters;
+        // starting depletion that tomorrow's re-plan should treat as 'now' —
+        // and the day-0 decision the daemon will persist.
+        if (dayIndex === 0) {
+            projectedNextDepletionMm = currentDepletionMillimeters;
+            day0Decision = decision;
+        }
     }
 
-    return { entries: irrigationSchedule, projectedNextDepletionMm };
+    return { entries: irrigationSchedule, projectedNextDepletionMm, decision: day0Decision };
+}
+
+/**
+ * Builds a `SchedulingDecision`, rounding the depletion/threshold values to one
+ * decimal for clean persisted output (matching the entry's `appliedDepthMm` /
+ * `depletionBeforeMm` precision). API-88.
+ */
+function buildDecision(
+    date: dayjs.Dayjs,
+    outcome: SchedulingOutcome,
+    reason: SchedulingDecisionReason,
+    depletionBeforeMm: number,
+    depletionAfterMm: number,
+    triggerThresholdMm: number,
+): SchedulingDecision {
+    return {
+        date,
+        outcome,
+        reason,
+        depletionBeforeMm: roundTo1Decimal(depletionBeforeMm),
+        depletionAfterMm: roundTo1Decimal(depletionAfterMm),
+        triggerThresholdMm: roundTo1Decimal(triggerThresholdMm),
+    };
 }
 
 type PlaceIrrigationInputs = {
@@ -272,16 +336,22 @@ type PlaceIrrigationInputs = {
     restrictions: ScheduleRestrictions;
 };
 
-type PlaceIrrigationOutcome = {
-    cycles: IrrigationCycle[];
-    entry: IrrigationScheduleEntry;
-};
+/**
+ * Result of `tryPlaceIrrigationForDay`. Either cycles were `placed` (with the
+ * resulting entry and a `partial` flag set when the overnight window clamped
+ * the refill, API-75), or the day was `skipped` / `deferred` with the specific
+ * reason — the caller persists that reason into the decisions log (API-88) and
+ * carries depletion forward unchanged.
+ */
+type PlaceIrrigationResult =
+    | { kind: 'placed'; cycles: IrrigationCycle[]; entry: IrrigationScheduleEntry; partial: boolean }
+    | { kind: 'skipped' | 'deferred'; reason: SchedulingDecisionReason };
 
 /**
  * Computes the day's irrigation block, anchored so the last cycle ends at
- * the next day's sunrise and cycles fill backward into the night. Returns
- * `null` when the day is disallowed or no cycles fit the overnight window —
- * callers treat that as "skip, carry depletion forward."
+ * the next day's sunrise and cycles fill backward into the night. Returns a
+ * `skipped` / `deferred` result when the day is disallowed or no cycles fit the
+ * overnight window — callers treat that as "skip, carry depletion forward."
  *
  * The overnight window is [midnight of cycle day, sunrise of cycle day] —
  * derived from `sunrise.startOf('day')` and `sunrise`. With the API-76 anchor
@@ -302,7 +372,7 @@ type PlaceIrrigationOutcome = {
  * dropped. In the normal evening-replan flow no cycle is dropped; the filter
  * only bites for in-flight replans (`now` lies inside the planning block).
  */
-function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigationOutcome | null {
+function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigationResult {
     const {
         date, sunrise, zone, currentDepletionMillimeters, totalAvailableWaterMillimeters,
         precipitationRateMillimetersPerHour, infiltrationRateMillimetersPerHour, soakTimeMinutes,
@@ -311,12 +381,12 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
 
     if (!isDayAllowed(restrictions, date.isoWeekday())) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} (isoWeekday ${date.isoWeekday()}) disallowed by schedule restrictions — skipping irrigation.`);
-        return null;
+        return { kind: 'skipped', reason: 'day-not-allowed' };
     }
 
     if (isNightSkipped(restrictions, date)) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): day ${date.format('YYYY-MM-DD')} is skip-marked — skipping irrigation.`);
-        return null;
+        return { kind: 'skipped', reason: 'operator-skip' };
     }
 
     const depletionBeforeIrrigation = currentDepletionMillimeters;
@@ -345,7 +415,7 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
     const maxRunTimeMinutes = computeMaxRunTimeMinutes(maximumCycleMinutes, soakTimeMinutes, windowMinutes);
     if (maxRunTimeMinutes <= 0) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): overnight window (${windowMinutes} min) too short to fit even one cycle (maxCycle ${maximumCycleMinutes.toFixed(1)} min) on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
-        return null;
+        return { kind: 'deferred', reason: 'window-too-short' };
     }
     const initialTotalRunTimeMinutes = Math.min(fullRefillRunTimeMinutes, maxRunTimeMinutes);
 
@@ -390,12 +460,12 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
 
     if (placedCycles === null) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): no cycle count from ${initialN} down fit the overnight window's residual gaps on ${date.format('YYYY-MM-DD')} — deferring irrigation.`);
-        return null;
+        return { kind: 'deferred', reason: 'no-cycle-fit' };
     }
 
     if (placedCycles.length === 0) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles fit the overnight window on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
-        return null;
+        return { kind: 'deferred', reason: 'no-cycle-fit' };
     }
 
     const grossIrrigationDepthMillimeters = (actualTotalRunTimeMinutes / 60) * precipitationRateMillimetersPerHour;
@@ -417,7 +487,7 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
 
     if (finalCycles.length === 0) {
         console.warn(`planner: zone ${zone.id} (${zone.name}): no cycles remain after past-window handling on ${date.format('YYYY-MM-DD')} — skipping irrigation.`);
-        return null;
+        return { kind: 'deferred', reason: 'past-window' };
     }
 
     // Net depth that actually reaches the root zone after losses. `depletionAfter`
@@ -436,7 +506,10 @@ function tryPlaceIrrigationForDay(inputs: PlaceIrrigationInputs): PlaceIrrigatio
         depletionAfterMm: roundTo1Decimal(depletionAfterIrrigation),
         sunriseAt: sunrise,
     };
-    return { cycles: finalCycles, entry };
+    // `partial` when the overnight window clamped the applied gross below a
+    // full refill (API-75) — distinguishes `partial-refill` from `full-refill`
+    // in the decisions log (API-88).
+    return { kind: 'placed', cycles: finalCycles, entry, partial: actualTotalRunTimeMinutes < fullRefillRunTimeMinutes };
 }
 
 /**

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -34,6 +34,7 @@ import {
     getAlertsDb,
     getScheduleEntriesRepo,
     getSchedulesRepo,
+    getSchedulingDecisionsRepo,
     getSitesRepo,
     getWeatherSnapshotsRepo,
     getWeatherStateRepo,
@@ -159,6 +160,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     const zonesRepo = getZonesRepo();
     const schedulesRepo = getSchedulesRepo();
     const scheduleEntriesRepo = getScheduleEntriesRepo();
+    const schedulingDecisionsRepo = getSchedulingDecisionsRepo();
     const weatherStateRepo = getWeatherStateRepo();
     const weatherSnapshotsRepo = getWeatherSnapshotsRepo();
 
@@ -203,7 +205,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     const tickDeps = {
         clock, alerter,
         runPlan, getWeather, getZoneActuationHistory,
-        zonesRepo, scheduleEntriesRepo, weatherStateRepo, weatherSnapshotsRepo, getAlertsDb,
+        zonesRepo, scheduleEntriesRepo, schedulingDecisionsRepo, weatherStateRepo, weatherSnapshotsRepo, getAlertsDb,
     };
 
     // Private implementation. `isScheduledTick` distinguishes the nightly

--- a/api/service/daemon/reconcile.test.ts
+++ b/api/service/daemon/reconcile.test.ts
@@ -100,6 +100,9 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository): DaemonService
             clearStaleSkipMarkers: async () => undefined,
         },
         scheduleEntries,
+        schedulingDecisions: {
+            record: async () => undefined,
+        },
         weatherState: {
             markFetchSuccessful: async () => undefined,
             isStale: async () => false,

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -134,6 +134,9 @@ function defaultRepos(scheduleEntries: ScheduleEntriesRepository, onAdvanceDeple
             clearStaleSkipMarkers: async () => undefined,
         },
         scheduleEntries,
+        schedulingDecisions: {
+            record: async () => undefined,
+        },
         weatherState: {
             markFetchSuccessful: async () => undefined,
             isStale: async () => false,

--- a/api/service/daemon/state.ts
+++ b/api/service/daemon/state.ts
@@ -4,6 +4,10 @@ import {
     createScheduleEntriesRepository,
     type ScheduleEntriesRepository,
 } from '@/repositories/schedule-entries';
+import {
+    createSchedulingDecisionsRepository,
+    type SchedulingDecisionsRepository,
+} from '@/repositories/scheduling-decisions';
 import { createSchedulesRepository, type SchedulesRepository } from '@/repositories/schedules';
 import { createSitesRepository, type SitesRepository } from '@/repositories/sites';
 import { createWeatherSnapshotsRepository, type WeatherSnapshotsRepository } from '@/repositories/weather-snapshots';
@@ -21,6 +25,7 @@ export type DaemonServiceRepos = {
     sites: SitesRepository;
     schedules: SchedulesRepository;
     scheduleEntries: ScheduleEntriesRepository;
+    schedulingDecisions: SchedulingDecisionsRepository;
     weatherState: WeatherStateRepository;
     weatherSnapshots: WeatherSnapshotsRepository;
 };
@@ -53,6 +58,7 @@ export function setDaemonRepos(input: SetDaemonReposInput): void {
             sites: createSitesRepository(input.db),
             schedules: createSchedulesRepository(input.db),
             scheduleEntries: createScheduleEntriesRepository(input.db),
+            schedulingDecisions: createSchedulingDecisionsRepository(input.db),
             weatherState: createWeatherStateRepository(input.db),
             weatherSnapshots: createWeatherSnapshotsRepository(input.db),
         };
@@ -81,6 +87,10 @@ export function getSchedulesRepo(): SchedulesRepository {
 
 export function getScheduleEntriesRepo(): ScheduleEntriesRepository {
     return getRepos().scheduleEntries;
+}
+
+export function getSchedulingDecisionsRepo(): SchedulingDecisionsRepository {
+    return getRepos().schedulingDecisions;
 }
 
 export function getWeatherStateRepo(): WeatherStateRepository {

--- a/api/service/daemon/tick/.test.ts
+++ b/api/service/daemon/tick/.test.ts
@@ -6,6 +6,7 @@ import { createTestZone } from '@/mock/zone';
 import type { HourlyWeather, WeatherData, Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { RecordSchedulingDecisionInput, SchedulingDecisionsRepository } from '@/repositories/scheduling-decisions';
 import type { Schedule } from '@/repositories/schedules';
 import type { RecordWeatherSnapshotInput, WeatherSnapshotsRepository } from '@/repositories/weather-snapshots';
 import type { WeatherStateRepository } from '@/repositories/weather-state';
@@ -60,7 +61,8 @@ function buildDeps(overrides?: {
     onAdvanceDepletion?: (advance: DepletionAdvance) => void;
     onReplaceForZone?: () => Array<PersistedCycle>;
     snapshotRecordThrows?: boolean;
-}): { deps: TickDeps; depletionAdvances: DepletionAdvance[]; alertCalls: AlertEvent[]; snapshotRecords: RecordWeatherSnapshotInput[] } {
+    decisionRecordThrows?: boolean;
+}): { deps: TickDeps; depletionAdvances: DepletionAdvance[]; alertCalls: AlertEvent[]; snapshotRecords: RecordWeatherSnapshotInput[]; decisionRecords: RecordSchedulingDecisionInput[] } {
     const depletionAdvances: DepletionAdvance[] = [];
     const { alerter, calls: alertCalls } = overrides?.alerter ? { alerter: overrides.alerter, calls: [] as AlertEvent[] } : recordingAlerter();
     const zonesRepo: ZonesRepository = {
@@ -95,6 +97,13 @@ function buildDeps(overrides?: {
             return 'snapshot-test';
         },
     };
+    const decisionRecords: RecordSchedulingDecisionInput[] = [];
+    const schedulingDecisionsRepo: SchedulingDecisionsRepository = {
+        record: async (input) => {
+            if (overrides?.decisionRecordThrows) throw new Error('decision write failed');
+            decisionRecords.push(input);
+        },
+    };
     return {
         deps: {
             clock: buildClock(),
@@ -104,6 +113,7 @@ function buildDeps(overrides?: {
             getZoneActuationHistory: overrides?.getZoneActuationHistory ?? (async () => []),
             zonesRepo,
             scheduleEntriesRepo,
+            schedulingDecisionsRepo,
             weatherStateRepo,
             weatherSnapshotsRepo,
             getAlertsDb: () => null as unknown as AlertsDb,
@@ -111,6 +121,7 @@ function buildDeps(overrides?: {
         depletionAdvances,
         alertCalls,
         snapshotRecords,
+        decisionRecords,
     };
 }
 
@@ -474,5 +485,99 @@ describe('runTickForZone — weather-snapshot persistence', () => {
         // returned a normal (non-empty-by-failure) result.
         expect(depletionAdvances).toHaveLength(1);
         expect(result).toMatchObject({ cyclesToArm: [], newBusyWindows: [] });
+    });
+});
+
+describe('runTickForZone — scheduling-decision persistence (API-88)', () => {
+    const baseInput = (zone: Zone, deps: TickDeps) => ({
+        zone,
+        activeSchedule: buildSchedule(),
+        today: dayjs(NOW).tz(SITE_TIMEZONE),
+        busyWindows: [],
+        pastWindow: { start: new Date(0), end: NOW },
+        tickKind: 'evening' as const,
+        isScheduledTick: true,
+        irrigationEnabled: true,
+        morningTickMinutesAfterSunrise: 60,
+        deps,
+    });
+
+    const runPlanWithDecision: TickDeps['runPlan'] = async () => ({
+        entries: [],
+        projectedNextDepletionMm: 10,
+        decision: {
+            date: dayjs('2026-05-04'),
+            outcome: 'skipped',
+            reason: 'below-threshold',
+            depletionBeforeMm: 10,
+            depletionAfterMm: 10,
+            triggerThresholdMm: 22.5,
+        },
+    });
+
+    it('records the planner decision, wired to the weather-snapshot id that drove it', async () => {
+        const zone = createTestZone({ id: 'zone-001' });
+        const { deps, decisionRecords } = buildDeps({ runPlan: runPlanWithDecision });
+
+        await runTickForZone(baseInput(zone, deps));
+
+        expect(decisionRecords).toHaveLength(1);
+        expect(decisionRecords[0]).toMatchObject({
+            zoneId: 'zone-001',
+            scheduleId: 'sched-001',
+            date: '2026-05-04',
+            replanAt: NOW,
+            outcome: 'skipped',
+            reason: 'below-threshold',
+            depletionBeforeMm: 10,
+            depletionAfterMm: 10,
+            triggerThresholdMm: 22.5,
+            weatherSnapshotId: 'snapshot-test',
+        });
+    });
+
+    it('records a null snapshot id when the snapshot write failed', async () => {
+        const zone = createTestZone({ id: 'zone-001' });
+        const { deps, decisionRecords } = buildDeps({
+            runPlan: runPlanWithDecision,
+            snapshotRecordThrows: true,
+        });
+
+        await runTickForZone(baseInput(zone, deps));
+
+        expect(decisionRecords).toHaveLength(1);
+        expect(decisionRecords[0]?.weatherSnapshotId).toBeNull();
+    });
+
+    it('records nothing when the planner returns no decision', async () => {
+        const zone = createTestZone({ id: 'zone-001' });
+        // Default runPlan returns no `decision`.
+        const { deps, decisionRecords } = buildDeps({});
+
+        await runTickForZone(baseInput(zone, deps));
+
+        expect(decisionRecords).toHaveLength(0);
+    });
+
+    it('continues the tick when the decision write fails — best-effort', async () => {
+        const zone = createTestZone({ id: 'zone-001' });
+        const { deps } = buildDeps({
+            runPlan: runPlanWithDecision,
+            decisionRecordThrows: true,
+        });
+
+        const result = await runTickForZone(baseInput(zone, deps));
+
+        // The decision write threw, but the tick still returned a normal result.
+        expect(result).toMatchObject({ cyclesToArm: [], newBusyWindows: [] });
+    });
+
+    it('does not record a decision when planning is skipped (no active schedule)', async () => {
+        const zone = createTestZone({ id: 'zone-001' });
+        const { deps, decisionRecords } = buildDeps({ runPlan: runPlanWithDecision });
+
+        await runTickForZone({ ...baseInput(zone, deps), activeSchedule: undefined });
+
+        expect(decisionRecords).toHaveLength(0);
     });
 });

--- a/api/service/daemon/tick/index.ts
+++ b/api/service/daemon/tick/index.ts
@@ -7,6 +7,7 @@ import { sumHourlyWeatherBetween } from '@/data/weather';
 import type { WeatherData, Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
+import type { SchedulingDecisionsRepository } from '@/repositories/scheduling-decisions';
 import type { Schedule } from '@/repositories/schedules';
 import type { WeatherSnapshotsRepository } from '@/repositories/weather-snapshots';
 import type { WeatherStateRepository } from '@/repositories/weather-state';
@@ -31,6 +32,7 @@ export type TickDeps = {
     getZoneActuationHistory: (zone: Zone, since: Date, until: Date) => Promise<ZoneActuationInterval[]>;
     zonesRepo: ZonesRepository;
     scheduleEntriesRepo: ScheduleEntriesRepository;
+    schedulingDecisionsRepo: SchedulingDecisionsRepository;
     weatherStateRepo: WeatherStateRepository;
     weatherSnapshotsRepo: WeatherSnapshotsRepository;
     getAlertsDb: () => AlertsDb | null;
@@ -96,7 +98,7 @@ export async function runTickForZone(input: RunTickForZoneInput): Promise<RunTic
         tickKind, isScheduledTick, irrigationEnabled,
         morningTickMinutesAfterSunrise, deps,
     } = input;
-    const { clock, alerter, runPlan, getWeather, getZoneActuationHistory, zonesRepo, scheduleEntriesRepo, weatherStateRepo, weatherSnapshotsRepo, getAlertsDb } = deps;
+    const { clock, alerter, runPlan, getWeather, getZoneActuationHistory, zonesRepo, scheduleEntriesRepo, schedulingDecisionsRepo, weatherStateRepo, weatherSnapshotsRepo, getAlertsDb } = deps;
 
     const tickNow = clock.now();
     let observedSunrise: Date | null = null;
@@ -111,9 +113,12 @@ export async function runTickForZone(input: RunTickForZoneInput): Promise<RunTic
     // Persist the fetched forecast for scheduling retrospectives — best-effort,
     // so a snapshot-write failure never stops reconciliation or planning. Only
     // when the zone has coordinates (it must, to have fetched weather). API-87.
+    // The returned id ties tonight's decision (API-88) back to this forecast;
+    // stays null when the write failed or the zone has no coordinates.
+    let weatherSnapshotId: string | null = null;
     if (zone.location) {
         try {
-            await weatherSnapshotsRepo.record({
+            weatherSnapshotId = await weatherSnapshotsRepo.record({
                 zoneId: zone.id,
                 latitude: zone.location.lat,
                 longitude: zone.location.lon,
@@ -206,7 +211,7 @@ export async function runTickForZone(input: RunTickForZoneInput): Promise<RunTic
         const planningZone = isScheduledTick
             ? { ...zone, currentDepletionMm: newDepletionMm, currentDepletionReconciledAt: tickNow }
             : zone;
-        const { entries } = await runPlan(planningZone, {
+        const { entries, decision } = await runPlan(planningZone, {
             busyWindows: [pastWindow, ...busyWindows],
             restrictions,
             overrides,
@@ -215,6 +220,28 @@ export async function runTickForZone(input: RunTickForZoneInput): Promise<RunTic
         const { cycles } = await scheduleEntriesRepo.replaceForZone(
             zone.id, entries, today, activeSchedule.id,
         );
+
+        // Persist tonight's planning decision for retrospectives — best-effort,
+        // so a write failure never stops arming. Ties to the weather snapshot
+        // that drove it (null if that write failed). API-88.
+        if (decision) {
+            try {
+                await schedulingDecisionsRepo.record({
+                    zoneId: zone.id,
+                    scheduleId: activeSchedule.id,
+                    date: decision.date.format('YYYY-MM-DD'),
+                    replanAt: tickNow,
+                    outcome: decision.outcome,
+                    reason: decision.reason,
+                    depletionBeforeMm: decision.depletionBeforeMm,
+                    depletionAfterMm: decision.depletionAfterMm,
+                    triggerThresholdMm: decision.triggerThresholdMm,
+                    weatherSnapshotId,
+                });
+            } catch (err) {
+                console.error(`daemon: failed to persist scheduling decision for zone ${zone.id} (${zone.name}); continuing.`, err);
+            }
+        }
 
         const cyclesToArm: Array<{ zone: Zone; cycle: PersistedCycle }> = [];
         const newBusyWindows: Array<{ start: Date; end: Date }> = [];


### PR DESCRIPTION
## Ticket

[API-88](http://192.168.2.100:7123/home/browse/API-88/) Record scheduling-decision provenance (skips + driving weather/depletion) for retrospectives

## Summary

Executed irrigation was already persisted, but **non-events** (skips/deferrals) and the **inputs** behind a decision left no record — so "why didn't zone X water on night Y?" was unanswerable. This adds an append-only decisions log.

- **New `scheduling_decisions` table + recorder repo** — one row per zone per replan capturing the day-0 outcome (`watered`/`skipped`/`deferred`), the reason, depletion before/after, the trigger threshold, and a reference to the weather snapshot that drove it. Append-only with 28-day pruning (env-overridable), mirroring the API-87 weather-snapshot recorder. The `weather_snapshot_id` FK is `ON DELETE SET NULL` so the snapshot prune never FK-fails.
- **Planner surfaces the day-0 decision** — `tryPlaceIrrigationForDay` now returns a discriminated result carrying the precise skip/defer reason (`below-threshold`, `rain-forecast`, `day-not-allowed`, `operator-skip`, `no-anchor`, `window-too-short`, `no-cycle-fit`, `past-window`, `full-refill`, `partial-refill`); `planZoneSchedule` returns the tonight decision on `PlanZoneScheduleResult`. No change to entries/depletion math.
- **Daemon tick persists it** — captures the weather-snapshot id (previously discarded) and best-effort-records the decision after planning, so a write failure never stops arming.

## Scope

Records the **day-0 (tonight's)** decision per replan — the actionable one. Future horizon days are speculative and re-decided every tick. No new HTTP endpoint; logs + DB satisfy the reconstruct-any-night requirement.

## Tests

Full `api` suite green (970 passing). New coverage: recorder repo (row shape, null snapshot ref, prune cutoff, retention resolver), all 10 planner decision reasons, and the tick wiring (snapshot-id wired through, null on snapshot failure, no-decision no-op, best-effort throw, no-schedule skip).