### PR TITLE
[APP-96/APP-97] Root-depth & Depletion-fraction rule-row tooltips

### DIFF
--- a/app/components/active-schedule-hero/.test.tsx
+++ b/app/components/active-schedule-hero/.test.tsx
@@ -1,7 +1,11 @@
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 import { ActiveScheduleHero } from '.';
 import type { ScheduleListItem } from '@/api/types/schedules';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
 
 const BASE_SCHEDULE: ScheduleListItem = {
     id: 'sched-001',
@@ -135,6 +139,69 @@ describe('ActiveScheduleHero', () => {
         expect(screen.getByLabelText('End by sunrise: Off')).toBeOnTheScreen();
         expect(screen.getByLabelText('Root depth override: —')).toBeOnTheScreen();
         expect(screen.getByLabelText('Depletion fraction: —')).toBeOnTheScreen();
+    });
+
+    it('exposes a help trigger on the Root depth and Depletion rows, closed by default.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        expect(screen.getByLabelText('What is Root depth override?')).toBeOnTheScreen();
+        expect(screen.getByLabelText('What is Depletion fraction?')).toBeOnTheScreen();
+        // Sheets stay closed until a trigger is tapped.
+        expect(screen.queryByText(/Management Allowable Depletion/)).toBeNull();
+    });
+
+    it('opens the Root depth help sheet with its title and body when the trigger is tapped.', () => {
+        render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('What is Root depth override?'));
+
+        // The sheet heading and the row label share the text; both instances render.
+        expect(screen.getAllByText('Root depth override').length).toBeGreaterThan(1);
+        expect(screen.getByText(/the planner aims to refill/)).toBeOnTheScreen();
+    });
+
+    it('opens the Depletion fraction help sheet, and the backdrop dismisses it.', async () => {
+        const { root } = render(
+            <ActiveScheduleHero
+                schedule={BASE_SCHEDULE}
+                skipping={false}
+                onReplan={noop}
+                onSwitchProfile={noop}
+                onToggleSkip={noop}
+            />,
+        );
+
+        fireEvent.press(screen.getByLabelText('What is Depletion fraction?'));
+        expect(screen.getByText(/Management Allowable Depletion/)).toBeOnTheScreen();
+
+        const backdrop = root.find(
+            node =>
+                typeof node.type === 'string' &&
+                node.props.accessibilityLabel === 'Dismiss modal',
+        );
+        fireEvent.press(backdrop);
+
+        // The sheet animates closed before unmounting.
+        await waitFor(
+            () => expect(screen.queryByText(/Management Allowable Depletion/)).toBeNull(),
+            { timeout: 5000 },
+        );
     });
 
     it('flips the footer button label between Skip tonight and Resume tonight.', () => {

--- a/app/components/active-schedule-hero/index.tsx
+++ b/app/components/active-schedule-hero/index.tsx
@@ -6,11 +6,30 @@ import { Button } from '@/components/button';
 import { DayStrip } from '@/components/day-strip';
 import { Refresh } from '@/components/icons';
 import { TileGradient } from '@/components/tile-gradient';
+import { Tooltip } from '@/components/tooltip';
 import { FontFamily } from '@/constants/fonts';
 import { daysArrayFromAllowed } from '@/lib/schedule-format';
 import config from '@/tailwind.config';
 
 const colors = config.theme.extend.colors;
+
+// Tooltip copy for the rule rows that carry a help trigger (APP-96 / APP-97).
+const ROOT_DEPTH_HELP = {
+    title: 'Root depth override',
+    body: [
+        `The depth of the wetted root zone the planner aims to refill, in meters. Each zone has a default root depth driven by its grass type. When this schedule sets an override, the planner uses the override instead — useful for short-rooted growth phases like overseeding (typically ~0.05 m).`,
+        `A dash (—) means no override is set and the zone's default applies.`,
+    ],
+};
+
+const DEPLETION_HELP = {
+    title: 'Depletion fraction',
+    body: [
+        `The fraction of plant-available soil water you're willing to let dry down before the next irrigation cycle (between 0 and 1). Combined with the zone's root depth and the soil's water-holding capacity, it sets the Management Allowable Depletion (MAD) — the trigger threshold for the next watering.`,
+        `Higher values = more drying allowed = less frequent watering. Lower values (e.g. 0.25 for overseeding) keep the soil consistently moist.`,
+        `A dash (—) means no override is set and the zone's default applies.`,
+    ],
+};
 
 /**
  * Props for the active schedule hero card.
@@ -113,11 +132,13 @@ export function ActiveScheduleHero({
                     label='Root depth override'
                     value={rootOverride !== null ? `${rootOverride.toFixed(2)} m` : '—'}
                     dim={rootOverride === null}
+                    help={ROOT_DEPTH_HELP}
                 />
                 <RuleRow
                     label='Depletion fraction'
                     value={depletion !== null ? depletion.toFixed(2) : '—'}
                     dim={depletion === null}
+                    help={DEPLETION_HELP}
                     last
                 />
             </View>
@@ -144,12 +165,14 @@ function RuleRow({
     good = false,
     dim = false,
     last = false,
+    help,
 }: {
     label: string;
     value: string;
     good?: boolean;
     dim?: boolean;
     last?: boolean;
+    help?: { title: string; body: string | string[] };
 }) {
     const valueColor =
         good ? colors.accent
@@ -157,7 +180,9 @@ function RuleRow({
         : colors.fg;
     return (
         <View style={[styles.ruleRow, last ? null : styles.ruleRowDivider]} accessibilityLabel={`${label}: ${value}`}>
-            <Text style={styles.ruleLabel}>{label}</Text>
+            {help ?
+                <Tooltip label={label} title={help.title} body={help.body} labelStyle={styles.ruleLabel} />
+            :   <Text style={styles.ruleLabel}>{label}</Text>}
             <Text style={[styles.ruleValue, { color: valueColor }]}>{value}</Text>
         </View>
     );

--- a/app/components/tooltip/.test.tsx
+++ b/app/components/tooltip/.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 
 import { Tooltip } from '.';
 
@@ -53,6 +53,24 @@ describe('Tooltip', () => {
 
         expect(screen.getByText('First paragraph about roots.')).toBeOnTheScreen();
         expect(screen.getByText('Second paragraph about depth.')).toBeOnTheScreen();
+    });
+
+    it('applies a caller-supplied labelStyle to the label.', () => {
+        render(
+            <Tooltip
+                label='Root depth override'
+                title='Root depth override'
+                body='Body text.'
+                labelStyle={{ color: 'rgb(1, 2, 3)' }}
+            />,
+        );
+
+        const label = screen.getByText('Root depth override');
+        const style = StyleSheet.flatten(label.props.style as Parameters<typeof StyleSheet.flatten>[0]) as
+            | { color?: string }
+            | undefined;
+
+        expect(style?.color).toBe('rgb(1, 2, 3)');
     });
 
     it('renders a custom node body as supplied.', () => {

--- a/app/components/tooltip/index.tsx
+++ b/app/components/tooltip/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, type ReactNode } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View, type StyleProp, type TextStyle } from 'react-native';
 
 import { Help } from '@/components/icons';
 import { Modal } from '@/components/modal';
@@ -20,6 +20,9 @@ export type TooltipProps = {
 
     /** Required. Sheet body. A single string renders one paragraph; an array renders one paragraph per entry; any other node renders as-is. */
     body: string | string[] | ReactNode;
+
+    /** Optional. Style override for the label text, so callers can match their surrounding typography. */
+    labelStyle?: StyleProp<TextStyle>;
 };
 
 /**
@@ -28,7 +31,7 @@ export type TooltipProps = {
  * the topic with a `title` and `body`. Mobile-first, tap-to-open — not a hover
  * popover. Dismisses via the backdrop or the Android back button.
  */
-export function Tooltip({ label, title, body }: TooltipProps) {
+export function Tooltip({ label, title, body, labelStyle }: TooltipProps) {
     const [isOpen, setOpen] = useState<boolean>(false);
 
     const open = useCallback(() => setOpen(true), []);
@@ -36,7 +39,7 @@ export function Tooltip({ label, title, body }: TooltipProps) {
 
     return (
         <View style={styles.row}>
-            <Text style={styles.label}>{label}</Text>
+            <Text style={[styles.label, labelStyle]}>{label}</Text>
 
             <Pressable
                 onPress={open}


### PR DESCRIPTION
## Tickets

- [APP-96](http://192.168.2.100:7123/home/browse/APP-96/) Schedules: add Root depth override tooltip with help-icon trigger
- [APP-97](http://192.168.2.100:7123/home/browse/APP-97/) Schedules: add Depletion fraction tooltip with help-icon trigger

Landed together (sibling tickets, identical shape) per both tickets' guidance.

## Summary

- Extends the active-schedule hero's local `RuleRow` with an optional `help` prop. When set, the label cell renders the merged APP-95 `Tooltip` (label + `?` trigger + slide-up sheet) instead of a plain label; otherwise it renders exactly as before. The row's value rendering and `accessibilityLabel` are unchanged.
- Gives `Tooltip` an optional `labelStyle` prop so the row can keep its sibling rows' exact label typography (12px / `fg-muted`) — the Rules block stays visually consistent.
- Wires the **Root depth override** and **Depletion fraction** rows with their tooltip copy (module-level `ROOT_DEPTH_HELP` / `DEPLETION_HELP` constants).
- Reuses the merged APP-95 `Tooltip` + `Modal` `variant='bottom-sheet'` — no second sheet.

### Tests
- `tooltip`: `labelStyle` override is applied to the label.
- `active-schedule-hero`: both rows expose a `What is <label>?` trigger (sheets closed by default); tapping each opens its sheet with the title + body; backdrop tap dismisses. Existing value/row assertions stay green. Added the `react-native-safe-area-context` mock (rows now render the sheet `Modal`).
- Full app suite green (86 suites / 692 tests), run twice — no animation-timing flakiness.

## Acceptance
Tapping the `?` next to either label opens the sheet with title + body; backdrop dismisses; the `0.18 m` / `0.50` / `—` value text is unchanged.