### PR TITLE
[APP-95] Tooltip component + Help icon

### DIFF
--- a/app/components/active-schedule-hero/.test.tsx
+++ b/app/components/active-schedule-hero/.test.tsx
@@ -105,7 +105,7 @@ describe('ActiveScheduleHero', () => {
         expect(screen.getByLabelText('Tonight skipped')).toBeOnTheScreen();
     });
 
-    it('renders all four rule rows with the schedule values.', () => {
+    it('renders the three rule rows with the schedule values.', () => {
         render(
             <ActiveScheduleHero
                 schedule={BASE_SCHEDULE}
@@ -116,13 +116,12 @@ describe('ActiveScheduleHero', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Time window: 22:00 → 06:00')).toBeOnTheScreen();
         expect(screen.getByLabelText('End by sunrise: On')).toBeOnTheScreen();
         expect(screen.getByLabelText('Root depth override: 0.18 m')).toBeOnTheScreen();
         expect(screen.getByLabelText('Depletion fraction: 0.50')).toBeOnTheScreen();
     });
 
-    it('renders em-dashes and `Off`/`Any time` for the null-rule fallbacks.', () => {
+    it('renders em-dashes and `Off` for the null-rule fallbacks.', () => {
         render(
             <ActiveScheduleHero
                 schedule={NULL_RULES_SCHEDULE}
@@ -133,7 +132,6 @@ describe('ActiveScheduleHero', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Time window: Any time')).toBeOnTheScreen();
         expect(screen.getByLabelText('End by sunrise: Off')).toBeOnTheScreen();
         expect(screen.getByLabelText('Root depth override: —')).toBeOnTheScreen();
         expect(screen.getByLabelText('Depletion fraction: —')).toBeOnTheScreen();

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -146,3 +146,13 @@ export function Check({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth 
         </Svg>
     );
 }
+
+export function Help({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Circle cx='8' cy='8' r='6.5' />
+            <Path d='M6.06 6 a 2 2 0 0 1 3.89 0.67 c 0 1.33 -2 2 -2 2' />
+            <Path d='M8 11.3 h 0.01' />
+        </Svg>
+    );
+}

--- a/app/components/tooltip/.test.tsx
+++ b/app/components/tooltip/.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { Tooltip } from '.';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
+describe('Tooltip', () => {
+    it('renders the label beside an accessible help trigger, with the sheet closed.', () => {
+        render(
+            <Tooltip
+                label='Root depth override'
+                title='Root depth override'
+                body='The depth of the wetted root zone the planner refills.'
+            />,
+        );
+
+        expect(screen.getByText('Root depth override')).toBeOnTheScreen();
+        expect(screen.getByLabelText('What is Root depth override?')).toBeOnTheScreen();
+        // The sheet body is hidden until the trigger is tapped.
+        expect(screen.queryByText('The depth of the wetted root zone the planner refills.')).toBeNull();
+    });
+
+    it('opens the sheet with the title and body when the trigger is tapped.', () => {
+        render(
+            <Tooltip
+                label='Depletion fraction'
+                title='Allowable depletion'
+                body='How dry the soil is allowed to get before the next watering.'
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('What is Depletion fraction?'));
+
+        expect(screen.getByText('Allowable depletion')).toBeOnTheScreen();
+        expect(
+            screen.getByText('How dry the soil is allowed to get before the next watering.'),
+        ).toBeOnTheScreen();
+    });
+
+    it('renders each paragraph when the body is an array of strings.', () => {
+        render(
+            <Tooltip
+                label='Root depth override'
+                title='Root depth override'
+                body={['First paragraph about roots.', 'Second paragraph about depth.']}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('What is Root depth override?'));
+
+        expect(screen.getByText('First paragraph about roots.')).toBeOnTheScreen();
+        expect(screen.getByText('Second paragraph about depth.')).toBeOnTheScreen();
+    });
+
+    it('renders a custom node body as supplied.', () => {
+        render(
+            <Tooltip
+                label='Root depth override'
+                title='Root depth override'
+                body={<Text>Custom node body.</Text>}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('What is Root depth override?'));
+
+        expect(screen.getByText('Custom node body.')).toBeOnTheScreen();
+    });
+
+    it('closes the sheet when the backdrop is tapped.', async () => {
+        const { root } = render(
+            <Tooltip
+                label='Depletion fraction'
+                title='Allowable depletion'
+                body='How dry the soil is allowed to get.'
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('What is Depletion fraction?'));
+        expect(screen.getByText('Allowable depletion')).toBeOnTheScreen();
+
+        // The backdrop Pressable is hidden from a11y queries by the sheet's
+        // `accessibilityViewIsModal`, so reach it via host-tree lookup.
+        const backdrop = root.find(
+            node =>
+                typeof node.type === 'string' &&
+                node.props.accessibilityLabel === 'Dismiss modal',
+        );
+        fireEvent.press(backdrop);
+
+        // The sheet plays a slide-down + fade before it unmounts; allow ample
+        // time so the assertion isn't flaky when the suite runs under load.
+        await waitFor(() => expect(screen.queryByText('Allowable depletion')).toBeNull(), { timeout: 5000 });
+    });
+});

--- a/app/components/tooltip/index.tsx
+++ b/app/components/tooltip/index.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useState, type ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { Help } from '@/components/icons';
+import { Modal } from '@/components/modal';
+import { FontFamily } from '@/constants/fonts';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * Props for the Tooltip component.
+ */
+export type TooltipProps = {
+    /** Required. The visible label text the help trigger sits beside. */
+    label: string;
+
+    /** Required. Heading shown at the top of the slide-up sheet; also announced when the sheet opens. */
+    title: string;
+
+    /** Required. Sheet body. A single string renders one paragraph; an array renders one paragraph per entry; any other node renders as-is. */
+    body: string | string[] | ReactNode;
+};
+
+/**
+ * A label paired with a small `?` trigger. Tapping the trigger opens a
+ * slide-up bottom sheet (the APP-94 `Modal` `bottom-sheet` variant) explaining
+ * the topic with a `title` and `body`. Mobile-first, tap-to-open — not a hover
+ * popover. Dismisses via the backdrop or the Android back button.
+ */
+export function Tooltip({ label, title, body }: TooltipProps) {
+    const [isOpen, setOpen] = useState<boolean>(false);
+
+    const open = useCallback(() => setOpen(true), []);
+    const close = useCallback(() => setOpen(false), []);
+
+    return (
+        <View style={styles.row}>
+            <Text style={styles.label}>{label}</Text>
+
+            <Pressable
+                onPress={open}
+                accessibilityRole='button'
+                accessibilityLabel={`What is ${label}?`}
+                hitSlop={8}
+                style={styles.trigger}
+            >
+                <Help size={13} color={colors['fg-muted']} />
+            </Pressable>
+
+            <Modal visible={isOpen} onRequestClose={close} variant='bottom-sheet' accessibilityLabel={title}>
+                <View style={styles.sheet}>
+                    <Text style={styles.title}>{title}</Text>
+                    {renderBody(body)}
+                </View>
+            </Modal>
+        </View>
+    );
+}
+
+/**
+ * Renders the sheet body. Strings become a single paragraph, string arrays
+ * become one paragraph per entry, and any other node is rendered as supplied.
+ *
+ * @param body - The body content passed to the tooltip.
+ * @returns The body element(s) to render inside the sheet.
+ */
+function renderBody(body: string | string[] | ReactNode): ReactNode {
+    if (typeof body === 'string') {
+        return <Text style={styles.body}>{body}</Text>;
+    }
+
+    if (Array.isArray(body) && body.every(item => typeof item === 'string')) {
+        return (
+            <View style={styles.paragraphs}>
+                {(body as string[]).map((paragraph, index) => (
+                    <Text key={index} style={styles.body}>{paragraph}</Text>
+                ))}
+            </View>
+        );
+    }
+
+    return body;
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+    },
+    label: {
+        fontFamily: FontFamily.sans,
+        fontSize: 13,
+        lineHeight: 16,
+        color: colors['fg-soft'],
+    },
+    trigger: {
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    sheet: {
+        paddingHorizontal: 22,
+        paddingTop: 20,
+        paddingBottom: 8,
+        gap: 10,
+    },
+    title: {
+        fontFamily: FontFamily.displaySemibold,
+        fontSize: 20,
+        lineHeight: 24,
+        letterSpacing: -0.2,
+        color: colors.fg,
+    },
+    paragraphs: {
+        gap: 10,
+    },
+    body: {
+        fontFamily: FontFamily.sans,
+        fontSize: 14,
+        lineHeight: 21,
+        color: colors['fg-soft'],
+    },
+});


### PR DESCRIPTION
## Ticket

[APP-95](http://192.168.2.100:7123/home/browse/APP-95/) Tooltip component: tap-to-open slide-up sheet with detailed explanation

## Summary

- Adds a `Help` icon (`?`-in-circle) to `app/components/icons.tsx`, following the existing 16×16 stroke-based icon recipe.
- Adds `app/components/tooltip/` — a `Tooltip` (label-as-prop API): renders a label beside a small `?` trigger; tapping it opens a slide-up bottom sheet showing a `title` heading and `body`. Reuses the **APP-94** `Modal` `variant='bottom-sheet'` primitive (no second sheet implementation, per the ticket). Dismisses via backdrop tap / Android back.
  - `body` accepts `string` (one paragraph), `string[]` (one paragraph each), or any `ReactNode` (rendered as-is).
  - Trigger exposes `accessibilityLabel="What is <label>?"`; the sheet announces `title` on open (the primitive's container label).
- Mobile-first, tap-to-open — no hover/desktop popover, no inline-anchored speech bubble, no rich content beyond title + body (all explicitly out of scope).

### Tests
- `tooltip/.test.tsx` (behavior-driven, query by text/label, no testIDs): trigger renders label + accessible button with the sheet closed; tap opens title + body; multi-paragraph `string[]` body; custom `ReactNode` body; backdrop tap closes. Mocks only `react-native-safe-area-context` (external boundary); renders the real `Modal`.

### Incidental
- Fixes **2 pre-existing, unrelated stale tests** on `main`: commit `79ca748` removed the Time-window rule row from `ActiveScheduleHero` but left the test asserting `Time window: …`. Updated those assertions (separate commit). Full app suite is green (86 suites / 688 tests).

## Follow-ups
- Two separate tickets wire this `Tooltip` onto the Schedules Rules block (Root depth override, Depletion fraction) — not included here.