### PR TITLE
[APP-81] Fix dead "Mark all read" button on Alerts screen

### DIFF
--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1065,6 +1065,32 @@ describe('buildApp alert routes', () => {
             expect(acked).toEqual(['my-id-here']);
             await app.close();
         });
+
+        it('accepts a bodyless POST with an empty Content-Type (Android RN networking) instead of 415 (APP-81)', async () => {
+            // React Native's Android networking attaches an empty Content-Type
+            // header to a bodyless POST, which bare Fastify rejects with
+            // `415 Unsupported Media Type: undefined` before the handler runs —
+            // the on-device cause of "Mark all read" silently doing nothing.
+            const acked: string[] = [];
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                alerts: {
+                    list: async () => [],
+                    ack: async (id) => { acked.push(id); return 'acked'; },
+                },
+            });
+
+            const res = await app.inject({
+                method: 'POST',
+                url: '/alerts/alert-001/ack',
+                headers: { 'content-type': '', 'content-length': '0' },
+            });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ status: 'acked' });
+            expect(acked).toEqual(['alert-001']);
+            await app.close();
+        });
     });
 });
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -259,6 +259,22 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
     const app = Fastify();
 
     /**
+     * Accept bodyless / empty-body POSTs regardless of `Content-Type`. Most of
+     * Irrigo's mutating routes are RPC-style — the path carries all the intent
+     * and the body is empty (zone open/close, alert ack, system enable/disable,
+     * schedule toggles, replan). React Native's Android networking attaches an
+     * empty `Content-Type` header to such requests, which bare Fastify rejects
+     * with `415 Unsupported Media Type: undefined` before the handler runs. A
+     * catch-all parser that tolerates an absent body makes these succeed from a
+     * real device; routes that take a real JSON body (e.g. `/push/register`)
+     * are unaffected — the built-in `application/json` parser still wins for
+     * `application/json` requests, and this only fires when no parser matches.
+     */
+    app.addContentTypeParser('*', { parseAs: 'string' }, (_req, body, done) => {
+        done(null, body.length > 0 ? body : undefined);
+    });
+
+    /**
      * `GET /` — placeholder root-of-host probe. Always 200; useful for
      * confirming the api process is up before pointing tooling at it.
      */

--- a/app/components/alerts-view/.test.tsx
+++ b/app/components/alerts-view/.test.tsx
@@ -186,6 +186,42 @@ describe('AlertsView', () => {
         });
     });
 
+    it('marks the Mark all read label pointer-transparent so taps reach the button (APP-81).', () => {
+        // Regression guard: the old hand-rolled Pressable wrapped a bare Text
+        // that swallowed the touch on a real device, so onPress never fired.
+        // The Button primitive declares pointerEvents='none' on its label.
+        const wrapper = seed([buildAlert({ id: 'a-1', ack: false })]);
+
+        render(<AlertsView now={NOW} />, { wrapper });
+
+        expect(screen.getByText('Mark all read').props.pointerEvents).toBe('none');
+    });
+
+    it('clears the list to the empty state after Mark all read (APP-81).', async () => {
+        // The server drops acked alerts from GET /alerts, so a successful
+        // ack-all should refetch to the empty list and render "Nothing to flag".
+        mockFetch.mockImplementation((input: unknown) => {
+            const url = String(input);
+            if (url.includes('/ack')) {
+                currentAlerts = [];
+                return Promise.resolve(jsonResponse({ status: 'acked' }));
+            }
+            if (url.endsWith('/alerts')) return Promise.resolve(jsonResponse({ alerts: currentAlerts }));
+            return Promise.resolve(jsonResponse({}));
+        });
+        const wrapper = seed([
+            buildAlert({ id: 'a-1', ack: false }),
+            buildAlert({ id: 'a-2', ack: false, title: 'Forecast stale', tone: 'warn', class: 'weather-stale' }),
+        ]);
+
+        render(<AlertsView now={NOW} />, { wrapper });
+        fireEvent.press(screen.getByLabelText('Mark all read'));
+
+        await waitFor(() => {
+            expect(screen.getByText('Nothing to flag')).toBeOnTheScreen();
+        });
+    });
+
     it('disables Mark all read when there are no unread alerts.', () => {
         const wrapper = seed([
             buildAlert({ id: 'a-1', ack: true }),

--- a/app/components/alerts-view/index.tsx
+++ b/app/components/alerts-view/index.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { AlertDto } from '@/api/types/alerts';
+import { Button } from '@/components/button';
 import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
 import { FontFamily } from '@/constants/fonts';
 import { useAckAlert, useAlerts } from '@/hooks/alerts';
@@ -96,18 +97,15 @@ export function AlertsView({ now = new Date() }: AlertsViewProps = {}) {
                 <View style={styles.titleRow}>
                     <Text style={styles.title}>{isEmpty ? 'Nothing to flag' : 'Recent alerts'}</Text>
                     {!isEmpty && (
-                        <Pressable
-                            accessibilityRole='button'
-                            accessibilityLabel='Mark all read'
-                            accessibilityState={{ disabled: markAllDisabled }}
+                        <Button
+                            variant='secondary'
+                            size='sm'
                             disabled={markAllDisabled}
                             onPress={onMarkAllRead}
-                            style={styles.markAll}
+                            accessibilityLabel='Mark all read'
                         >
-                            <Text style={[styles.markAllText, markAllDisabled ? styles.markAllDisabled : null]}>
-                                Mark all read
-                            </Text>
-                        </Pressable>
+                            Mark all read
+                        </Button>
                     )}
                 </View>
 
@@ -201,20 +199,6 @@ const styles = StyleSheet.create({
         flex: 1,
         backgroundColor: colors.bg,
     },
-    markAll: {
-        paddingVertical: 10,
-        paddingHorizontal: 6,
-    },
-    markAllText: {
-        fontFamily: FontFamily.sansMedium,
-        fontSize: 13,
-        lineHeight: 13,
-        color: colors['fg-soft'],
-    },
-    markAllDisabled: {
-        color: colors['fg-dim'],
-        opacity: 0.4,
-    },
     headingBlock: {
         gap: 14,
         paddingHorizontal: 20,
@@ -232,7 +216,7 @@ const styles = StyleSheet.create({
     titleRow: {
         flexDirection: 'row',
         justifyContent: 'space-between',
-        alignItems: 'baseline',
+        alignItems: 'center',
         gap: 12,
         marginTop: 8,
     },


### PR DESCRIPTION
## Ticket

[APP-81](http://192.168.2.100:7123/home/browse/APP-81/) — Fix the "Mark all read" button on the Alerts screen

## Summary

There were **two** independent bugs behind "Mark all read does nothing on a real device":

### 1. Dead tap target (client)
The control was a hand-rolled `Pressable` wrapping a bare `<Text>` with no `pointerEvents='none'`. On a real device the `Text` swallowed the touch, so `onPress` never fired. Jest's `fireEvent.press` calls `onPress` directly, which masked it in tests.
- **Fix:** replaced it with the existing `Button` primitive (built under APP-70 for exactly this — its label declares `pointerEvents='none'`), which also satisfies the ticket's "make it an actual button" ask. Center-aligned the heading row; dropped the unused text styles.

### 2. Ack POST rejected with HTTP 415 (server)
With the tap fixed, each `POST /alerts/:id/ack` was rejected by the API with `415 Unsupported Media Type: undefined`. React Native's Android networking attaches an **empty `Content-Type`** to a bodyless POST, which bare `Fastify()` treats as an unparseable body. This was a latent bug for *every* bodyless RPC route (zone open/close, system enable/disable, schedule toggles, replan, ack) and was invisible because the API tests use `app.inject(...)` with no headers.
- **Fix:** registered a catch-all content-type parser in `buildApp` that tolerates an absent/empty body. JSON-body routes (e.g. `/push/register`) are unaffected — the built-in `application/json` parser still wins for JSON requests.

## Tests
- `alerts-view`: regression test for the pointer-transparent label + end-to-end test that the list clears to the empty state after Mark all read.
- `api`: regression test that a bodyless POST with an empty `Content-Type` returns 200 instead of 415.
- Full suites green: app 674/674, api 971/971.