### PR TITLE
[APP-101] No-op the alert bell tap when already on /alerts

### DIFF
--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -5,6 +5,7 @@ const mockHideAsync = jest.fn(() => Promise.resolve());
 const mockStatusBar = jest.fn();
 const mockStackScreen = jest.fn();
 const mockRouterPush = jest.fn();
+const mockRouterNavigate = jest.fn();
 const mockUsePathname = jest.fn(() => '/');
 const mockHeaderProps = jest.fn();
 const mockDrawerProps = jest.fn();
@@ -36,7 +37,7 @@ jest.mock('expo-router', () => {
     };
     return {
         Stack,
-        useRouter: () => ({ push: mockRouterPush }),
+        useRouter: () => ({ push: mockRouterPush, navigate: mockRouterNavigate }),
         usePathname: () => mockUsePathname(),
         DarkTheme: {
             dark: true,
@@ -165,6 +166,7 @@ describe('RootLayout', () => {
         mockHideAsync.mockClear();
         mockStackScreen.mockClear();
         mockRouterPush.mockReset();
+        mockRouterNavigate.mockReset();
         mockUsePathname.mockReset();
         mockUsePathname.mockReturnValue('/');
         mockHeaderProps.mockClear();
@@ -261,7 +263,20 @@ describe('RootLayout', () => {
 
         fireEvent.press(screen.getByLabelText('Alerts'));
 
-        expect(mockRouterPush).toHaveBeenCalledWith('/alerts');
+        expect(mockRouterNavigate).toHaveBeenCalledWith('/alerts');
+    });
+
+    it('uses the deduping navigate() API (not push) for the bell so re-tapping on /alerts does not stack a duplicate (APP-101).', () => {
+        render(<RootLayout />);
+
+        fireEvent.press(screen.getByLabelText('Alerts'));
+
+        // `navigate` is a no-op on the focused route, where `push` would stack
+        // a duplicate /alerts the user has to unwind on back-press. The dedup
+        // itself lives in React Navigation; the layout's contract is choosing
+        // navigate over push.
+        expect(mockRouterNavigate).toHaveBeenCalledWith('/alerts');
+        expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
     it('routes via expo-router when the drawer selects a destination (APP-58).', () => {

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -87,7 +87,11 @@ function AppShell() {
             <View style={{ paddingTop: insets.top, backgroundColor: '#000000' }}>
                 <Header
                     onMenuPress={() => setDrawerOpen(true)}
-                    onAlertsPress={() => router.push('/alerts' as never)}
+                    // `navigate` (not `push`) so re-tapping the bell while
+                    // already on /alerts is a no-op instead of stacking a
+                    // duplicate screen the user has to unwind on back-press
+                    // (APP-101). NAVIGATE dedupes on the focused route.
+                    onAlertsPress={() => router.navigate('/alerts' as never)}
                 />
             </View>
             <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: '#000000' } }}>


### PR DESCRIPTION
## Ticket

[APP-101](http://192.168.2.100:7123/home/browse/APP-101/) — Alerts: tapping the bell while already on /alerts stacks a duplicate screen — no-op instead

## Summary

- The header bell wired `onAlertsPress` to `router.push('/alerts')`, which always stacks a new `/alerts` screen — tapping the bell while already on Alerts piled up duplicates that back-press had to unwind one at a time.
- Switched the bell to `router.navigate('/alerts')`. `navigate` emits React Navigation's `NAVIGATE` action, which dedupes at the router level: no-op on the focused route, pops back to an existing `/alerts` if one is already in the stack, and otherwise pushes as before. This is the router-level fix rather than a per-call `pathname` guard.
- Tests: the bell test now asserts it uses the deduping `navigate()` (not `push()`); the existing drawer/navigation tests are unchanged.

## Out of scope (flagged)

The drawer's `onSelect` (`_layout.tsx`) still uses `router.push(ROUTE_FOR_NAV_ID[id])` and would stack a duplicate when the already-active row is selected. The ticket explicitly leaves this to a follow-up. The same `navigate`-over-`push` swap would fix it (it already has `activeId` in scope) — worth a follow-up ticket if confirmed on-device.