### PR TITLE
[APP-93] Backfill Maintenance endBySunrise

### DIFF
--- a/api/db/backfill-end-by-sunrise.test.ts
+++ b/api/db/backfill-end-by-sunrise.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, it, expect } from 'bun:test';
+import { readJournalFile } from './verify-migrations';
+
+const DRIZZLE_DIR = path.resolve(import.meta.dir, '..', 'drizzle');
+const MIGRATION_TAG = '0018_backfill_maintenance_end_by_sunrise';
+
+/**
+ * APP-93: the Maintenance schedule's `end_by_sunrise` shipped as `null` in
+ * existing databases because the seed's ON CONFLICT set never refreshes it
+ * (preserving operator edits). Migration 0018 is a one-shot, idempotent
+ * backfill that converges those rows on `true`. There is no live-DB harness
+ * in this suite, so these guard the migration artifact itself: the SQL is
+ * correct and the journal links it as the newest on-disk migration.
+ */
+describe('0018 backfill maintenance end_by_sunrise', () => {
+    it('ships an idempotent UPDATE scoped to the maintenance slug', async () => {
+        const raw = await readFile(path.join(DRIZZLE_DIR, `${MIGRATION_TAG}.sql`), 'utf8');
+        const sql = raw.replace(/\s+/g, ' ').trim().toLowerCase();
+
+        expect(sql).toContain('update "schedules"');
+        expect(sql).toContain('set "end_by_sunrise" = true');
+        expect(sql).toContain(`where "slug" = 'maintenance'`);
+        // IS NULL guard keeps the backfill idempotent and avoids clobbering a
+        // deliberate operator `false`.
+        expect(sql).toContain('"end_by_sunrise" is null');
+    });
+
+    it('is registered in the journal as the newest migration', async () => {
+        const journal = await readJournalFile(DRIZZLE_DIR);
+
+        const entry = journal.entries.find(e => e.tag === MIGRATION_TAG);
+        expect(entry).toBeDefined();
+
+        const newestWhen = journal.entries.reduce((max, e) => (e.when > max ? e.when : max), 0);
+        expect(entry!.when).toBe(newestWhen);
+    });
+});

--- a/api/drizzle/0018_backfill_maintenance_end_by_sunrise.sql
+++ b/api/drizzle/0018_backfill_maintenance_end_by_sunrise.sql
@@ -1,0 +1,1 @@
+UPDATE "schedules" SET "end_by_sunrise" = TRUE WHERE "slug" = 'maintenance' AND "end_by_sunrise" IS NULL;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1780259459819,
       "tag": "0017_thick_romulus",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1780333663387,
+      "tag": "0018_backfill_maintenance_end_by_sunrise",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Ticket

[APP-93](http://192.168.2.100:7123/home/browse/APP-93/) Schedules: "End by sunrise" reads "Off" for Maintenance even though seed says true

## Summary

- The Maintenance hero card rendered **End by sunrise: Off** because the `schedules.end_by_sunrise` column held `null` — the row was inserted before `endBySunrise: true` was added to the seed JSON, and `upsertSchedules`' `ON CONFLICT` set deliberately refreshes only `name` (preserving operator edits), so re-seeding never backfills it.
- Adds a hand-authored, idempotent Drizzle migration `0018_backfill_maintenance_end_by_sunrise.sql` — `UPDATE schedules SET end_by_sunrise = TRUE WHERE slug = 'maintenance' AND end_by_sunrise IS NULL` — plus its `_journal.json` entry. Existing DBs converge on `db:migrate`; fresh DBs get the value via the normal seed insert. Follows the `0014_drop_sunset_at` custom-migration precedent (no snapshot file).
- No `app/` or `seed.ts` change: the UI's strict `=== true` reduction is correct, and the "don't clobber operator edits" seed policy is intentionally left intact.
- Adds `api/db/backfill-end-by-sunrise.test.ts` guarding the migration SQL clauses and its journal linkage (no live-DB harness exists in the suite, so coverage is at the artifact level).