### PR TITLE
[APP-87] Fix zone tile always showing "Last ran last night"

### DIFF
--- a/app/components/zone-tile/.test.tsx
+++ b/app/components/zone-tile/.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, within } from '@testing-library/react-native';
 import { StyleSheet, type ViewStyle } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -108,5 +108,38 @@ describe('ZoneTile', () => {
 
         expect(gradient.props.colors).toEqual([...TILE_GRADIENT_COLORS.elevated]);
         expect(style.borderColor).toBe(colors['accent-border']);
+    });
+
+    // Without a `now` prop the tile drives its own clock, so the footer must
+    // refresh as wall-clock time advances instead of freezing at mount. APP-87.
+    describe('live clock (no now prop)', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            // 2026-05-23T03:00:00Z = 21:00 MDT on 2026-05-22.
+            jest.setSystemTime(new Date('2026-05-23T03:00:00.000Z'));
+        });
+
+        afterEach(() => {
+            // Cancel the tile's interval without firing it post-test.
+            jest.clearAllTimers();
+            jest.useRealTimers();
+        });
+
+        it('refreshes the "Last ran" footer as the day rolls over.', () => {
+            // Ran 23:00 MDT on 2026-05-21 — one midnight before the mounted "now".
+            const zone: ZoneSummary = { ...HEALTHY_ZONE, lastFiredAt: '2026-05-22T05:00:00.000Z' };
+            render(<ZoneTile zone={zone} onPress={() => {}} />);
+
+            expect(screen.getByText('Last ran last night')).toBeOnTheScreen();
+
+            act(() => {
+                // Advance to the next evening (21:00 MDT May 23) and let one
+                // interval tick fire so the tile re-reads the clock.
+                jest.setSystemTime(new Date('2026-05-24T03:00:00.000Z'));
+                jest.advanceTimersByTime(60_000);
+            });
+
+            expect(screen.getByText('Last ran 2 nights ago')).toBeOnTheScreen();
+        });
     });
 });

--- a/app/components/zone-tile/index.tsx
+++ b/app/components/zone-tile/index.tsx
@@ -5,6 +5,7 @@ import type { ZoneSummary } from '@/api/types/zones';
 import { Battery } from '@/components/battery';
 import { TileGradient } from '@/components/tile-gradient';
 import { FontFamily } from '@/constants/fonts';
+import { useNow } from '@/hooks/now';
 import { formatLastRan } from '@/lib/relative-time';
 import config from '@/tailwind.config';
 
@@ -32,7 +33,11 @@ export type ZoneTileProps = {
  */
 export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
     const handlePress = useCallback(() => onPress(zone), [onPress, zone]);
-    const referenceNow = useMemo(() => now ?? new Date(), [now]);
+    // Refresh the reference clock every minute so the "Last ran ..." label
+    // stays accurate while Home stays mounted, instead of freezing at mount.
+    // A caller-supplied `now` (tests) disables the interval. APP-87.
+    const tickingNow = useNow(now === undefined ? 60_000 : null);
+    const referenceNow = now ?? tickingNow;
     const pastRaw = zone.currentDepletionMm >= zone.rawMm;
     const lastRan = useMemo(() => formatLastRan(zone.lastFiredAt, referenceNow), [zone.lastFiredAt, referenceNow]);
 

--- a/app/hooks/now/.test.tsx
+++ b/app/hooks/now/.test.tsx
@@ -1,0 +1,44 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useNow } from '.';
+
+describe('useNow', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-05-23T09:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        // Cancel the hook's interval without firing it (firing after the test
+        // would set state outside act()).
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it('refreshes the returned instant on each interval tick.', () => {
+        const { result } = renderHook(() => useNow(60_000));
+        const first = result.current.getTime();
+        expect(first).toBe(new Date('2026-05-23T09:00:00.000Z').getTime());
+
+        // Advancing the fake timers also advances the faked `Date`, so the
+        // interval callback re-reads the clock one minute on.
+        act(() => {
+            jest.advanceTimersByTime(60_000);
+        });
+
+        expect(result.current.getTime()).toBe(new Date('2026-05-23T09:01:00.000Z').getTime());
+        expect(result.current.getTime()).toBeGreaterThan(first);
+    });
+
+    it('stays frozen when intervalMs is null (no timer spun up).', () => {
+        const { result } = renderHook(() => useNow(null));
+        const first = result.current;
+
+        act(() => {
+            jest.advanceTimersByTime(60 * 60_000);
+        });
+
+        // No interval was scheduled, so the value is the same instance.
+        expect(result.current).toBe(first);
+    });
+});

--- a/app/hooks/now/index.ts
+++ b/app/hooks/now/index.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns the current instant, refreshed on a fixed interval so relative-time
+ * labels (e.g. a zone tile's "Last ran ...") stay accurate while the screen
+ * stays mounted instead of drifting against a `new Date()` frozen at mount.
+ * APP-87.
+ *
+ * @param intervalMs - How often to refresh, in milliseconds. Defaults to one
+ *   minute — fine-grained enough to cross hour/midnight boundaries promptly,
+ *   cheap enough to ignore. Pass `null` to freeze at the initial value (no
+ *   timer); callers that supply their own deterministic `now` use this so they
+ *   don't spin up a real interval.
+ * @returns The current `Date`, replaced with a fresh instance each tick.
+ */
+export function useNow(intervalMs: number | null = 60_000): Date {
+    const [now, setNow] = useState<Date>(() => new Date());
+
+    useEffect(() => {
+        if (intervalMs === null) return;
+        const id = setInterval(() => setNow(new Date()), intervalMs);
+        return () => clearInterval(id);
+    }, [intervalMs]);
+
+    return now;
+}

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -30,6 +30,20 @@ describe('formatLastRan', () => {
         expect(formatLastRan(isoThreeDaysAgo, NOW)).toBe('3 nights ago');
     });
 
+    it('counts calendar nights, not 24h spans — a run 24-48h back across two midnights reads "2 nights ago". APP-87.', () => {
+        // 2026-05-22T05:00:00Z = 23:00 MDT on 2026-05-21, ~34h before NOW
+        // (09:00 MDT May 23). Two midnights have passed, so it is two nights
+        // ago — the raw-ms bucketing bug rendered this as "last night".
+        expect(formatLastRan('2026-05-22T05:00:00.000Z', NOW)).toBe('2 nights ago');
+    });
+
+    it('treats a run on the previous calendar day as "last night" even when read in the evening. APP-87.', () => {
+        // 2026-05-22T05:30:00Z = 23:30 MDT on 2026-05-21 (one calendar day
+        // before), read at 21:00 MDT on 2026-05-22 — ~21.5h, one midnight.
+        const eveningOfMay22 = new Date('2026-05-23T03:00:00.000Z'); // 21:00 MDT May 22
+        expect(formatLastRan('2026-05-22T05:30:00.000Z', eveningOfMay22)).toBe('last night');
+    });
+
     it('clamps future-dated input to "just now" (defensive: clock skew, upstream bugs). APP-55.', () => {
         const isoOneHourAhead = new Date(NOW.getTime() + 60 * 60_000).toISOString();
         expect(formatLastRan(isoOneHourAhead, NOW)).toBe('just now');

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -12,23 +12,30 @@ import { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE } from '@/constants/duration';
  *   - same calendar day   → `'<n>h ago'`
  *   - last calendar day   → `'last night'`
  *   - older               → `'<n> nights ago'`
+ *
+ * Day buckets are counted in device-local *calendar* days, not raw 24 h spans,
+ * so a run 24–48 h back that crossed two midnights reads `'2 nights ago'`
+ * rather than `'last night'`. APP-87.
  */
 export function formatLastRan(iso: string | null, now: Date): string {
     if (iso === null) return '';
     const last = dayjs(iso);
     const present = dayjs(now);
     // Clamp future-dated input to 0 so clock skew (or upstream data bugs)
-    // can't bucket into a negative `Math.floor(diffMs / MS_PER_DAY)` and
-    // render `'-2 nights ago'`. APP-55.
+    // can't render a negative bucket like `'-2 nights ago'`. APP-55.
     const diffMs = Math.max(0, present.valueOf() - last.valueOf());
     if (diffMs < MS_PER_HOUR) return 'just now';
-    if (diffMs < MS_PER_DAY) {
+
+    // Calendar-day offset (device-local): the number of midnights between the
+    // run and now. `Math.max(0, …)` guards future-dated runs that slipped past
+    // the sub-hour clamp above.
+    const dayDiff = Math.max(0, present.startOf('day').diff(last.startOf('day'), 'day'));
+    if (dayDiff === 0) {
         const hours = Math.floor(diffMs / MS_PER_HOUR);
         return `${hours}h ago`;
     }
-    const days = Math.floor(diffMs / MS_PER_DAY);
-    if (days === 1) return 'last night';
-    return `${days} nights ago`;
+    if (dayDiff === 1) return 'last night';
+    return `${dayDiff} nights ago`;
 }
 
 /**


### PR DESCRIPTION
## Ticket

[APP-87](http://192.168.2.100:7123/home/browse/APP-87/) Zone tiles always display "Last ran last night"

## Problem

Zone tiles showed **"Last ran last night"** for almost any prior run. Two compounding root causes:

1. **Raw-ms day bucketing** in `formatLastRan` — days were `Math.floor(diffMs / MS_PER_DAY)`, so any run **24–48 h** ago fell in the `days === 1` branch → "last night", even when it was two calendar nights ago. Since zones run nightly, the common case always read "last night".
2. **Frozen reference clock** in `ZoneTile` — `useMemo(() => now ?? new Date(), [now])` captured `new Date()` once at mount (Home never passes `now`), so the label drifted the longer the app stayed open.

## Fix

- **Calendar-night bucketing** ([app/lib/relative-time/index.ts](app/lib/relative-time/index.ts)): `formatLastRan` now counts device-local midnights (`present.startOf('day').diff(last.startOf('day'), 'day')`) — `just now` / `Nh ago` / `last night` / `N nights ago` reflect real calendar nights. The sub-hour `just now` guard and the future-clamp are preserved.
- **Live clock** ([app/hooks/now/index.ts](app/hooks/now/index.ts)): new `useNow(intervalMs)` hook returns a `Date` refreshed on an interval (`null` freezes it). `ZoneTile` uses it (1-minute tick) when no `now` prop is supplied, so the footer stays current; a caller-supplied `now` (tests) keeps results deterministic and timer-free.

## Tests

- `relative-time`: added regression cases — a ~34 h run across two midnights → "2 nights ago" (previously "last night"), and a previous-calendar-day evening read → "last night".
- `useNow`: ticks on the interval; frozen when `null`.
- `zone-tile`: fake-timer test asserts the footer rolls "last night" → "2 nights ago" as the day turns over with no `now` prop.

Full `app` suite green: **671 passing, 85 suites.**