### PR TITLE
[APP-102] Remove the Zones entry from the navigation drawer

### DIFF
--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -234,12 +234,12 @@ describe('RootLayout', () => {
         expect(screen.getByText('active:schedules')).toBeOnTheScreen();
     });
 
-    it('maps /zone/<slug> paths onto the zones nav id (APP-58).', () => {
+    it('falls back to the home nav id for /zone/<slug> paths now that the Zones entry is gone (APP-102).', () => {
         mockUsePathname.mockReturnValue('/zone/north');
 
         render(<RootLayout />);
 
-        expect(screen.getByText('active:zones')).toBeOnTheScreen();
+        expect(screen.getByText('active:home')).toBeOnTheScreen();
     });
 
     it('maps /activity onto the activity nav id (APP-58).', () => {

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -37,15 +37,15 @@ export const irrigoDarkTheme: typeof DarkTheme = {
 
 const ROUTE_FOR_NAV_ID: Record<NavItemId, string> = {
     home: '/',
-    zones: '/zones',
     schedules: '/schedules',
     activity: '/activity',
 };
 
 function pathnameToActiveId(pathname: string): NavItemId {
-    // Strip trailing 's' off each plural id so `/zone/<slug>` resolves to
-    // the same tab as `/zones` (no separate /zone/* schedules / activity
-    // detail routes exist, but the form holds for them too).
+    // Strip trailing 's' off each plural id so a `/schedule/<slug>`-style
+    // detail route would still resolve to the same nav id as its `/schedules`
+    // list. Zone detail pages (`/zone/<slug>`) have no nav id since the Zones
+    // entry was removed (APP-102), so they fall back to 'home'.
     return (Object.keys(ROUTE_FOR_NAV_ID) as NavItemId[]).find(
         id => id !== 'home' && pathname.startsWith('/' + id.replace(/s$/, '')),
     ) ?? 'home';

--- a/app/components/nav-drawer/.test.tsx
+++ b/app/components/nav-drawer/.test.tsx
@@ -43,7 +43,7 @@ const SAMPLE_INACTIVE: ScheduleListItem = {
 };
 
 describe('NavDrawer', () => {
-    it('renders the brand row, four nav items, close button, and footer when visible.', async () => {
+    it('renders the brand row, three nav items, close button, and footer when visible.', async () => {
         const { wrapper, client } = buildApiWrapper();
         client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE, SAMPLE_INACTIVE]);
 
@@ -55,7 +55,7 @@ describe('NavDrawer', () => {
         expect(screen.getByText('Irrigo')).toBeOnTheScreen();
         expect(screen.getByText('Calgary · 740 m²')).toBeOnTheScreen();
         expect(screen.getByLabelText('Home')).toBeOnTheScreen();
-        expect(screen.getByLabelText('Zones')).toBeOnTheScreen();
+        expect(screen.queryByLabelText('Zones')).toBeNull();
         expect(screen.getByLabelText('Schedules')).toBeOnTheScreen();
         expect(screen.getByLabelText('Activity')).toBeOnTheScreen();
         expect(screen.getByLabelText('Close menu')).toBeOnTheScreen();
@@ -85,10 +85,10 @@ describe('NavDrawer', () => {
             <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={onSelect} />,
             { wrapper },
         );
-        fireEvent.press(screen.getByLabelText('Zones'));
+        fireEvent.press(screen.getByLabelText('Activity'));
 
         expect(onSelect).toHaveBeenCalledTimes(1);
-        expect(onSelect).toHaveBeenCalledWith('zones');
+        expect(onSelect).toHaveBeenCalledWith('activity');
     });
 
     it('also calls onClose after a nav item is selected so the drawer dismisses.', () => {
@@ -126,14 +126,13 @@ describe('NavDrawer', () => {
         client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
 
         render(
-            <NavDrawer visible onClose={jest.fn()} activeId='zones' onSelect={jest.fn()} />,
+            <NavDrawer visible onClose={jest.fn()} activeId='activity' onSelect={jest.fn()} />,
             { wrapper },
         );
 
-        expect(screen.getByLabelText('Zones').props.accessibilityState).toMatchObject({ selected: true });
+        expect(screen.getByLabelText('Activity').props.accessibilityState).toMatchObject({ selected: true });
         expect(screen.getByLabelText('Home').props.accessibilityState).toMatchObject({ selected: false });
         expect(screen.getByLabelText('Schedules').props.accessibilityState).toMatchObject({ selected: false });
-        expect(screen.getByLabelText('Activity').props.accessibilityState).toMatchObject({ selected: false });
     });
 
     it('shows the active schedule name and formatted cadence in the footer.', async () => {

--- a/app/components/nav-drawer/index.tsx
+++ b/app/components/nav-drawer/index.tsx
@@ -20,7 +20,7 @@ import { BlurView } from 'expo-blur';
 
 import { BrandGlyph } from '@/components/brand-glyph';
 import { Button } from '@/components/button';
-import { Cal, History, Home as HomeIcon, X, Zone, type IconProps } from '@/components/icons';
+import { Cal, History, Home as HomeIcon, X, type IconProps } from '@/components/icons';
 import { FontFamily } from '@/constants/fonts';
 import { Duration } from '@/constants/motion';
 import { useSchedules } from '@/hooks/schedules';
@@ -42,7 +42,7 @@ const REANIMATED_EASING_STANDARD = Easing.bezier(0.2, 0.7, 0.2, 1);
  * The four nav destinations the drawer offers. Consumers map these to their
  * own routes; the drawer itself stays route-agnostic.
  */
-export type NavItemId = 'home' | 'zones' | 'schedules' | 'activity';
+export type NavItemId = 'home' | 'schedules' | 'activity';
 
 type NavItem = {
     id: NavItemId;
@@ -52,7 +52,6 @@ type NavItem = {
 
 const NAV_ITEMS: readonly NavItem[] = [
     { id: 'home', label: 'Home', icon: HomeIcon },
-    { id: 'zones', label: 'Zones', icon: Zone },
     { id: 'schedules', label: 'Schedules', icon: Cal },
     { id: 'activity', label: 'Activity', icon: History },
 ];
@@ -95,8 +94,8 @@ export type NavDrawerProps = {
 };
 
 /**
- * Irrigo's left-anchored nav drawer. Composes a brand row, four nav items
- * (Home / Zones / Schedules / Activity), and a glow-bordered footer card
+ * Irrigo's left-anchored nav drawer. Composes a brand row, three nav items
+ * (Home / Schedules / Activity), and a glow-bordered footer card
  * surfacing the currently-active schedule with a "Switch profile" shortcut.
  *
  * Controlled component — `visible`, `activeId`, `onClose`, and `onSelect`


### PR DESCRIPTION
## Ticket

[APP-102](http://192.168.2.100:7123/home/browse/APP-102/) — Remove the "Zones" entry from the navigation drawer.

## Summary

- Removed the **Zones** row from `NAV_ITEMS` in `app/components/nav-drawer/index.tsx`, dropped `'zones'` from the exported `NavItemId` union, and cleaned up the now-unused `Zone` icon import.
- Dropped the `zones: '/zones'` entry from `ROUTE_FOR_NAV_ID` in `app/app/_layout.tsx`. The `/zones` route never existed (only `/zone/[slug]` detail pages do), so the entry was a dead link.
- Side effect: visiting a `/zone/<slug>` detail page now resolves the drawer's `activeId` to `'home'` (the fallback) since there's no longer a Zones row to highlight.
- Updated the nav-drawer and layout tests to assert the Zones row is gone, retarget the tap/active-state coverage to Activity, and verify the `/zone/<slug>` → home fallback.