### PR TITLE
[API-101] GET/PATCH /settings/notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,18 +29,10 @@ HA_RETRY_BASE_MS=1000
 
 # --- Home Assistant notifications ---
 # Name of the HA notify service to call (e.g. `mobile_app_pixel_8`,
-# `persistent_notification`). Leave empty to disable all notifications
-# regardless of the per-event flags below.
+# `persistent_notification`). Leave empty to disable all notifications.
+# The per-event opt-in flags are no longer env-configured — they live in the
+# `notification_settings` DB row and are managed via `PATCH /settings/notifications`.
 HA_NOTIFY_SERVICE=
-
-# Per-event opt-in flags. Scheduled-run and error events default to on. The
-# per-manual-fire watering events default to off (noisy if the operator runs
-# zones from the HTTP surface frequently).
-NOTIFY_ON_SCHEDULE_START=true
-NOTIFY_ON_SCHEDULE_END=true
-NOTIFY_ON_WATERING_START=false
-NOTIFY_ON_WATERING_END=false
-NOTIFY_ON_ERROR=true
 
 # --- Open-Meteo (optional; consumed by API code, not docker-compose) ---
 # Set to false to disable all weather API calls (e.g. offline dev, CI without

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Irrigation control system. The repo contains:
 First-time setup:
 
 1. `cp .env.example .env` — at the repo root. Docker Compose loads `.env` from the directory containing the compose file.
-2. Edit `.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them. To opt into push notifications via Home Assistant, set `HA_NOTIFY_SERVICE` (e.g. `mobile_app_pixel_8`); the `NOTIFY_ON_WATERING_START` / `NOTIFY_ON_WATERING_END` / `NOTIFY_ON_ERROR` flags toggle each event type (defaults: `false`/`false`/`true`).
+2. Edit `.env` and fill in the required values: `HA_URL` (your Home Assistant base URL) and `HA_TOKEN` (a long-lived access token from HA → Profile → Security → Long-Lived Access Tokens). Postgres / pgAdmin / port values have working defaults and only need to be set if you're overriding them. To opt into push notifications via Home Assistant, set `HA_NOTIFY_SERVICE` (e.g. `mobile_app_pixel_8`). The per-event toggles (schedule start/end, watering start/end, error) are no longer env vars — they live in the `notification_settings` DB row and are read/changed at runtime via `GET` / `PATCH /settings/notifications` (defaults: schedule start/end + error on, watering start/end off).
 3. From the repo root, bring the stack up: `docker compose up` (or `bun --cwd=./api run up` for the variant that includes pgAdmin via the `tools` profile).
 
 `.env` is gitignored — never commit credentials.

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1346,6 +1346,113 @@ describe('buildApp /system routes', () => {
     });
 });
 
+describe('buildApp /settings/notifications routes', () => {
+    const DEFAULTS = { scheduleStart: true, scheduleEnd: true, wateringStart: false, wateringEnd: false, error: true };
+
+    describe('GET /settings/notifications', () => {
+        it('returns 200 with the settings DTO from the handler', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                notificationSettings: {
+                    get: async () => DEFAULTS,
+                    update: async () => DEFAULTS,
+                },
+            });
+
+            const res = await app.inject({ method: 'GET', url: '/settings/notifications' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual(DEFAULTS);
+            await app.close();
+        });
+
+        it('returns 404 when the handler is absent from BuildAppOptions', async () => {
+            const app = buildApp({ getStatus: () => buildStatus() });
+
+            const res = await app.inject({ method: 'GET', url: '/settings/notifications' });
+
+            expect(res.statusCode).toBe(404);
+            await app.close();
+        });
+    });
+
+    describe('PATCH /settings/notifications', () => {
+        it('passes the subset to the handler and echoes the updated DTO', async () => {
+            const patches: Array<Record<string, unknown>> = [];
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                notificationSettings: {
+                    get: async () => DEFAULTS,
+                    update: async (patch) => {
+                        patches.push(patch);
+                        return { ...DEFAULTS, ...patch };
+                    },
+                },
+            });
+
+            const res = await app.inject({
+                method: 'PATCH',
+                url: '/settings/notifications',
+                payload: { wateringStart: true, error: false },
+            });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual({ ...DEFAULTS, wateringStart: true, error: false });
+            expect(patches).toEqual([{ wateringStart: true, error: false }]);
+            await app.close();
+        });
+
+        it('accepts an empty body as a no-op and echoes the current DTO', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                notificationSettings: { get: async () => DEFAULTS, update: async (patch) => ({ ...DEFAULTS, ...patch }) },
+            });
+
+            const res = await app.inject({ method: 'PATCH', url: '/settings/notifications', payload: {} });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toEqual(DEFAULTS);
+            await app.close();
+        });
+
+        it('returns 400 for an unknown field without calling the handler', async () => {
+            let called = false;
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                notificationSettings: { get: async () => DEFAULTS, update: async (patch) => { called = true; return { ...DEFAULTS, ...patch }; } },
+            });
+
+            const res = await app.inject({
+                method: 'PATCH',
+                url: '/settings/notifications',
+                payload: { bogus: true },
+            });
+
+            expect(res.statusCode).toBe(400);
+            expect(res.json()).toMatchObject({ error: 'bad-request' });
+            expect(called).toBe(false);
+            await app.close();
+        });
+
+        it('returns 400 when a known field carries a non-boolean value', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                notificationSettings: { get: async () => DEFAULTS, update: async (patch) => ({ ...DEFAULTS, ...patch }) },
+            });
+
+            const res = await app.inject({
+                method: 'PATCH',
+                url: '/settings/notifications',
+                payload: { scheduleStart: 'yes' },
+            });
+
+            expect(res.statusCode).toBe(400);
+            expect(res.json()).toMatchObject({ error: 'bad-request' });
+            await app.close();
+        });
+    });
+});
+
 describe('wrapSystemWithReplan', () => {
     const buildState = (enabled: boolean) => ({ irrigationEnabled: enabled, since: '2026-05-21T12:00:00.000Z' });
 

--- a/api/.test.ts
+++ b/api/.test.ts
@@ -1434,6 +1434,23 @@ describe('buildApp /settings/notifications routes', () => {
             await app.close();
         });
 
+        it('returns 400 when the body is not a JSON object', async () => {
+            const app = buildApp({
+                getStatus: () => buildStatus(),
+                notificationSettings: { get: async () => DEFAULTS, update: async (patch) => ({ ...DEFAULTS, ...patch }) },
+            });
+
+            const res = await app.inject({
+                method: 'PATCH',
+                url: '/settings/notifications',
+                payload: ['scheduleStart'],
+            });
+
+            expect(res.statusCode).toBe(400);
+            expect(res.json()).toMatchObject({ error: 'bad-request' });
+            await app.close();
+        });
+
         it('returns 400 when a known field carries a non-boolean value', async () => {
             const app = buildApp({
                 getStatus: () => buildStatus(),

--- a/api/db/backfill-end-by-sunrise.test.ts
+++ b/api/db/backfill-end-by-sunrise.test.ts
@@ -27,13 +27,17 @@ describe('0018 backfill maintenance end_by_sunrise', () => {
         expect(sql).toContain('"end_by_sunrise" is null');
     });
 
-    it('is registered in the journal as the newest migration', async () => {
+    it('is registered in the journal, ordered after the schema migration it backfills', async () => {
         const journal = await readJournalFile(DRIZZLE_DIR);
 
         const entry = journal.entries.find(e => e.tag === MIGRATION_TAG);
         expect(entry).toBeDefined();
 
-        const newestWhen = journal.entries.reduce((max, e) => (e.when > max ? e.when : max), 0);
-        expect(entry!.when).toBe(newestWhen);
+        // The backfill must sort strictly after 0017 (the last migration that
+        // predates it) so the verifier treats a DB stopped at 0017 as behind.
+        // It need not be the global newest — later migrations stack on top.
+        const previous = journal.entries.find(e => e.tag === '0017_thick_romulus');
+        expect(previous).toBeDefined();
+        expect(entry!.when).toBeGreaterThan(previous!.when);
     });
 });

--- a/api/db/schema/index.ts
+++ b/api/db/schema/index.ts
@@ -1,6 +1,7 @@
 export { alerts } from './alerts';
 export { grassTypes } from './grass-types';
 export { irrigationCycles } from './irrigation-cycles';
+export { notificationSettings, NOTIFICATION_SETTINGS_SINGLETON_ID } from './notification-settings';
 export { pushTokens } from './push-tokens';
 export { scheduleEntries } from './schedule-entries';
 export { schedulingDecisions } from './scheduling-decisions';

--- a/api/db/schema/notification-settings.ts
+++ b/api/db/schema/notification-settings.ts
@@ -1,0 +1,28 @@
+import { boolean, pgTable, text } from 'drizzle-orm/pg-core';
+import { auditColumns } from './audit-columns';
+
+/**
+ * Singleton row backing the operator's notification preferences — the five
+ * per-event toggles the mobile settings screen reads and PATCHes. The id
+ * column is a constant string ('singleton') so upserts always target the same
+ * row. The migration seeds a row whose defaults match the historical
+ * `NOTIFY_ON_*` env defaults so first-boot behaviour is preserved.
+ *
+ * Replaces the env-snapshot the notifier used to read at construction time
+ * (API-101): the row is now the source of truth, read live on each event.
+ */
+export const notificationSettings = pgTable('notification_settings', {
+    id: text('id').primaryKey(),
+    scheduleStart: boolean('schedule_start').notNull().default(true),
+    scheduleEnd: boolean('schedule_end').notNull().default(true),
+    wateringStart: boolean('watering_start').notNull().default(false),
+    wateringEnd: boolean('watering_end').notNull().default(false),
+    error: boolean('error').notNull().default(true),
+    ...auditColumns,
+});
+
+/**
+ * The fixed primary key value used for the singleton row. Exported so the
+ * reader and writer can avoid embedding the literal in every query.
+ */
+export const NOTIFICATION_SETTINGS_SINGLETON_ID = 'singleton';

--- a/api/drizzle/0019_true_domino.sql
+++ b/api/drizzle/0019_true_domino.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "notification_settings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"schedule_start" boolean DEFAULT true NOT NULL,
+	"schedule_end" boolean DEFAULT true NOT NULL,
+	"watering_start" boolean DEFAULT false NOT NULL,
+	"watering_end" boolean DEFAULT false NOT NULL,
+	"error" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO "notification_settings" ("id", "schedule_start", "schedule_end", "watering_start", "watering_end", "error") VALUES ('singleton', true, true, false, false, true) ON CONFLICT ("id") DO NOTHING;

--- a/api/drizzle/meta/0019_snapshot.json
+++ b/api/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1451 @@
+{
+  "id": "832441f7-352d-401d-ba58-02e334649dc2",
+  "prevId": "272a59ec-bafe-457e-aa00-0b1f78d9bf78",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_at": {
+          "name": "when_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ack": {
+          "name": "ack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alerts_zone_id_zones_id_fk": {
+          "name": "alerts_zone_id_zones_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alerts_class_check": {
+          "name": "alerts_class_check",
+          "value": "\"alerts\".\"class\" in ('weather-stale', 'ha-call-failed', 'missed-close', 'actuation-stale')"
+        },
+        "alerts_tone_check": {
+          "name": "alerts_tone_check",
+          "value": "\"alerts\".\"tone\" in ('warn', 'danger')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.grass_types": {
+      "name": "grass_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crop_coefficient": {
+          "name": "crop_coefficient",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grass_types_slug_unique": {
+          "name": "grass_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.irrigation_cycles": {
+      "name": "irrigation_cycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schedule_entry_id": {
+          "name": "schedule_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk": {
+          "name": "irrigation_cycles_schedule_entry_id_schedule_entries_id_fk",
+          "tableFrom": "irrigation_cycles",
+          "tableTo": "schedule_entries",
+          "columnsFrom": [
+            "schedule_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_start": {
+          "name": "schedule_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_end": {
+          "name": "schedule_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "watering_start": {
+          "name": "watering_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watering_end": {
+          "name": "watering_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_token_unique": {
+          "name": "push_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.schedule_entries": {
+      "name": "schedule_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_depth_mm": {
+          "name": "applied_depth_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "sunrise_at": {
+          "name": "sunrise_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_entries_zone_id_zones_id_fk": {
+          "name": "schedule_entries_zone_id_zones_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_entries_schedule_id_schedules_id_fk": {
+          "name": "schedule_entries_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_entries",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_days": {
+          "name": "allowed_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_time_windows": {
+          "name": "allowed_time_windows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_depth_m_override": {
+          "name": "root_depth_m_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowable_depletion_fraction_override": {
+          "name": "allowable_depletion_fraction_override",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_by_sunrise": {
+          "name": "end_by_sunrise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_night_date": {
+          "name": "skipped_night_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_site_slug_idx": {
+          "name": "schedules_site_slug_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_one_active_per_site": {
+          "name": "schedules_one_active_per_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_site_id_sites_id_fk": {
+          "name": "schedules_site_id_sites_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduling_decisions": {
+      "name": "scheduling_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replan_at": {
+          "name": "replan_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_before_mm": {
+          "name": "depletion_before_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depletion_after_mm": {
+          "name": "depletion_after_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_threshold_mm": {
+          "name": "trigger_threshold_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weather_snapshot_id": {
+          "name": "weather_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduling_decisions_zone_id_zones_id_fk": {
+          "name": "scheduling_decisions_zone_id_zones_id_fk",
+          "tableFrom": "scheduling_decisions",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scheduling_decisions_schedule_id_schedules_id_fk": {
+          "name": "scheduling_decisions_schedule_id_schedules_id_fk",
+          "tableFrom": "scheduling_decisions",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scheduling_decisions_weather_snapshot_id_weather_snapshots_id_fk": {
+          "name": "scheduling_decisions_weather_snapshot_id_weather_snapshots_id_fk",
+          "tableFrom": "scheduling_decisions",
+          "tableTo": "weather_snapshots",
+          "columnsFrom": [
+            "weather_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soil_types": {
+      "name": "soil_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_water_holding_capacity_mm_per_m": {
+          "name": "available_water_holding_capacity_mm_per_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infiltration_rate_mm_per_hr": {
+          "name": "infiltration_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "soil_types_slug_unique": {
+          "name": "soil_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_state": {
+      "name": "system_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "irrigation_enabled": {
+          "name": "irrigation_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "since": {
+          "name": "since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_daily_snapshots": {
+      "name": "weather_daily_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sunrise_at": {
+          "name": "sunrise_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sunset_at": {
+          "name": "sunset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "et0_mm_per_day": {
+          "name": "et0_mm_per_day",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_daily_snapshots_snapshot_id_weather_snapshots_id_fk": {
+          "name": "weather_daily_snapshots_snapshot_id_weather_snapshots_id_fk",
+          "tableFrom": "weather_daily_snapshots",
+          "tableTo": "weather_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_hourly_snapshots": {
+      "name": "weather_hourly_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_mm": {
+          "name": "precipitation_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "et0_mm": {
+          "name": "et0_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_hourly_snapshots_snapshot_id_weather_snapshots_id_fk": {
+          "name": "weather_hourly_snapshots_snapshot_id_weather_snapshots_id_fk",
+          "tableFrom": "weather_hourly_snapshots",
+          "tableTo": "weather_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_snapshots": {
+      "name": "weather_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_snapshots_zone_id_zones_id_fk": {
+          "name": "weather_snapshots_zone_id_zones_id_fk",
+          "tableFrom": "weather_snapshots",
+          "tableTo": "zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_state": {
+      "name": "weather_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_successful_fetch_at": {
+          "name": "last_successful_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zones": {
+      "name": "zones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grass_type_id": {
+          "name": "grass_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soil_type_id": {
+          "name": "soil_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_depth_m": {
+          "name": "root_depth_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowable_depletion_fraction": {
+          "name": "allowable_depletion_fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "irrigation_efficiency": {
+          "name": "irrigation_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_rate_l_per_min": {
+          "name": "flow_rate_l_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_m2": {
+          "name": "area_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precipitation_rate_mm_per_hr": {
+          "name": "precipitation_rate_mm_per_hr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_depletion_mm": {
+          "name": "current_depletion_mm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_depletion_reconciled_at": {
+          "name": "current_depletion_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_assistant_entity_id": {
+          "name": "home_assistant_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microclimate_factor": {
+          "name": "microclimate_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "patch": {
+          "name": "patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zones_site_id_sites_id_fk": {
+          "name": "zones_site_id_sites_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_grass_type_id_grass_types_id_fk": {
+          "name": "zones_grass_type_id_grass_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "grass_types",
+          "columnsFrom": [
+            "grass_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zones_soil_type_id_soil_types_id_fk": {
+          "name": "zones_soil_type_id_soil_types_id_fk",
+          "tableFrom": "zones",
+          "tableTo": "soil_types",
+          "columnsFrom": [
+            "soil_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zones_slug_unique": {
+          "name": "zones_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "zones_patch_check": {
+          "name": "zones_patch_check",
+          "value": "\"zones\".\"patch\" in ('a', 'b', 'c')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1780333663387,
       "tag": "0018_backfill_maintenance_end_by_sunrise",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1780407734676,
+      "tag": "0019_true_domino",
+      "breakpoints": true
     }
   ]
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -37,9 +37,11 @@ import dayjs from 'dayjs';
 import type { ZoneSummary } from '@/models/zone';
 import { closeZone, getZoneState, openZone } from '@/data/home-assistant';
 import { bootSystemService, getSystemState, setIrrigationEnabled } from '@/service/system';
+import { bootNotificationSettingsService, getNotificationSettings, updateNotificationSettings } from '@/service/notification-settings';
 import type { Database } from '@/db';
 import type { PushRegistration } from '@/models/push-token';
 import type { SystemStateDto } from '@/models/system';
+import type { NotificationSettingsDto, NotificationSettingsPatch } from '@/models/notification-settings';
 import type { TonightDto } from '@/models/tonight';
 import {
     bootPushTokensService,
@@ -96,6 +98,16 @@ export type SystemApi = {
     get: () => Promise<SystemStateDto>;
     enable: () => Promise<SystemStateDto>;
     disable: () => Promise<SystemStateDto>;
+};
+
+/**
+ * HTTP surface of the operator notification toggles. Production wires this
+ * against `getNotificationSettings` / `updateNotificationSettings` from
+ * `@/service/notification-settings`.
+ */
+export type NotificationSettingsApi = {
+    get: () => Promise<NotificationSettingsDto>;
+    update: (patch: NotificationSettingsPatch) => Promise<NotificationSettingsDto>;
 };
 
 /**
@@ -215,6 +227,14 @@ export type BuildAppOptions = {
     system?: SystemApi;
 
     /**
+     * Optional. When supplied, registers `GET /settings/notifications` and
+     * `PATCH /settings/notifications` — the operator notification toggles
+     * surface backing the mobile settings screen. Production binds these to
+     * the notification-settings service.
+     */
+    notificationSettings?: NotificationSettingsApi;
+
+    /**
      * Optional. When supplied, registers `GET /tonight` — the next-run
      * summary backing the mobile Home hero card and `CycleStrip`. Production
      * binds this to the tonight module's DB-backed lister.
@@ -313,6 +333,10 @@ export function buildApp(opts: BuildAppOptions): FastifyInstance {
 
     if (opts.system) {
         registerSystemRoutes(app, opts.system);
+    }
+
+    if (opts.notificationSettings) {
+        registerNotificationSettingsRoutes(app, opts.notificationSettings);
     }
 
     if (opts.activity) {
@@ -493,6 +517,47 @@ function registerSystemRoutes(app: FastifyInstance, system: SystemApi): void {
             const message = err instanceof Error ? err.message : String(err);
             return reply.code(502).send({ error: 'replan-failed', message });
         }
+    });
+}
+
+const NOTIFICATION_SETTINGS_KEYS = ['scheduleStart', 'scheduleEnd', 'wateringStart', 'wateringEnd', 'error'] as const;
+
+function registerNotificationSettingsRoutes(app: FastifyInstance, settings: NotificationSettingsApi): void {
+    /**
+     * `GET /settings/notifications` — the operator's five per-event toggles,
+     * backing the mobile settings screen. Always 200 with the full DTO.
+     */
+    app.get('/settings/notifications', async (_req, reply) => {
+        const dto = await settings.get();
+        return reply.code(200).send(dto);
+    });
+
+    /**
+     * `PATCH /settings/notifications` — updates any subset of the five flags
+     * and echoes the full updated DTO. The body must be an object whose keys
+     * are all recognised flags and whose values are all booleans; any unknown
+     * key or non-boolean value is a 400. An empty body is a valid no-op that
+     * returns the current settings.
+     */
+    app.patch('/settings/notifications', async (req, reply) => {
+        const body = req.body;
+        if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+            return reply.code(400).send({ error: 'bad-request', message: 'Body must be a JSON object.' });
+        }
+
+        const patch: NotificationSettingsPatch = {};
+        for (const [key, value] of Object.entries(body)) {
+            if (!(NOTIFICATION_SETTINGS_KEYS as readonly string[]).includes(key)) {
+                return reply.code(400).send({ error: 'bad-request', message: `Unknown field '${key}'.` });
+            }
+            if (typeof value !== 'boolean') {
+                return reply.code(400).send({ error: 'bad-request', message: `Field '${key}' must be a boolean.` });
+            }
+            patch[key as keyof NotificationSettingsPatch] = value;
+        }
+
+        const dto = await settings.update(patch);
+        return reply.code(200).send(dto);
     });
 }
 
@@ -827,6 +892,7 @@ if (import.meta.main) {
     const alertsDb = db as unknown as AlertsDb;
     const typedDb = db as unknown as Database;
     bootSystemService({ db: typedDb });
+    bootNotificationSettingsService({ db: typedDb });
     bootSitesService({ db: typedDb });
     bootSchedulesService({ db: typedDb });
     bootZonesService({ db: typedDb });
@@ -874,6 +940,10 @@ if (import.meta.main) {
             ack: id => acknowledgeAlert(alertsDb, id),
         },
         system: wrapSystemWithReplan(baseSystem, () => daemon.rePlan()),
+        notificationSettings: {
+            get: () => getNotificationSettings(),
+            update: patch => updateNotificationSettings(patch),
+        },
         activity: params => listActivity(db as unknown as ActivityDb, params),
         tonight: () => getTonightSummary(realClock.now()),
         schedulesList: () => listSchedules(realClock.now()),

--- a/api/models/notification-settings.ts
+++ b/api/models/notification-settings.ts
@@ -1,0 +1,35 @@
+/**
+ * Wire-format snapshot of the operator's per-event notification toggles.
+ * Served by `GET /settings/notifications` and echoed by `PATCH`; also read
+ * live by `createNotifier` to decide whether to fire each event.
+ *
+ * All five fields are required booleans. `scheduleStart` / `scheduleEnd`
+ * cover the daemon's scheduled runs; `wateringStart` / `wateringEnd` cover
+ * manual operator fires; `error` covers failure notifications.
+ */
+export type NotificationSettingsDto = {
+    scheduleStart: boolean;
+    scheduleEnd: boolean;
+    wateringStart: boolean;
+    wateringEnd: boolean;
+    error: boolean;
+};
+
+/**
+ * Partial update accepted by `PATCH /settings/notifications` — any subset of
+ * the five flags. Keys outside the DTO are rejected by the route with a 400.
+ */
+export type NotificationSettingsPatch = Partial<NotificationSettingsDto>;
+
+/**
+ * Default toggles, matching the historical `NOTIFY_ON_*` env defaults so first
+ * boot (and the defensive fallback when the singleton row is missing) preserve
+ * today's behaviour.
+ */
+export const NOTIFICATION_SETTINGS_DEFAULTS: NotificationSettingsDto = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: false,
+    wateringEnd: false,
+    error: true,
+};

--- a/api/notifications/.test.ts
+++ b/api/notifications/.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { bootNotificationSettingsService } from '@/service/notification-settings';
+import type { NotificationSettingsRow } from '@/repositories/notification-settings';
 import { createNotifier, noopNotifier, buildMessage } from '.';
 
 const mockFetch = mock(() => Promise.resolve({} as Response));
@@ -8,20 +10,23 @@ const HA_URL = 'http://ha.local:8123';
 const HA_TOKEN = 'test-token-456';
 const HA_NOTIFY_SERVICE = 'mobile_app_pixel_8';
 
-const ENV_KEYS = [
-    'HA_URL',
-    'HA_TOKEN',
-    'HA_NOTIFY_SERVICE',
-    'NOTIFY_ON_SCHEDULE_START',
-    'NOTIFY_ON_SCHEDULE_END',
-    'NOTIFY_ON_WATERING_START',
-    'NOTIFY_ON_WATERING_END',
-    'NOTIFY_ON_ERROR',
-] as const;
+const ENV_KEYS = ['HA_URL', 'HA_TOKEN', 'HA_NOTIFY_SERVICE'] as const;
+
+// The per-event toggles now live in the notification-settings service rather
+// than env, so these tests boot the service against a mutable fake whose flags
+// can be flipped between events. Defaults match the historical env defaults.
+const DEFAULT_FLAGS: NotificationSettingsRow = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: false,
+    wateringEnd: false,
+    error: true,
+};
 
 describe('createNotifier', () => {
     let saved: Record<string, string | undefined>;
     let warnSpy: ReturnType<typeof spyOn>;
+    let flags: NotificationSettingsRow;
 
     beforeEach(() => {
         saved = {};
@@ -29,11 +34,13 @@ describe('createNotifier', () => {
         process.env.HA_URL = HA_URL;
         process.env.HA_TOKEN = HA_TOKEN;
         process.env.HA_NOTIFY_SERVICE = HA_NOTIFY_SERVICE;
-        delete process.env.NOTIFY_ON_SCHEDULE_START;
-        delete process.env.NOTIFY_ON_SCHEDULE_END;
-        delete process.env.NOTIFY_ON_WATERING_START;
-        delete process.env.NOTIFY_ON_WATERING_END;
-        delete process.env.NOTIFY_ON_ERROR;
+        flags = { ...DEFAULT_FLAGS };
+        bootNotificationSettingsService({
+            repo: {
+                findSingleton: async () => flags,
+                upsertSingleton: async (row) => { flags = row; },
+            },
+        });
         mockFetch.mockClear();
         mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' } as Response);
         warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
@@ -95,8 +102,8 @@ describe('createNotifier', () => {
     });
 
     it('does not POST schedule events when their flag is set to false', async () => {
-        process.env.NOTIFY_ON_SCHEDULE_START = 'false';
-        process.env.NOTIFY_ON_SCHEDULE_END = 'false';
+        flags.scheduleStart = false;
+        flags.scheduleEnd = false;
         const notifier = createNotifier();
 
         await notifier('schedule-begun', { scheduleNight: '2026-05-15' });
@@ -129,8 +136,8 @@ describe('createNotifier', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('POSTs a watering-started event when NOTIFY_ON_WATERING_START=true', async () => {
-        process.env.NOTIFY_ON_WATERING_START = 'true';
+    it('POSTs a watering-started event when wateringStart is enabled', async () => {
+        flags.wateringStart = true;
         const notifier = createNotifier();
 
         await notifier('watering-started', { zoneName: 'Front Lawn', durationMin: 20 });
@@ -170,8 +177,8 @@ describe('createNotifier', () => {
         expect(warnSpy).toHaveBeenCalled();
     });
 
-    it('treats NOTIFY_ON_ERROR=false as disabled', async () => {
-        process.env.NOTIFY_ON_ERROR = 'false';
+    it('treats the error flag set to false as disabled', async () => {
+        flags.error = false;
         const notifier = createNotifier();
 
         await notifier('error', { errorTitle: 'HA open failed', errorSub: 'Last attempt failed: oops.' });
@@ -179,14 +186,16 @@ describe('createNotifier', () => {
         expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('parses 1/0 as truthy/falsy for the flags', async () => {
-        process.env.NOTIFY_ON_WATERING_START = '1';
-        process.env.NOTIFY_ON_WATERING_END = '0';
+    it('reads the flags live, so flipping one mid-process affects the next event', async () => {
         const notifier = createNotifier();
 
+        // wateringStart starts false (default) — the first fire is suppressed.
         await notifier('watering-started', { zoneName: 'A' });
-        await notifier('watering-ended', { zoneName: 'A' });
+        expect(mockFetch).not.toHaveBeenCalled();
 
+        // Flip the flag on; the next event reads the new value and POSTs.
+        flags.wateringStart = true;
+        await notifier('watering-started', { zoneName: 'A' });
         expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 });

--- a/api/notifications/index.ts
+++ b/api/notifications/index.ts
@@ -2,6 +2,8 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 
+import { getNotificationSettings } from '@/service/notification-settings';
+
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -85,10 +87,16 @@ export type Notifier = (event: NotificationEvent, context?: NotificationContext)
 export const noopNotifier: Notifier = async () => {};
 
 /**
- * Reads notification config from env at construction time and returns a
+ * Reads the HA transport config from env at construction time and returns a
  * `Notifier` closure. If `HA_URL`, `HA_TOKEN`, or `HA_NOTIFY_SERVICE` is
  * missing, returns `noopNotifier` and logs a single `console.warn` so the
  * operator knows notifications are off.
+ *
+ * The per-event on/off toggles are NOT snapshotted here — they live in the
+ * notification-settings singleton row and are read live on each event via
+ * `getNotificationSettings()` (API-101), so a `PATCH /settings/notifications`
+ * takes effect on the very next event without a restart. Requires
+ * `bootNotificationSettingsService` to have run before the first event fires.
  */
 export function createNotifier(): Notifier {
     const url = process.env.HA_URL;
@@ -100,21 +108,14 @@ export function createNotifier(): Notifier {
         return noopNotifier;
     }
 
-    const flags = {
-        scheduleStart: parseBoolean(process.env.NOTIFY_ON_SCHEDULE_START, true),
-        scheduleEnd: parseBoolean(process.env.NOTIFY_ON_SCHEDULE_END, true),
-        wateringStarted: parseBoolean(process.env.NOTIFY_ON_WATERING_START, false),
-        wateringEnded: parseBoolean(process.env.NOTIFY_ON_WATERING_END, false),
-        error: parseBoolean(process.env.NOTIFY_ON_ERROR, true),
-    };
-
     const endpoint = `${url.endsWith('/') ? url.slice(0, -1) : url}/api/services/notify/${service}`;
 
     return async (event, context) => {
+        const flags = await getNotificationSettings();
         if (event === 'schedule-begun' && !flags.scheduleStart) return;
         if (event === 'schedule-ended' && !flags.scheduleEnd) return;
-        if (event === 'watering-started' && !flags.wateringStarted) return;
-        if (event === 'watering-ended' && !flags.wateringEnded) return;
+        if (event === 'watering-started' && !flags.wateringStart) return;
+        if (event === 'watering-ended' && !flags.wateringEnd) return;
         if (event === 'error' && !flags.error) return;
 
         const message = buildMessage(event, context);
@@ -200,12 +201,4 @@ function formatNextIrrigation(
 
 function roundMin(value: number): number {
     return Math.round(value * 10) / 10;
-}
-
-function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
-    if (raw === undefined) return fallback;
-    const lower = raw.trim().toLowerCase();
-    if (lower === 'true' || lower === '1') return true;
-    if (lower === 'false' || lower === '0' || lower === '') return false;
-    return fallback;
 }

--- a/api/repositories/notification-settings/index.ts
+++ b/api/repositories/notification-settings/index.ts
@@ -1,0 +1,65 @@
+import { eq, sql } from 'drizzle-orm';
+import type { Database } from '@/db';
+import { NOTIFICATION_SETTINGS_SINGLETON_ID, notificationSettings } from '@/db/schema';
+import type { NotificationSettingsDto } from '@/models/notification-settings';
+
+export { NOTIFICATION_SETTINGS_SINGLETON_ID };
+
+/**
+ * Raw DB shape of the singleton `notification_settings` row — the five flags,
+ * no audit columns. Identical in shape to `NotificationSettingsDto`; kept as a
+ * distinct alias so the repository boundary stays explicit.
+ */
+export type NotificationSettingsRow = NotificationSettingsDto;
+
+/**
+ * Domain interface backing the notification toggles. Services depend on this
+ * exclusively — they never see Drizzle's chain shape. Tests construct fake
+ * implementations as plain object literals.
+ */
+export interface NotificationSettingsRepository {
+    findSingleton(): Promise<NotificationSettingsRow | null>;
+    upsertSingleton(row: NotificationSettingsRow): Promise<void>;
+}
+
+/**
+ * Builds the production `NotificationSettingsRepository` bound to a Drizzle
+ * client. Mirrors `createSystemStateRepository`: a full-row upsert keyed on the
+ * constant singleton id so writes always target the same row. Factory unit
+ * tests pass a partial Drizzle stub via `as unknown as Database`.
+ *
+ * @param db - Drizzle client.
+ */
+export function createNotificationSettingsRepository(db: Database): NotificationSettingsRepository {
+    return {
+        findSingleton: async () => {
+            const rows = await db
+                .select({
+                    scheduleStart: notificationSettings.scheduleStart,
+                    scheduleEnd: notificationSettings.scheduleEnd,
+                    wateringStart: notificationSettings.wateringStart,
+                    wateringEnd: notificationSettings.wateringEnd,
+                    error: notificationSettings.error,
+                })
+                .from(notificationSettings)
+                .where(eq(notificationSettings.id, NOTIFICATION_SETTINGS_SINGLETON_ID))
+                .limit(1);
+            return rows[0] ?? null;
+        },
+        upsertSingleton: async (row) => {
+            await db
+                .insert(notificationSettings)
+                .values({ id: NOTIFICATION_SETTINGS_SINGLETON_ID, ...row })
+                .onConflictDoUpdate({
+                    target: notificationSettings.id,
+                    set: {
+                        scheduleStart: sql`excluded.schedule_start`,
+                        scheduleEnd: sql`excluded.schedule_end`,
+                        wateringStart: sql`excluded.watering_start`,
+                        wateringEnd: sql`excluded.watering_end`,
+                        error: sql`excluded.error`,
+                    },
+                });
+        },
+    };
+}

--- a/api/service/notification-settings/.test.ts
+++ b/api/service/notification-settings/.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { NotificationSettingsRepository, NotificationSettingsRow } from '@/repositories/notification-settings';
+import { NOTIFICATION_SETTINGS_DEFAULTS } from '@/models/notification-settings';
+import { bootNotificationSettingsService, getNotificationSettings, updateNotificationSettings } from '.';
+
+const ALL_ON: NotificationSettingsRow = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: true,
+    wateringEnd: true,
+    error: true,
+};
+
+function fakeRepo(overrides?: Partial<NotificationSettingsRepository>): NotificationSettingsRepository {
+    return {
+        findSingleton: async () => null,
+        upsertSingleton: async () => {},
+        ...overrides,
+    };
+}
+
+describe('getNotificationSettings', () => {
+    it('returns the stored row as the DTO', async () => {
+        const row: NotificationSettingsRow = { ...NOTIFICATION_SETTINGS_DEFAULTS, wateringStart: true };
+        bootNotificationSettingsService({ repo: fakeRepo({ findSingleton: async () => row }) });
+
+        const result = await getNotificationSettings();
+
+        expect(result).toEqual({
+            scheduleStart: true,
+            scheduleEnd: true,
+            wateringStart: true,
+            wateringEnd: false,
+            error: true,
+        });
+    });
+
+    describe('defensive fallback when the row is missing', () => {
+        let warnSpy: ReturnType<typeof spyOn>;
+
+        beforeEach(() => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it('returns the defaults and warns', async () => {
+            bootNotificationSettingsService({ repo: fakeRepo({ findSingleton: async () => null }) });
+
+            const result = await getNotificationSettings();
+
+            expect(result).toEqual(NOTIFICATION_SETTINGS_DEFAULTS);
+            const messages = warnSpy.mock.calls.map(args => String((args as unknown[])[0]));
+            expect(messages.some(m => m.includes('singleton row missing'))).toBe(true);
+        });
+    });
+});
+
+describe('updateNotificationSettings', () => {
+    it('merges the partial onto the current row and returns the full DTO', async () => {
+        const upsertCalls: NotificationSettingsRow[] = [];
+        bootNotificationSettingsService({
+            repo: fakeRepo({
+                findSingleton: async () => ({ ...ALL_ON }),
+                upsertSingleton: async (row) => { upsertCalls.push(row); },
+            }),
+        });
+
+        const result = await updateNotificationSettings({ wateringStart: false, error: false });
+
+        expect(result).toEqual({
+            scheduleStart: true,
+            scheduleEnd: true,
+            wateringStart: false,
+            wateringEnd: true,
+            error: false,
+        });
+        expect(upsertCalls).toEqual([result]);
+    });
+
+    it('merges onto the defaults when the row is missing', async () => {
+        let warnSpy: ReturnType<typeof spyOn> | null = spyOn(console, 'warn').mockImplementation(() => {});
+        bootNotificationSettingsService({ repo: fakeRepo({ findSingleton: async () => null }) });
+
+        const result = await updateNotificationSettings({ scheduleStart: false });
+
+        expect(result).toEqual({ ...NOTIFICATION_SETTINGS_DEFAULTS, scheduleStart: false });
+        warnSpy.mockRestore();
+        warnSpy = null;
+    });
+
+    it('round-trips through a paired repository (get-after-update sees the new state)', async () => {
+        let stored: NotificationSettingsRow = { ...NOTIFICATION_SETTINGS_DEFAULTS };
+        bootNotificationSettingsService({
+            repo: {
+                findSingleton: async () => stored,
+                upsertSingleton: async (row) => { stored = row; },
+            },
+        });
+
+        const post = await updateNotificationSettings({ wateringEnd: true });
+        const read = await getNotificationSettings();
+
+        expect(post.wateringEnd).toBe(true);
+        expect(read).toEqual(post);
+    });
+});
+
+describe('bootNotificationSettingsService', () => {
+    it('accepts a pre-built repo for testing', async () => {
+        bootNotificationSettingsService({
+            repo: fakeRepo({ findSingleton: async () => ({ ...ALL_ON }) }),
+        });
+
+        const result = await getNotificationSettings();
+
+        expect(result.wateringStart).toBe(true);
+    });
+});

--- a/api/service/notification-settings/index.ts
+++ b/api/service/notification-settings/index.ts
@@ -1,0 +1,68 @@
+import type { Database } from '@/db';
+import {
+    createNotificationSettingsRepository,
+    type NotificationSettingsRepository,
+} from '@/repositories/notification-settings';
+import {
+    NOTIFICATION_SETTINGS_DEFAULTS,
+    type NotificationSettingsDto,
+    type NotificationSettingsPatch,
+} from '@/models/notification-settings';
+
+/**
+ * Input to `bootNotificationSettingsService`. Production passes `{ db }` — the
+ * service builds its own repository via the factory. Tests pass `{ repo }`
+ * with a fake implementation; no Drizzle stub needed.
+ */
+export type BootNotificationSettingsServiceInput =
+    | { db: Database }
+    | { repo: NotificationSettingsRepository };
+
+let repo: NotificationSettingsRepository | null = null;
+
+/**
+ * Wires the notification-settings service to its repository. Call once at
+ * process boot; call again in test `beforeEach` with a fake repository to
+ * isolate behavior. Service functions throw with a clear message if invoked
+ * before this is called.
+ */
+export function bootNotificationSettingsService(input: BootNotificationSettingsServiceInput): void {
+    repo = 'repo' in input ? input.repo : createNotificationSettingsRepository(input.db);
+}
+
+function getRepo(): NotificationSettingsRepository {
+    if (!repo) {
+        throw new Error('Notification-settings service not booted — call bootNotificationSettingsService({ db }) at startup.');
+    }
+    return repo;
+}
+
+/**
+ * Reads the notification toggles. If the singleton row is missing (a bypassed
+ * migration), warns and returns the defaults so the notifier and routes keep
+ * working — operators can tell something is off from the log line. Mirrors
+ * `getSystemState`'s defensive fallback.
+ */
+export async function getNotificationSettings(): Promise<NotificationSettingsDto> {
+    const row = await getRepo().findSingleton();
+    if (!row) {
+        console.warn('notification-settings: singleton row missing — falling back to defaults. Re-run migrations.');
+        return { ...NOTIFICATION_SETTINGS_DEFAULTS };
+    }
+    return row;
+}
+
+/**
+ * Merges `patch` onto the current settings (or the defaults when the row is
+ * missing), persists the full row, and returns the post-update DTO so routes
+ * can echo it back without a re-read.
+ *
+ * @param patch - Any subset of the five flags.
+ */
+export async function updateNotificationSettings(patch: NotificationSettingsPatch): Promise<NotificationSettingsDto> {
+    const current = await getNotificationSettings();
+    const next: NotificationSettingsDto = { ...current, ...patch };
+    await getRepo().upsertSingleton(next);
+    console.log(`notification-settings: updated ${JSON.stringify(patch)}.`);
+    return next;
+}


### PR DESCRIPTION
## Ticket

[API-101](http://192.168.2.100:7123/home/browse/API-101/) Add GET/PATCH /settings/notifications endpoints

## Summary

Moves the five `NOTIFY_*` notification toggles from a startup `process.env` snapshot to a singleton DB row, served by two routes and read live by the notifier. Companion to APP-86 (client settings screen).

- **Schema/migration** — new `notification_settings` singleton table (five `boolean not null` flags + audit columns); migration `0019` creates it and seeds the singleton row with the historical env defaults (`schedule_start`/`schedule_end`/`error` on, `watering_start`/`watering_end` off).
- **Repository + service** — mirrors the `system-state` singleton pattern: `createNotificationSettingsRepository` (`findSingleton`/`upsertSingleton`) + a booted service (`getNotificationSettings`, `updateNotificationSettings(partial)` which merges onto current and echoes the full DTO; defensive defaults + warn when the row is missing).
- **Routes** — `GET /settings/notifications` → full DTO; `PATCH` → accepts any subset, echoes the updated DTO. Unknown keys, non-boolean values, and non-object bodies → 400; empty `{}` is a no-op.
- **Notifier** — `createNotifier()` no longer snapshots flags at construction; it reads them from the service on each event, so a `PATCH` takes effect on the very next notification without a restart.
- **Env deprecation** — dropped the `NOTIFY_ON_*` reads, removed them from `.env.example`, and updated the root `CLAUDE.md` "Local development" snippet. `HA_URL`/`HA_TOKEN`/`HA_NOTIFY_SERVICE` are unchanged (they still gate notifications on/off).

### Tests
- `service/notification-settings/.test.ts` — get/update/merge/fallback/round-trip/boot.
- `api/.test.ts` — GET + PATCH route behaviour (subset echo, empty no-op, unknown-key / non-boolean / non-object → 400).
- `notifications/.test.ts` — refactored to drive flags through the booted service; added a **flip-a-flag-mid-process affects the next event** test.
- Also relaxed an over-strict APP-93 migration test (`0018` "is the newest" → "sorts after `0017`") that this PR's new `0019` migration exposed.
- Full api suite green (986 / 986), type-check clean.

## Notes
- Unblocks APP-86.
- Migration applies via `bun --cwd=./api run db:migrate` (creates the table + seeds the singleton row).