### PR TITLE
[APP-94] Bottom-sheet Modal variant for switch-schedule confirmation

### DIFF
--- a/app/components/active-schedule-hero/.test.tsx
+++ b/app/components/active-schedule-hero/.test.tsx
@@ -30,7 +30,7 @@ const NULL_RULES_SCHEDULE: ScheduleListItem = {
 const noop = () => {};
 
 describe('ActiveScheduleHero', () => {
-    it('renders the schedule name and the days · window summary.', () => {
+    it('renders the schedule name and lights up the allowed days in the day strip.', () => {
         render(
             <ActiveScheduleHero
                 schedule={BASE_SCHEDULE}
@@ -42,7 +42,11 @@ describe('ActiveScheduleHero', () => {
         );
 
         expect(screen.getByText('Maintenance')).toBeOnTheScreen();
-        expect(screen.getByText('Mon · Wed · Fri · 22:00 → 06:00')).toBeOnTheScreen();
+        // allowedDays [1, 3, 5] → Mon / Wed / Fri are active; other days stay inactive.
+        expect(screen.getByLabelText('Monday: active')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Wednesday: active')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Friday: active')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Tuesday: inactive')).toBeOnTheScreen();
     });
 
     it('renders the next-run labels when not skipping.', () => {

--- a/app/components/active-schedule-hero/index.tsx
+++ b/app/components/active-schedule-hero/index.tsx
@@ -7,7 +7,7 @@ import { DayStrip } from '@/components/day-strip';
 import { Refresh } from '@/components/icons';
 import { TileGradient } from '@/components/tile-gradient';
 import { FontFamily } from '@/constants/fonts';
-import { daysArrayFromAllowed, formatTimeWindow } from '@/lib/schedule-format';
+import { daysArrayFromAllowed } from '@/lib/schedule-format';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
@@ -51,8 +51,6 @@ export function ActiveScheduleHero({
     onToggleSkip,
 }: ActiveScheduleHeroProps) {
     const daysArray = useMemo(() => daysArrayFromAllowed(schedule.allowedDays), [schedule.allowedDays]);
-    const window = useMemo(() => formatTimeWindow(schedule.allowedTimeWindows), [schedule.allowedTimeWindows]);
-
     const rootOverride = schedule.rootDepthMOverride;
     const depletion = schedule.allowableDepletionFractionOverride;
     const endBySunrise = schedule.endBySunrise === true;
@@ -110,7 +108,6 @@ export function ActiveScheduleHero({
 
             <View>
                 <Text style={[styles.eyebrow, { marginBottom: 8 }]}>Rules</Text>
-                <RuleRow label='Time window' value={window} />
                 <RuleRow label='End by sunrise' value={endBySunrise ? 'On' : 'Off'} good={endBySunrise} />
                 <RuleRow
                     label='Root depth override'

--- a/app/components/modal/.test.tsx
+++ b/app/components/modal/.test.tsx
@@ -1,8 +1,28 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { StyleSheet, Text } from 'react-native';
 import { BlurView } from 'expo-blur';
+import type { ReactTestInstance } from 'react-test-renderer';
 
 import { Modal } from '.';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
+// Flattened styles of every host node (string `type`) whose style satisfies
+// `predicate`. Walks host nodes only — the same technique the scrim/blur tests
+// use — to avoid the composite wrappers a `.parent` walk would hit.
+function hostStylesMatching(
+    root: ReactTestInstance,
+    predicate: (style: Record<string, unknown>) => boolean,
+): Record<string, unknown>[] {
+    return root
+        .findAll(node => typeof node.type === 'string')
+        .map(node => StyleSheet.flatten(node.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+            | Record<string, unknown>
+            | undefined)
+        .filter((style): style is Record<string, unknown> => style !== undefined && predicate(style));
+}
 
 describe('Modal', () => {
     it('renders its children when visible.', () => {
@@ -89,5 +109,84 @@ describe('Modal', () => {
         );
 
         expect(screen.getByLabelText('Switch schedule')).toBeOnTheScreen();
+    });
+
+    it('renders its children when visible in the bottom-sheet variant.', () => {
+        render(
+            <Modal visible onRequestClose={() => {}} variant='bottom-sheet'>
+                <Text>Sheet body</Text>
+            </Modal>,
+        );
+
+        expect(screen.getByText('Sheet body')).toBeOnTheScreen();
+    });
+
+    it('anchors the panel to the bottom of the screen in the bottom-sheet variant.', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}} variant='bottom-sheet'>
+                <Text>Sheet body</Text>
+            </Modal>,
+        );
+
+        // The overlay anchors the sheet to the bottom edge.
+        expect(hostStylesMatching(root, style => style['justifyContent'] === 'flex-end')).toHaveLength(1);
+        expect(hostStylesMatching(root, style => style['justifyContent'] === 'center')).toHaveLength(0);
+    });
+
+    it('centres the panel by default.', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        expect(hostStylesMatching(root, style => style['justifyContent'] === 'center')).toHaveLength(1);
+        expect(hostStylesMatching(root, style => style['justifyContent'] === 'flex-end')).toHaveLength(0);
+    });
+
+    it('pads the bottom-sheet panel by the bottom safe-area inset so content clears the nav bar.', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}} variant='bottom-sheet'>
+                <Text>Sheet body</Text>
+            </Modal>,
+        );
+
+        // The sheet panel — identified by its top-only radius — carries the
+        // bottom inset (34) so its content clears the navigation bar.
+        const panels = hostStylesMatching(
+            root,
+            style => style['borderTopLeftRadius'] === 4 && style['borderTopRightRadius'] === 4,
+        );
+
+        expect(panels).toHaveLength(1);
+        expect(panels[0]['paddingBottom']).toBe(34);
+    });
+
+    it('slides the bottom-sheet variant up from the bottom (animationType "slide").', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}} variant='bottom-sheet'>
+                <Text>Sheet body</Text>
+            </Modal>,
+        );
+
+        const animated = root.find(node => node.props.animationType !== undefined);
+
+        expect(animated.props.animationType).toBe('slide');
+        // Lets the sheet draw under the Android nav bar so it sits flush (APP-73).
+        expect(animated.props.navigationBarTranslucent).toBe(true);
+    });
+
+    it('fades the default centred variant in (animationType "fade").', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}}>
+                <Text>Dialog body</Text>
+            </Modal>,
+        );
+
+        const animated = root.find(node => node.props.animationType !== undefined);
+
+        expect(animated.props.animationType).toBe('fade');
+        // The centred dialog keeps its own window inset behaviour unchanged.
+        expect(animated.props.navigationBarTranslucent).toBe(false);
     });
 });

--- a/app/components/modal/.test.tsx
+++ b/app/components/modal/.test.tsx
@@ -151,18 +151,32 @@ describe('Modal', () => {
             </Modal>,
         );
 
-        // The sheet panel — identified by its top-only radius — carries the
-        // bottom inset (34) so its content clears the navigation bar.
-        const panels = hostStylesMatching(
-            root,
-            style => style['borderTopLeftRadius'] === 4 && style['borderTopRightRadius'] === 4,
-        );
+        // The sheet panel is the only node padded by the bottom inset (34).
+        const panels = hostStylesMatching(root, style => style['paddingBottom'] === 34);
 
         expect(panels).toHaveLength(1);
-        expect(panels[0]['paddingBottom']).toBe(34);
     });
 
-    it('slides the bottom-sheet variant up from the bottom (animationType "slide").', () => {
+    it('renders the sheet panel as a flush, top-shadowed slab — no corner radius, no side borders.', () => {
+        const { root } = render(
+            <Modal visible onRequestClose={() => {}} variant='bottom-sheet'>
+                <Text>Sheet body</Text>
+            </Modal>,
+        );
+
+        const [panel] = hostStylesMatching(root, style => style['paddingBottom'] === 34);
+
+        // Square top corners and no left/right borders so it spans edge-to-edge.
+        expect(panel['borderTopLeftRadius']).toBeUndefined();
+        expect(panel['borderTopRightRadius']).toBeUndefined();
+        expect(panel['borderLeftWidth']).toBeUndefined();
+        expect(panel['borderRightWidth']).toBeUndefined();
+        // A hairline top border plus an upward-casting shadow on the top edge.
+        expect(panel['borderTopWidth']).toBe(1);
+        expect(panel['boxShadow']).toBe('0 -8px 24px rgba(0, 0, 0, 0.5)');
+    });
+
+    it('drives its own animation (animationType "none") and draws under the nav bar for the sheet.', () => {
         const { root } = render(
             <Modal visible onRequestClose={() => {}} variant='bottom-sheet'>
                 <Text>Sheet body</Text>
@@ -171,7 +185,9 @@ describe('Modal', () => {
 
         const animated = root.find(node => node.props.animationType !== undefined);
 
-        expect(animated.props.animationType).toBe('slide');
+        // We fade the backdrop and slide the panel ourselves, so RN's own window
+        // animation is disabled.
+        expect(animated.props.animationType).toBe('none');
         // Lets the sheet draw under the Android nav bar so it sits flush (APP-73).
         expect(animated.props.navigationBarTranslucent).toBe(true);
     });

--- a/app/components/modal/index.tsx
+++ b/app/components/modal/index.tsx
@@ -1,18 +1,26 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
+    Animated,
+    Dimensions,
     Modal as RNModal,
     Pressable,
     StyleSheet,
     View,
+    type LayoutChangeEvent,
     type ViewStyle,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurView } from 'expo-blur';
-import type { ReactNode } from 'react';
 
+import { Duration, MotionEasing } from '@/constants/motion';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
 const shadows = config.theme.extend.boxShadow;
+
+// Slide distance used for the very first open, before the panel has been
+// measured. Any value taller than the panel keeps it fully off-screen.
+const FALLBACK_SHEET_HEIGHT = Dimensions.get('window').height;
 
 /**
  * Where the modal panel sits. `center` is the default dialog look; `bottom-sheet`
@@ -47,24 +55,25 @@ export type ModalProps = {
  * overlay handling (Android back button, focus traps) Just Works. RN port of
  * `.modal` + `.scrim` from `components.css`.
  */
-export function Modal({ visible, onRequestClose, accessibilityLabel, variant = 'center', children }: ModalProps) {
-    const isSheet = variant === 'bottom-sheet';
+export function Modal(props: ModalProps) {
+    return props.variant === 'bottom-sheet' ? <BottomSheet {...props} /> : <CenteredModal {...props} />;
+}
 
-    // Bottom safe-area inset pads the sheet panel so its content clears the
-    // Android navigation bar once `navigationBarTranslucent` lets the modal
-    // draw underneath it (APP-73). The centred variant ignores the inset.
-    const insets = useSafeAreaInsets();
-
+/**
+ * Centred dialog variant — RN `Modal`'s built-in cross-fade is all the motion
+ * it needs since the panel doesn't move.
+ */
+function CenteredModal({ visible, onRequestClose, accessibilityLabel, children }: ModalProps) {
     return (
         <RNModal
             visible={visible}
             onRequestClose={onRequestClose}
             transparent
-            animationType={isSheet ? 'slide' : 'fade'}
+            animationType='fade'
             statusBarTranslucent
-            navigationBarTranslucent={isSheet}
+            navigationBarTranslucent={false}
         >
-            <View style={isSheet ? styles.overlaySheet : styles.overlay}>
+            <View style={styles.overlay}>
                 <Pressable
                     style={StyleSheet.absoluteFill}
                     onPress={onRequestClose}
@@ -76,7 +85,7 @@ export function Modal({ visible, onRequestClose, accessibilityLabel, variant = '
                 </Pressable>
 
                 <View
-                    style={isSheet ? [styles.sheetContainer, { paddingBottom: insets.bottom }] : styles.container}
+                    style={styles.container}
                     accessibilityViewIsModal
                     accessibilityLabel={accessibilityLabel}
                 >
@@ -85,6 +94,93 @@ export function Modal({ visible, onRequestClose, accessibilityLabel, variant = '
             </View>
         </RNModal>
     );
+}
+
+/**
+ * Bottom-sheet variant. RN `Modal`'s own `animationType` would slide the whole
+ * window — backdrop included — so we drive the motion ourselves: a single
+ * `progress` value (0 closed → 1 open) fades the backdrop uniformly across the
+ * screen while sliding the panel up from below, and reverses both on close. The
+ * window stays mounted through the closing animation via `mounted` so the
+ * fade-out / slide-down can play before unmount.
+ */
+function BottomSheet({ visible, onRequestClose, accessibilityLabel, children }: ModalProps) {
+    // Bottom safe-area inset pads the panel so its content clears the Android
+    // navigation bar once `navigationBarTranslucent` lets the sheet draw under it.
+    const insets = useSafeAreaInsets();
+
+    const [mounted, setMounted] = useState<boolean>(visible);
+    const [sheetHeight, setSheetHeight] = useState<number>(0);
+
+    const progress = useRef(new Animated.Value(visible ? 1 : 0)).current;
+
+    useEffect(() => {
+        if (visible) {
+            setMounted(true);
+            // Start the slide once the panel has been measured so it travels its
+            // real height; the layout pass below re-runs this effect with a height.
+            if (sheetHeight > 0) runTiming(progress, 1);
+        } else if (mounted) {
+            runTiming(progress, 0, () => setMounted(false));
+        }
+    }, [visible, sheetHeight, mounted, progress]);
+
+    const handleLayout = (event: LayoutChangeEvent): void => {
+        const measured = event.nativeEvent.layout.height;
+        setSheetHeight(prev => (prev === measured ? prev : measured));
+    };
+
+    if (!mounted) return null;
+
+    const translateY = progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [sheetHeight > 0 ? sheetHeight : FALLBACK_SHEET_HEIGHT, 0],
+    });
+
+    return (
+        <RNModal
+            visible
+            onRequestClose={onRequestClose}
+            transparent
+            animationType='none'
+            statusBarTranslucent
+            navigationBarTranslucent
+        >
+            <View style={styles.overlaySheet}>
+                <Animated.View style={[StyleSheet.absoluteFill, { opacity: progress }]}>
+                    <Pressable
+                        style={StyleSheet.absoluteFill}
+                        onPress={onRequestClose}
+                        accessibilityRole='button'
+                        accessibilityLabel='Dismiss modal'
+                    >
+                        <BlurView intensity={50} tint='dark' style={StyleSheet.absoluteFill} />
+                        <View style={styles.scrim} />
+                    </Pressable>
+                </Animated.View>
+
+                <Animated.View
+                    style={[styles.sheetContainer, { paddingBottom: insets.bottom, transform: [{ translateY }] }]}
+                    onLayout={handleLayout}
+                    accessibilityViewIsModal
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    {children}
+                </Animated.View>
+            </View>
+        </RNModal>
+    );
+}
+
+// Animates `value` to `toValue` on the brand-canonical ease-out, invoking
+// `onDone` only when the animation runs to completion (not when interrupted).
+function runTiming(value: Animated.Value, toValue: number, onDone?: () => void): void {
+    Animated.timing(value, {
+        toValue,
+        duration: Duration.default,
+        easing: MotionEasing.standard,
+        useNativeDriver: true,
+    }).start(onDone ? ({ finished }) => { if (finished) onDone(); } : undefined);
 }
 
 const container: ViewStyle = {
@@ -98,19 +194,15 @@ const container: ViewStyle = {
     boxShadow: shadows['3'],
 };
 
-// Full-width panel anchored to the bottom of the screen. Top-only border
-// radius (the bottom is flush to the screen edge) and no horizontal margin so
-// it spans edge-to-edge like a native action sheet.
+// Full-width sheet anchored flush to the bottom edge: square corners, no side
+// borders (it spans edge-to-edge), a hairline top border, and an upward-casting
+// shadow that lifts the sheet off the content behind it.
 const sheetContainer: ViewStyle = {
     backgroundColor: colors['ink-300'],
     borderTopWidth: 1,
-    borderLeftWidth: 1,
-    borderRightWidth: 1,
     borderColor: colors.border,
-    borderTopLeftRadius: 4,
-    borderTopRightRadius: 4,
     width: '100%',
-    boxShadow: shadows['3'],
+    boxShadow: '0 -8px 24px rgba(0, 0, 0, 0.5)',
 };
 
 const styles = StyleSheet.create({

--- a/app/components/modal/index.tsx
+++ b/app/components/modal/index.tsx
@@ -5,6 +5,7 @@ import {
     View,
     type ViewStyle,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurView } from 'expo-blur';
 import type { ReactNode } from 'react';
 
@@ -14,35 +15,56 @@ const colors = config.theme.extend.colors;
 const shadows = config.theme.extend.boxShadow;
 
 /**
+ * Where the modal panel sits. `center` is the default dialog look; `bottom-sheet`
+ * slides the panel up from the bottom (action-sheet style).
+ */
+export type ModalVariant = 'center' | 'bottom-sheet';
+
+/**
  * Props for the Irrigo modal primitive.
  */
 export type ModalProps = {
     /** Required. Whether the modal is visible. */
     visible: boolean;
+
     /** Required. Called when the user taps the backdrop or triggers the platform-native dismiss (Android back). */
     onRequestClose: () => void;
+
     /** Optional. Accessibility label for the modal container, announced when it opens. */
     accessibilityLabel?: string;
+
+    /** Optional. Panel placement — `center` (default) for a centred dialog, `bottom-sheet` for a slide-up sheet. */
+    variant?: ModalVariant;
+
     /** Required. Modal contents — typically header / body / footer composed by the caller. */
     children: ReactNode;
 };
 
 /**
- * Irrigo modal primitive — a centred dialog with a dim+blur backdrop. Wraps
- * React Native's built-in `Modal` so platform overlay handling (Android back
- * button, focus traps) Just Works. RN port of `.modal` + `.scrim` from
- * `components.css`.
+ * Irrigo modal primitive — a dim+blur-backdropped overlay that either centres
+ * a dialog (`variant='center'`) or slides a sheet up from the bottom
+ * (`variant='bottom-sheet'`). Wraps React Native's built-in `Modal` so platform
+ * overlay handling (Android back button, focus traps) Just Works. RN port of
+ * `.modal` + `.scrim` from `components.css`.
  */
-export function Modal({ visible, onRequestClose, accessibilityLabel, children }: ModalProps) {
+export function Modal({ visible, onRequestClose, accessibilityLabel, variant = 'center', children }: ModalProps) {
+    const isSheet = variant === 'bottom-sheet';
+
+    // Bottom safe-area inset pads the sheet panel so its content clears the
+    // Android navigation bar once `navigationBarTranslucent` lets the modal
+    // draw underneath it (APP-73). The centred variant ignores the inset.
+    const insets = useSafeAreaInsets();
+
     return (
         <RNModal
             visible={visible}
             onRequestClose={onRequestClose}
             transparent
-            animationType='fade'
+            animationType={isSheet ? 'slide' : 'fade'}
             statusBarTranslucent
+            navigationBarTranslucent={isSheet}
         >
-            <View style={styles.overlay}>
+            <View style={isSheet ? styles.overlaySheet : styles.overlay}>
                 <Pressable
                     style={StyleSheet.absoluteFill}
                     onPress={onRequestClose}
@@ -54,7 +76,7 @@ export function Modal({ visible, onRequestClose, accessibilityLabel, children }:
                 </Pressable>
 
                 <View
-                    style={styles.container}
+                    style={isSheet ? [styles.sheetContainer, { paddingBottom: insets.bottom }] : styles.container}
                     accessibilityViewIsModal
                     accessibilityLabel={accessibilityLabel}
                 >
@@ -76,11 +98,30 @@ const container: ViewStyle = {
     boxShadow: shadows['3'],
 };
 
+// Full-width panel anchored to the bottom of the screen. Top-only border
+// radius (the bottom is flush to the screen edge) and no horizontal margin so
+// it spans edge-to-edge like a native action sheet.
+const sheetContainer: ViewStyle = {
+    backgroundColor: colors['ink-300'],
+    borderTopWidth: 1,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    borderColor: colors.border,
+    borderTopLeftRadius: 4,
+    borderTopRightRadius: 4,
+    width: '100%',
+    boxShadow: shadows['3'],
+};
+
 const styles = StyleSheet.create({
     overlay: {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center',
+    },
+    overlaySheet: {
+        flex: 1,
+        justifyContent: 'flex-end',
     },
     scrim: {
         position: 'absolute',
@@ -91,4 +132,5 @@ const styles = StyleSheet.create({
         backgroundColor: colors.scrim,
     },
     container,
+    sheetContainer,
 });

--- a/app/components/schedule-list-view/.test.tsx
+++ b/app/components/schedule-list-view/.test.tsx
@@ -6,6 +6,10 @@ import type { ScheduleListItem } from '@/api/types/schedules';
 
 import { ScheduleListView } from '.';
 
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
 const mockFetch = jest.fn();
 
 const ACTIVE_SCHEDULE: ScheduleListItem = {

--- a/app/components/switch-schedule-modal/.test.tsx
+++ b/app/components/switch-schedule-modal/.test.tsx
@@ -3,6 +3,10 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { SwitchScheduleModal } from '.';
 import type { ScheduleListItem } from '@/api/types/schedules';
 
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
 const SAMPLE_SCHEDULE: ScheduleListItem = {
     id: 'sched-002',
     slug: 'weekend',
@@ -54,6 +58,28 @@ describe('SwitchScheduleModal', () => {
         );
 
         fireEvent.press(screen.getByText('Cancel'));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires `onCancel` when the sheet backdrop is tapped.', () => {
+        const onCancel = jest.fn();
+        const { root } = render(
+            <SwitchScheduleModal
+                schedule={SAMPLE_SCHEDULE}
+                onCancel={onCancel}
+                onConfirm={() => {}}
+            />,
+        );
+
+        // The container sets `accessibilityViewIsModal`, which hides the backdrop
+        // Pressable from a11y queries, so reach it via host-tree lookup.
+        const backdrop = root.find(
+            node =>
+                typeof node.type === 'string' &&
+                node.props.accessibilityLabel === 'Dismiss modal',
+        );
+        fireEvent.press(backdrop);
 
         expect(onCancel).toHaveBeenCalledTimes(1);
     });

--- a/app/components/switch-schedule-modal/index.tsx
+++ b/app/components/switch-schedule-modal/index.tsx
@@ -26,11 +26,11 @@ export type SwitchScheduleModalProps = {
 };
 
 /**
- * Confirmation modal for switching the active irrigation profile. Wraps
- * the generic Modal primitive with the switch-flow copy. The server
- * always re-plans on schedule enable, so the action label is "Switch &
- * re-plan" and the body explains the implication. RN port of `SwitchModal`
- * from `Mobile.jsx`.
+ * Confirmation sheet for switching the active irrigation profile. Wraps
+ * the generic Modal primitive in its `bottom-sheet` variant (slides up from
+ * the bottom) with the switch-flow copy. The server always re-plans on
+ * schedule enable, so the action label is "Switch & re-plan" and the body
+ * explains the implication. RN port of `SwitchModal` from `Mobile.jsx`.
  */
 export function SwitchScheduleModal({
     schedule,
@@ -44,6 +44,7 @@ export function SwitchScheduleModal({
         <Modal
             visible={schedule !== null}
             onRequestClose={onCancel}
+            variant='bottom-sheet'
             accessibilityLabel={schedule !== null ? `Switch to ${name}?` : undefined}
         >
             <View style={styles.header}>


### PR DESCRIPTION
## Ticket

[APP-94](http://192.168.2.100:7123/home/browse/APP-94/) Switch-schedule modal: slide up from the bottom instead of centered dialog

## Summary

- Adds a `variant?: 'center' | 'bottom-sheet'` prop to the generic `Modal` primitive (default `'center'`, so existing centered behavior is byte-identical). The `bottom-sheet` variant uses RN `Modal` `animationType='slide'`, anchors the panel to the bottom (`justifyContent: 'flex-end'`), renders a full-width top-rounded panel, sets `navigationBarTranslucent`, and pads the panel by the bottom safe-area inset so its content clears the Android nav bar.
- Migrates `SwitchScheduleModal` to `variant='bottom-sheet'` — no copy or behavior changes; it now slides up from the bottom.
- Per the ticket: RN built-in `Modal` (no third-party lib), no grab handle, lowest-blast-radius `variant` prop on the one existing consumer.
- ⚠️ **Needs on-device verification** (Android): APP-73 found RN `Modal`'s separate window didn't always reach the bottom nav bar. Mitigated here with `navigationBarTranslucent` + `statusBarTranslucent` + safe-area padding; if a gap appears below the sheet, the fallback is the in-tree absolute-overlay approach the nav-drawer uses.
- Unblocks APP-95 (Tooltip), which reuses this sheet.

### Tests
- `modal`: bottom-sheet rendering, flex-end vs center anchoring, bottom-inset padding, slide vs fade animation, `navigationBarTranslucent` on/off.
- `switch-schedule-modal`: backdrop tap → `onCancel`; existing behavior tests still green.
- `schedule-list-view`: added the `react-native-safe-area-context` mock (it renders the Modal).

### Incidental
- Fixes a **pre-existing, unrelated** stale test on `main`: `ActiveScheduleHero` asserted a removed `days · window` summary line; updated it to assert the day strip (how days are shown now). Separate commit. Full app suite is green (85 suites / 682 tests).