### PR TITLE
[APP-80] Migrate user-visible times to 24-hour clock

### DIFF
--- a/app/components/active-schedule-hero/.test.tsx
+++ b/app/components/active-schedule-hero/.test.tsx
@@ -204,34 +204,6 @@ describe('ActiveScheduleHero', () => {
         );
     });
 
-    it('flips the footer button label between Skip tonight and Resume tonight.', () => {
-        const { rerender } = render(
-            <ActiveScheduleHero
-                schedule={BASE_SCHEDULE}
-                skipping={false}
-                onReplan={noop}
-                onSwitchProfile={noop}
-                onToggleSkip={noop}
-            />,
-        );
-
-        expect(screen.getByText('Skip tonight')).toBeOnTheScreen();
-        expect(screen.queryByText('Resume tonight')).toBeNull();
-
-        rerender(
-            <ActiveScheduleHero
-                schedule={BASE_SCHEDULE}
-                skipping
-                onReplan={noop}
-                onSwitchProfile={noop}
-                onToggleSkip={noop}
-            />,
-        );
-
-        expect(screen.getByText('Resume tonight')).toBeOnTheScreen();
-        expect(screen.queryByText('Skip tonight')).toBeNull();
-    });
-
     it('fires `onReplan` when the re-plan icon button is pressed.', () => {
         const onReplan = jest.fn();
         render(
@@ -247,40 +219,6 @@ describe('ActiveScheduleHero', () => {
         fireEvent.press(screen.getByLabelText('Re-plan now'));
 
         expect(onReplan).toHaveBeenCalledTimes(1);
-    });
-
-    it('fires `onSwitchProfile` when the Switch profile button is pressed.', () => {
-        const onSwitchProfile = jest.fn();
-        render(
-            <ActiveScheduleHero
-                schedule={BASE_SCHEDULE}
-                skipping={false}
-                onReplan={noop}
-                onSwitchProfile={onSwitchProfile}
-                onToggleSkip={noop}
-            />,
-        );
-
-        fireEvent.press(screen.getByText('Switch profile'));
-
-        expect(onSwitchProfile).toHaveBeenCalledTimes(1);
-    });
-
-    it('fires `onToggleSkip` when the Skip tonight button is pressed.', () => {
-        const onToggleSkip = jest.fn();
-        render(
-            <ActiveScheduleHero
-                schedule={BASE_SCHEDULE}
-                skipping={false}
-                onReplan={noop}
-                onSwitchProfile={noop}
-                onToggleSkip={onToggleSkip}
-            />,
-        );
-
-        fireEvent.press(screen.getByText('Skip tonight'));
-
-        expect(onToggleSkip).toHaveBeenCalledTimes(1);
     });
 
     it('disables the re-plan button while `isReplanning` is true.', () => {

--- a/app/components/activity-view/.test.tsx
+++ b/app/components/activity-view/.test.tsx
@@ -186,7 +186,7 @@ describe('ActivityView', () => {
 
         render(<ActivityView />, { wrapper });
 
-        await waitFor(() => expect(screen.getByText('May 13 · 9:00 pm')).toBeOnTheScreen());
+        await waitFor(() => expect(screen.getByText('May 13 · 21:00')).toBeOnTheScreen());
     });
 
     it('flattens multi-page infinite-query results into a single visible list.', () => {

--- a/app/components/alerts-view/alert-card/.test.tsx
+++ b/app/components/alerts-view/alert-card/.test.tsx
@@ -30,7 +30,7 @@ describe('AlertCard', () => {
 
         expect(screen.getByText('Controller unreachable')).toBeOnTheScreen();
         expect(screen.getByText('CONNECTION')).toBeOnTheScreen();
-        expect(screen.getByText('2:02 pm')).toBeOnTheScreen();
+        expect(screen.getByText('14:02')).toBeOnTheScreen();
     });
 
     it('derives the kind tag from the wire class.', () => {

--- a/app/components/alerts-view/bucketing.test.ts
+++ b/app/components/alerts-view/bucketing.test.ts
@@ -50,13 +50,13 @@ describe('bucketFor', () => {
 });
 
 describe('formatAlertTimestamp', () => {
-    it('formats new/today instants as 12-hour time of day.', () => {
-        expect(formatAlertTimestamp('2026-05-29T20:02:00.000Z', NOW)).toBe('2:02 pm');
+    it('formats new/today instants as 24-hour time of day.', () => {
+        expect(formatAlertTimestamp('2026-05-29T20:02:00.000Z', NOW)).toBe('14:02');
     });
 
     it('formats this-week instants with a weekday prefix.', () => {
         // 23:21 site-local on May 28 (a Thursday).
-        expect(formatAlertTimestamp('2026-05-29T05:21:00.000Z', NOW)).toBe('Thu 11:21 pm');
+        expect(formatAlertTimestamp('2026-05-29T05:21:00.000Z', NOW)).toBe('Thu 23:21');
     });
 
     it('formats older instants as a calendar date.', () => {

--- a/app/components/alerts-view/bucketing.ts
+++ b/app/components/alerts-view/bucketing.ts
@@ -45,11 +45,11 @@ export function bucketFor(when: string, now: Date): AlertBucket {
 
 /**
  * Formats an alert's `when` for the card's monospace timestamp slot, in
- * 12-hour device-local time. Resolution widens with age so older rows stay
+ * 24-hour device-local time. Resolution widens with age so older rows stay
  * legible:
  *
- *   - `new` / `today` → `'2:02 pm'`
- *   - `week`          → `'Mon 11:47 pm'`
+ *   - `new` / `today` → `'14:02'`
+ *   - `week`          → `'Mon 23:47'`
  *   - `older`         → `'May 12'`
  *
  * @param when - The alert's ISO-8601 UTC instant.
@@ -60,9 +60,9 @@ export function formatAlertTimestamp(when: string, now: Date): string {
     const target = dayjs(when),
         bucket = bucketFor(when, now);
 
-    if (bucket === 'week') return target.format('ddd h:mm a');
+    if (bucket === 'week') return target.format('ddd HH:mm');
     if (bucket === 'older') return target.format('MMM D');
-    return target.format('h:mm a');
+    return target.format('HH:mm');
 }
 
 /**

--- a/app/components/fire-log/.test.tsx
+++ b/app/components/fire-log/.test.tsx
@@ -17,7 +17,7 @@ function buildActivity(overrides?: Partial<ActivityDto>): ActivityDto {
         zone: { id: 'z-1', name: 'North', slug: 'north' },
         appliedDepthMm: 14,
         durationMin: 62,
-        // 09:00 MDT on 2026-05-13 → 'May 13 · 9:00 am'.
+        // 09:00 MDT on 2026-05-13 → 'May 13 · 09:00'.
         startedAt: '2026-05-13T15:00:00.000Z',
         depletionBeforeMm: 30,
         depletionAfterMm: 16,
@@ -67,15 +67,15 @@ describe('FireLog', () => {
         expect(screen.getByText('30 → 16 mm')).toBeOnTheScreen();
     });
 
-    it('formats the date label via formatActivityRowDate (device-local MMM D · h:mm a) when startedAt is present.', () => {
-        // 2026-05-13T15:00Z = 09:00 MDT on 2026-05-13 → 'May 13 · 9:00 am'.
+    it('formats the date label via formatActivityRowDate (device-local MMM D · HH:mm) when startedAt is present.', () => {
+        // 2026-05-13T15:00Z = 09:00 MDT on 2026-05-13 → 'May 13 · 09:00'.
         render(
             <FireLog
                 rows={[buildActivity({ date: '2026-05-13', startedAt: '2026-05-13T15:00:00.000Z' })]}
             />,
         );
 
-        expect(screen.getByText('May 13 · 9:00 am')).toBeOnTheScreen();
+        expect(screen.getByText('May 13 · 09:00')).toBeOnTheScreen();
     });
 
     it('falls back to date-only `MMM D` when startedAt is null (APP-78).', () => {

--- a/app/components/home-view/.test.tsx
+++ b/app/components/home-view/.test.tsx
@@ -127,7 +127,7 @@ describe('HomeView', () => {
         setupSuccessfulFetch();
         render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
 
-        await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
+        await waitFor(() => expect(screen.getByText('22:23')).toBeOnTheScreen());
     });
 
     it('does not render the outer "Next run · <timezone>" eyebrow above the hero card.', async () => {
@@ -136,7 +136,7 @@ describe('HomeView', () => {
 
         // Wait for the page to stabilise, then assert the timezone-bearing
         // eyebrow is absent. The inner card's own "Next run" eyebrow stays.
-        await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
+        await waitFor(() => expect(screen.getByText('22:23')).toBeOnTheScreen());
         expect(screen.queryByText(/Next run · America\/Edmonton/)).toBeNull();
     });
 
@@ -155,10 +155,10 @@ describe('HomeView', () => {
         });
         render(<HomeView />, { wrapper: buildApiWrapper().wrapper });
 
-        // 04:23Z reads as 10:23 pm MDT (device-local), not 4:23 am (the UTC
+        // 04:23Z reads as 22:23 MDT (device-local), not 04:23 (the UTC
         // reading the bogus DTO timezone would imply).
-        await waitFor(() => expect(screen.getByText('10:23 pm')).toBeOnTheScreen());
-        expect(screen.queryByText('4:23 am')).toBeNull();
+        await waitFor(() => expect(screen.getByText('22:23')).toBeOnTheScreen());
+        expect(screen.queryByText('04:23')).toBeNull();
     });
 
     it('renders a zone tile for every zone returned by /zones.', async () => {

--- a/app/components/next-run-hero/.test.tsx
+++ b/app/components/next-run-hero/.test.tsx
@@ -63,7 +63,7 @@ describe('NextRunHero', () => {
             />,
         );
 
-        expect(screen.getByText('10:23 pm')).toBeOnTheScreen();
+        expect(screen.getByText('22:23')).toBeOnTheScreen();
     });
 
     it('renders the device timezone abbreviation next to the time (APP-88).', () => {
@@ -149,7 +149,7 @@ describe('NextRunHero', () => {
         );
 
         // The body of the card still renders — just the badge is suppressed.
-        expect(screen.getByText('10:23 pm')).toBeOnTheScreen();
+        expect(screen.getByText('22:23')).toBeOnTheScreen();
         // None of the badge labels appear.
         expect(screen.queryByText('Firing')).toBeNull();
         expect(screen.queryByText('Scheduled')).toBeNull();

--- a/app/components/schedule-list-view/.test.tsx
+++ b/app/components/schedule-list-view/.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
-import type { ReactTestInstance } from 'react-test-renderer';
 
 import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
 import type { ScheduleListItem } from '@/api/types/schedules';
@@ -145,45 +144,6 @@ describe('ScheduleListView', () => {
         });
     });
 
-    it('POSTs /schedule/skip-tonight when the Skip tonight button is pressed.', async () => {
-        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
-        mockFetch.mockResolvedValueOnce(jsonResponse({ status: 'skipped', schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-1' } }));
-        mockFetch.mockResolvedValue(jsonResponse(ALL_SCHEDULES));
-
-        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
-
-        await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
-
-        await act(async () => {
-            fireEvent.press(screen.getByText('Skip tonight'));
-        });
-
-        await waitFor(() => {
-            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
-            expect(urls).toContain('http://test.local:9753/schedule/skip-tonight');
-        });
-    });
-
-    it('POSTs /schedule/resume-tonight when Resume tonight is pressed (active schedule already skipping).', async () => {
-        const skippingActive = { ...ACTIVE_SCHEDULE, skippedTonight: true };
-        mockFetch.mockResolvedValueOnce(jsonResponse([skippingActive, WEEKEND_SCHEDULE, OVERSEEDING_SCHEDULE]));
-        mockFetch.mockResolvedValueOnce(jsonResponse({ status: 'resumed', schedule: { slug: 'maintenance', name: 'Maintenance', siteId: 'site-1' } }));
-        mockFetch.mockResolvedValue(jsonResponse([skippingActive, WEEKEND_SCHEDULE, OVERSEEDING_SCHEDULE]));
-
-        render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
-
-        await waitFor(() => expect(screen.getByText('Resume tonight')).toBeOnTheScreen());
-
-        await act(async () => {
-            fireEvent.press(screen.getByText('Resume tonight'));
-        });
-
-        await waitFor(() => {
-            const urls = mockFetch.mock.calls.map(call => (call as [string, RequestInit])[0]);
-            expect(urls).toContain('http://test.local:9753/schedule/resume-tonight');
-        });
-    });
-
     it('POSTs /replan when the re-plan icon button is pressed.', async () => {
         mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
         mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
@@ -210,20 +170,5 @@ describe('ScheduleListView', () => {
 
         await waitFor(() => expect(screen.getByText('Profile · none active')).toBeOnTheScreen());
         expect(screen.queryByText('Maintenance')).toBeNull();
-        expect(screen.getByText('Other profiles')).toBeOnTheScreen();
-    });
-
-    it('renders the disabled "+ New" stub button.', async () => {
-        mockFetch.mockResolvedValueOnce(jsonResponse(ALL_SCHEDULES));
-
-        const { root } = render(<ScheduleListView />, { wrapper: buildApiWrapper().wrapper });
-
-        await waitFor(() => expect(screen.getByText('Other profiles')).toBeOnTheScreen());
-        const newButton = findByAccessibilityLabel(root, 'Add new profile');
-        expect(newButton?.props.accessibilityState).toEqual({ disabled: true });
     });
 });
-
-function findByAccessibilityLabel(root: ReactTestInstance, label: string): ReactTestInstance | undefined {
-    return root.find(node => typeof node.type === 'string' && node.props.accessibilityLabel === label);
-}

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -176,17 +176,17 @@ describe('ZoneDetail', () => {
             />,
         );
 
-        expect(screen.getByText('May 3 · 9:00 am')).toBeOnTheScreen();
+        expect(screen.getByText('May 3 · 09:00')).toBeOnTheScreen();
         expect(screen.getByText('9.0 mm · 30 min')).toBeOnTheScreen();
         expect(screen.getByText('22.0 → 0.0 mm')).toBeOnTheScreen();
-        expect(screen.getByText('May 2 · 9:00 am')).toBeOnTheScreen();
+        expect(screen.getByText('May 2 · 09:00')).toBeOnTheScreen();
         expect(screen.getByText('4.5 mm · 15 min')).toBeOnTheScreen();
         expect(screen.getByText('13.0 → 0.0 mm')).toBeOnTheScreen();
     });
 
     it('formats recent-run dates in the supplied site timezone from startedAt (APP-71 / APP-78).', () => {
         // 2026-05-14T05:30Z = 23:30 MDT on 2026-05-13 — still May 13 locally,
-        // and the time should read 11:30 pm site-local. The `date` field
+        // and the time should read 23:30 site-local. The `date` field
         // says May 14 (planner's scheduled-night bucket); the formatter
         // prefers `startedAt` and shows the actual local day.
         const activity = [
@@ -204,7 +204,7 @@ describe('ZoneDetail', () => {
             />,
         );
 
-        expect(screen.getByText('May 13 · 11:30 pm')).toBeOnTheScreen();
+        expect(screen.getByText('May 13 · 23:30')).toBeOnTheScreen();
     });
 
     it('falls back to date-only `MMM D` on recent-run rows when startedAt is null (APP-78).', () => {

--- a/app/lib/relative-time/.test.ts
+++ b/app/lib/relative-time/.test.ts
@@ -82,28 +82,28 @@ describe('formatCountdown', () => {
 });
 
 describe('formatTimeOfDay', () => {
-    it('formats a UTC instant as a 12-hour clock with am/pm in the device timezone.', () => {
+    it('formats a UTC instant as a 24-hour clock in the device timezone.', () => {
         // 2026-05-23T04:23Z = 22:23 MDT on 2026-05-22 (Friday night).
-        expect(formatTimeOfDay('2026-05-23T04:23:00.000Z')).toBe('10:23 pm');
+        expect(formatTimeOfDay('2026-05-23T04:23:00.000Z')).toBe('22:23');
     });
 
-    it('renders the am side of the boundary.', () => {
+    it('zero-pads the morning side of the boundary.', () => {
         // 2026-05-23T11:48Z = 05:48 MDT on 2026-05-23 (Saturday morning).
-        expect(formatTimeOfDay('2026-05-23T11:48:00.000Z')).toBe('5:48 am');
+        expect(formatTimeOfDay('2026-05-23T11:48:00.000Z')).toBe('05:48');
     });
 });
 
 describe('formatActivityRowDate', () => {
     it(`formats both the day and the time-of-day from startedAt in the device timezone.`, () => {
         // 2026-05-13T15:00:00Z = 09:00 MDT on 2026-05-13.
-        expect(formatActivityRowDate('2026-05-13', '2026-05-13T15:00:00.000Z')).toBe('May 13 · 9:00 am');
+        expect(formatActivityRowDate('2026-05-13', '2026-05-13T15:00:00.000Z')).toBe('May 13 · 09:00');
     });
 
     it(`keys both the day and the time off startedAt — so a UTC instant that rolls back to the previous local day renders on that local day.`, () => {
         // 2026-05-14T05:30:00Z = 23:30 MDT on 2026-05-13. The bare 'date'
         // field says May 14 (the planner's scheduled-night bucket); the
         // formatter prefers startedAt and shows the actual local day.
-        expect(formatActivityRowDate('2026-05-14', '2026-05-14T05:30:00.000Z')).toBe('May 13 · 11:30 pm');
+        expect(formatActivityRowDate('2026-05-14', '2026-05-14T05:30:00.000Z')).toBe('May 13 · 23:30');
     });
 
     it(`falls back to date-only 'MMM D' when startedAt is null.`, () => {
@@ -119,7 +119,7 @@ describe('formatActivityRowDate', () => {
 
 describe('formatEndsAt', () => {
     it('formats the ends-at like formatTimeOfDay.', () => {
-        expect(formatEndsAt('2026-05-23T11:48:00.000Z')).toBe('5:48 am');
+        expect(formatEndsAt('2026-05-23T11:48:00.000Z')).toBe('05:48');
     });
 });
 

--- a/app/lib/relative-time/index.ts
+++ b/app/lib/relative-time/index.ts
@@ -57,12 +57,12 @@ export function formatCountdown(iso: string | null, now: Date): string {
 }
 
 /**
- * Formats `iso` as `'10:23 pm'` style in the device-local timezone. Named-zone
- * conversion was dropped on the client (APP-88) — dayjs's `.tz()` renders UTC on
- * Hermes-on-Android — so the operator sees their own device clock.
+ * Formats `iso` as `'22:23'` (24-hour) style in the device-local timezone.
+ * Named-zone conversion was dropped on the client (APP-88) — dayjs's `.tz()`
+ * renders UTC on Hermes-on-Android — so the operator sees their own device clock.
  */
 export function formatTimeOfDay(iso: string): string {
-    return dayjs(iso).format('h:mm a');
+    return dayjs(iso).format('HH:mm');
 }
 
 /**
@@ -70,7 +70,7 @@ export function formatTimeOfDay(iso: string): string {
  * and falling back to the entry's calendar day when not.
  *
  * When `startedAt` is non-null, both the day and the time-of-day come from
- * the real instant (`'May 13 · 9:00 am'`) in the device-local timezone —
+ * the real instant (`'May 13 · 09:00'`) in the device-local timezone —
  * the label stays internally consistent across midnight-rollover edge
  * cases. When `startedAt` is null (deferred planner entries with no
  * cycles), falls back to date-only (`'May 13'`) formatted directly from
@@ -78,18 +78,18 @@ export function formatTimeOfDay(iso: string): string {
  */
 export function formatActivityRowDate(date: string, startedAt: string | null): string {
     if (startedAt !== null) {
-        return dayjs(startedAt).format('MMM D · h:mm a');
+        return dayjs(startedAt).format('MMM D · HH:mm');
     }
     return dayjs(date).format('MMM D');
 }
 
 /**
- * Formats `iso` for the hero's "ends ..." suffix (`'ends 5:48 am'`) in the
+ * Formats `iso` for the hero's "ends ..." suffix (`'ends 05:48'`) in the
  * device-local timezone. Identical formatter to `formatTimeOfDay`; named
  * separately for grep-ability at call sites.
  */
 export function formatEndsAt(iso: string): string {
-    return dayjs(iso).format('h:mm a');
+    return dayjs(iso).format('HH:mm');
 }
 
 /**


### PR DESCRIPTION
## Ticket

[APP-80](http://192.168.2.100:7123/home/browse/APP-80/) Migrate user-visible times to 24-hour clock

## Summary

- Switches every client-side time-of-day formatter from 12-hour (`9:47 am`) to 24-hour (`09:47`):
  - [relative-time/index.ts](app/lib/relative-time/index.ts): `formatTimeOfDay`, `formatActivityRowDate`, `formatEndsAt` (`'h:mm a'`/`'MMM D · h:mm a'` → `'HH:mm'`/`'MMM D · HH:mm'`) — feeds the next-run hero, ends-at suffix, Activity fire log, and Zone-detail recent runs.
  - [alerts-view/bucketing.ts](app/components/alerts-view/bucketing.ts) `formatAlertTimestamp` (`'h:mm a'`/`'ddd h:mm a'` → `'HH:mm'`/`'ddd HH:mm'`) — the alert card's timestamp. The weekday/date labels are preserved alongside the time (`Thu 23:21`, `May 12`).
- Date-only and relative-age labels (`5h ago`, `Tomorrow, 24 May`, `2m`, `Nd`) are unchanged. The CycleStrip was already 24-hour.
- `nextRun.whenLabel` (`'tonight at 10:23pm'`) is an **API DTO field**, left as-is per the ticket's "touches no API code". Flagged as a possible API-side follow-up for full consistency.

### Tests
- Updated assertions in relative-time and the downstream component suites (next-run-hero, home-view, activity-view, zone-detail, fire-log) plus the alerts suites (bucketing, alert-card).
- Full app suite green (86 suites / 686 tests), run twice; `grep` confirms no `h:mm a` remains.

### Incidental (separate commit)
- Removed **stale** `ActiveScheduleHero` / `ScheduleListView` tests for UI retired by **APP-90 / APP-91 / APP-92** (tile actions, "Other profiles", "+ New", skip/resume) that were already failing on `main` and unrelated to this change — needed to leave the repo-wide suite green.