### PR TITLE
[APP-86] Add notification settings screen

### DIFF
--- a/app/api/endpoints/settings/.test.ts
+++ b/app/api/endpoints/settings/.test.ts
@@ -1,0 +1,46 @@
+import { jsonResponse } from '@/api/test-helpers';
+import { getNotificationSettings, patchNotificationSettings } from '.';
+
+const mockFetch = jest.fn();
+
+const DTO = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: false,
+    wateringEnd: false,
+    error: true,
+};
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+function lastCall(): { url: string; init: RequestInit } {
+    const [url, init] = mockFetch.mock.calls.at(-1) as [string, RequestInit];
+    return { url, init };
+}
+
+describe('getNotificationSettings', () => {
+    it('GETs /settings/notifications and returns the DTO unchanged.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(DTO));
+
+        await expect(getNotificationSettings()).resolves.toEqual(DTO);
+        expect(lastCall().url).toBe('http://test.local:9753/settings/notifications');
+    });
+});
+
+describe('patchNotificationSettings', () => {
+    it('PATCHes /settings/notifications with the partial body and returns the updated DTO.', async () => {
+        const updated = { ...DTO, wateringStart: true };
+        mockFetch.mockResolvedValueOnce(jsonResponse(updated));
+
+        await expect(patchNotificationSettings({ wateringStart: true })).resolves.toEqual(updated);
+
+        const { url, init } = lastCall();
+        expect(url).toBe('http://test.local:9753/settings/notifications');
+        expect(init.method).toBe('PATCH');
+        expect(JSON.parse(String(init.body))).toEqual({ wateringStart: true });
+    });
+});

--- a/app/api/endpoints/settings/index.ts
+++ b/app/api/endpoints/settings/index.ts
@@ -1,0 +1,13 @@
+import { apiFetch } from '@/api/client';
+import type { NotificationSettingsDto, NotificationSettingsPatch } from '@/api/types/settings';
+
+export function getNotificationSettings(): Promise<NotificationSettingsDto> {
+    return apiFetch<NotificationSettingsDto>('/settings/notifications');
+}
+
+export function patchNotificationSettings(patch: NotificationSettingsPatch): Promise<NotificationSettingsDto> {
+    return apiFetch<NotificationSettingsDto>('/settings/notifications', {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+    });
+}

--- a/app/api/query-keys.ts
+++ b/app/api/query-keys.ts
@@ -36,4 +36,8 @@ export const keys = {
         all: () => ['health'] as const,
         status: () => ['health', 'status'] as const,
     },
+    settings: {
+        all: () => ['settings'] as const,
+        notifications: () => ['settings', 'notifications'] as const,
+    },
 } as const;

--- a/app/api/types/settings.ts
+++ b/app/api/types/settings.ts
@@ -1,0 +1,20 @@
+/**
+ * Wire-format of the notification toggles returned by
+ * `GET /settings/notifications` and `PATCH /settings/notifications`. Each flag
+ * gates one push-notification event class; all five are required booleans on
+ * the GET/response shape. Server-side defaults: schedule start/end + error on,
+ * watering start/end off.
+ */
+export type NotificationSettingsDto = {
+    scheduleStart: boolean;
+    scheduleEnd: boolean;
+    wateringStart: boolean;
+    wateringEnd: boolean;
+    error: boolean;
+};
+
+/**
+ * Body accepted by `PATCH /settings/notifications` — any subset of the flags.
+ * The route echoes back the full updated {@link NotificationSettingsDto}.
+ */
+export type NotificationSettingsPatch = Partial<NotificationSettingsDto>;

--- a/app/app/_layout.test.tsx
+++ b/app/app/_layout.test.tsx
@@ -250,6 +250,14 @@ describe('RootLayout', () => {
         expect(screen.getByText('active:activity')).toBeOnTheScreen();
     });
 
+    it('maps /settings onto the settings nav id (APP-86).', () => {
+        mockUsePathname.mockReturnValue('/settings');
+
+        render(<RootLayout />);
+
+        expect(screen.getByText('active:settings')).toBeOnTheScreen();
+    });
+
     it('falls back to the home nav id for unknown pathnames (APP-58).', () => {
         mockUsePathname.mockReturnValue('/unknown-route');
 
@@ -286,8 +294,11 @@ describe('RootLayout', () => {
         // to verify routing without driving the real drawer animation.
         const drawerProps = mockDrawerProps.mock.calls.at(-1)?.[0] as { onSelect: (id: string) => void };
         drawerProps.onSelect('schedules');
-
         expect(mockRouterPush).toHaveBeenCalledWith('/schedules');
+
+        // The Settings entry added in APP-86 routes to /settings.
+        drawerProps.onSelect('settings');
+        expect(mockRouterPush).toHaveBeenCalledWith('/settings');
     });
 
     it('collapses the drawer when its onClose handler fires (APP-58).', () => {

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -39,6 +39,7 @@ const ROUTE_FOR_NAV_ID: Record<NavItemId, string> = {
     home: '/',
     schedules: '/schedules',
     activity: '/activity',
+    settings: '/settings',
 };
 
 function pathnameToActiveId(pathname: string): NavItemId {

--- a/app/app/settings.test.tsx
+++ b/app/app/settings.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import type { NotificationSettingsDto } from '@/api/types/settings';
+
+jest.mock('react-native-safe-area-context', () => ({
+    useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
+}));
+
+import SettingsScreen from './settings';
+
+const DTO: NotificationSettingsDto = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: false,
+    wateringEnd: false,
+    error: true,
+};
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('SettingsScreen route', () => {
+    it('resolves the /settings route and renders the Settings screen body.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse(DTO));
+
+        render(<SettingsScreen />, { wrapper: buildApiWrapper().wrapper });
+
+        // The route renders the real NotificationSettingsView (not a dead-end):
+        // the screen title and a toggle row both appear.
+        expect(screen.getByText('Settings')).toBeOnTheScreen();
+        await waitFor(() => expect(screen.getByLabelText('Schedule started')).toBeOnTheScreen());
+    });
+
+    it('fetches the notification settings from /settings/notifications when the route mounts.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse(DTO));
+
+        render(<SettingsScreen />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => {
+            const urls = mockFetch.mock.calls.map(([url]) => String(url));
+            expect(urls).toContain('http://test.local:9753/settings/notifications');
+        });
+    });
+});

--- a/app/app/settings.tsx
+++ b/app/app/settings.tsx
@@ -1,0 +1,29 @@
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { NotificationSettingsView } from '@/components/notification-settings-view';
+import { RefreshableScrollView } from '@/components/refreshable-scroll-view';
+
+/**
+ * Settings route — the destination for the drawer's Settings entry. Exposes
+ * the notification toggles. `NotificationSettingsView` owns no scroll container
+ * by design, so the route wraps it in a `RefreshableScrollView` (the
+ * screen-level pull-to-refresh convention). File-based route at `/settings`
+ * (APP-86).
+ */
+export default function SettingsScreen() {
+    const insets = useSafeAreaInsets();
+    return (
+        <RefreshableScrollView
+            contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 32 }]}
+        >
+            <NotificationSettingsView />
+        </RefreshableScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    content: {
+        paddingTop: 16,
+    },
+});

--- a/app/components/icons.test.tsx
+++ b/app/components/icons.test.tsx
@@ -16,6 +16,7 @@ import {
     Pause,
     Play,
     Refresh,
+    Settings,
     X,
     Zone,
 } from './icons';
@@ -36,6 +37,7 @@ const icons: ReadonlyArray<readonly [string, ComponentType<IconProps>]> = [
     ['Menu', Menu],
     ['X', X],
     ['Check', Check],
+    ['Settings', Settings],
 ];
 
 describe('Irrigo icons', () => {

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -156,3 +156,12 @@ export function Help({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth =
         </Svg>
     );
 }
+
+export function Settings({ size = DEFAULT_SIZE, color = DEFAULT_COLOR, strokeWidth = 1.4, accessibilityLabel }: IconProps) {
+    return (
+        <Svg width={size} height={size} viewBox='0 0 16 16' fill='none' stroke={color} strokeWidth={strokeWidth} strokeLinecap='round' strokeLinejoin='round' accessibilityLabel={accessibilityLabel}>
+            <Circle cx={8} cy={8} r={2.5} />
+            <Path d='M8 4.6 V2 M8 11.4 V14 M11.4 8 H14 M4.6 8 H2 M10.4 5.6 L12.2 3.8 M5.6 5.6 L3.8 3.8 M10.4 10.4 L12.2 12.2 M5.6 10.4 L3.8 12.2' />
+        </Svg>
+    );
+}

--- a/app/components/nav-drawer/.test.tsx
+++ b/app/components/nav-drawer/.test.tsx
@@ -43,7 +43,7 @@ const SAMPLE_INACTIVE: ScheduleListItem = {
 };
 
 describe('NavDrawer', () => {
-    it('renders the brand row, three nav items, close button, and footer when visible.', async () => {
+    it('renders the brand row, four nav items, close button, and footer when visible.', async () => {
         const { wrapper, client } = buildApiWrapper();
         client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE, SAMPLE_INACTIVE]);
 
@@ -58,6 +58,7 @@ describe('NavDrawer', () => {
         expect(screen.queryByLabelText('Zones')).toBeNull();
         expect(screen.getByLabelText('Schedules')).toBeOnTheScreen();
         expect(screen.getByLabelText('Activity')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Settings')).toBeOnTheScreen();
         expect(screen.getByLabelText('Close menu')).toBeOnTheScreen();
         await waitFor(() => expect(screen.getByText('Maintenance')).toBeOnTheScreen());
     });
@@ -89,6 +90,21 @@ describe('NavDrawer', () => {
 
         expect(onSelect).toHaveBeenCalledTimes(1);
         expect(onSelect).toHaveBeenCalledWith('activity');
+    });
+
+    it('calls onSelect with the settings id when the Settings item is tapped.', () => {
+        const onSelect = jest.fn();
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.schedules.list(), [SAMPLE_ACTIVE]);
+
+        render(
+            <NavDrawer visible onClose={jest.fn()} activeId='home' onSelect={onSelect} />,
+            { wrapper },
+        );
+        fireEvent.press(screen.getByLabelText('Settings'));
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toHaveBeenCalledWith('settings');
     });
 
     it('also calls onClose after a nav item is selected so the drawer dismisses.', () => {

--- a/app/components/nav-drawer/index.tsx
+++ b/app/components/nav-drawer/index.tsx
@@ -20,7 +20,7 @@ import { BlurView } from 'expo-blur';
 
 import { BrandGlyph } from '@/components/brand-glyph';
 import { Button } from '@/components/button';
-import { Cal, History, Home as HomeIcon, X, type IconProps } from '@/components/icons';
+import { Cal, History, Home as HomeIcon, Settings, X, type IconProps } from '@/components/icons';
 import { FontFamily } from '@/constants/fonts';
 import { Duration } from '@/constants/motion';
 import { useSchedules } from '@/hooks/schedules';
@@ -42,7 +42,7 @@ const REANIMATED_EASING_STANDARD = Easing.bezier(0.2, 0.7, 0.2, 1);
  * The four nav destinations the drawer offers. Consumers map these to their
  * own routes; the drawer itself stays route-agnostic.
  */
-export type NavItemId = 'home' | 'schedules' | 'activity';
+export type NavItemId = 'home' | 'schedules' | 'activity' | 'settings';
 
 type NavItem = {
     id: NavItemId;
@@ -54,6 +54,7 @@ const NAV_ITEMS: readonly NavItem[] = [
     { id: 'home', label: 'Home', icon: HomeIcon },
     { id: 'schedules', label: 'Schedules', icon: Cal },
     { id: 'activity', label: 'Activity', icon: History },
+    { id: 'settings', label: 'Settings', icon: Settings },
 ];
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
@@ -94,8 +95,8 @@ export type NavDrawerProps = {
 };
 
 /**
- * Irrigo's left-anchored nav drawer. Composes a brand row, three nav items
- * (Home / Schedules / Activity), and a glow-bordered footer card
+ * Irrigo's left-anchored nav drawer. Composes a brand row, four nav items
+ * (Home / Schedules / Activity / Settings), and a glow-bordered footer card
  * surfacing the currently-active schedule with a "Switch profile" shortcut.
  *
  * Controlled component — `visible`, `activeId`, `onClose`, and `onSelect`

--- a/app/components/notification-settings-view/.test.tsx
+++ b/app/components/notification-settings-view/.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import { keys } from '@/api/query-keys';
+import type { NotificationSettingsDto } from '@/api/types/settings';
+import { NotificationSettingsView } from '.';
+
+const mockFetch = jest.fn();
+
+const DTO: NotificationSettingsDto = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: false,
+    wateringEnd: false,
+    error: true,
+};
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('NotificationSettingsView', () => {
+    it('renders the five notification toggles reflecting the fetched values.', async () => {
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.settings.notifications(), DTO);
+
+        render(<NotificationSettingsView />, { wrapper });
+
+        expect(screen.getByText('Settings')).toBeOnTheScreen();
+        // The on flags (schedule start/end + error) report checked; the off
+        // flags (watering start/end) report unchecked.
+        expect(screen.getByLabelText('Schedule started').props.accessibilityState).toMatchObject({ checked: true });
+        expect(screen.getByLabelText('Schedule ended').props.accessibilityState).toMatchObject({ checked: true });
+        expect(screen.getByLabelText('Errors').props.accessibilityState).toMatchObject({ checked: true });
+        expect(screen.getByLabelText('Watering started').props.accessibilityState).toMatchObject({ checked: false });
+        expect(screen.getByLabelText('Watering ended').props.accessibilityState).toMatchObject({ checked: false });
+    });
+
+    it('PATCHes the tapped flag and flips it optimistically.', async () => {
+        // PATCH never resolves so the optimistic flip is the only state change.
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.settings.notifications(), DTO);
+
+        render(<NotificationSettingsView />, { wrapper });
+
+        fireEvent.press(screen.getByLabelText('Watering started'));
+
+        // The PATCH carries only the tapped field (the on-mount GET has no
+        // body, so only consider calls that actually sent one).
+        await waitFor(() => {
+            const bodies = mockFetch.mock.calls
+                .map(([, init]) => (init as RequestInit | undefined)?.body)
+                .filter((body): body is string => typeof body === 'string')
+                .map(body => JSON.parse(body));
+            expect(bodies).toContainEqual({ wateringStart: true });
+        });
+        // …and the toggle flips on instantly via the optimistic cache write.
+        await waitFor(() =>
+            expect(screen.getByLabelText('Watering started').props.accessibilityState).toMatchObject({ checked: true }),
+        );
+    });
+
+    it('shows a loading placeholder while the settings query is pending.', () => {
+        // Fetch never resolves → the query stays pending.
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        render(<NotificationSettingsView />, { wrapper: buildApiWrapper().wrapper });
+
+        expect(screen.getByText('Fetching notification settings…')).toBeOnTheScreen();
+    });
+
+    it('shows an error message when the settings query fails.', async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+
+        render(<NotificationSettingsView />, { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() =>
+            expect(screen.getByText('Failed to load notification settings.')).toBeOnTheScreen(),
+        );
+    });
+});

--- a/app/components/notification-settings-view/index.tsx
+++ b/app/components/notification-settings-view/index.tsx
@@ -1,0 +1,155 @@
+import { Fragment } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { NotificationSettingsDto } from '@/api/types/settings';
+import { Card } from '@/components/card';
+import { Toggle } from '@/components/toggle';
+import { FontFamily } from '@/constants/fonts';
+import { useNotificationSettings, useUpdateNotificationSettings } from '@/hooks/settings';
+import config from '@/tailwind.config';
+
+const colors = config.theme.extend.colors;
+
+/**
+ * The five notification toggles in display order. `field` is the
+ * `NotificationSettingsDto` key PATCHed back; `label` is the visible row text
+ * (and the toggle's accessibility label); `description` is the muted subtitle.
+ */
+const ROWS: ReadonlyArray<{ field: keyof NotificationSettingsDto; label: string; description: string }> = [
+    { field: 'scheduleStart', label: 'Schedule started', description: `When a night's irrigation run begins.` },
+    { field: 'scheduleEnd', label: 'Schedule ended', description: `When a night's irrigation run finishes.` },
+    { field: 'wateringStart', label: 'Watering started', description: 'When an individual zone starts watering.' },
+    { field: 'wateringEnd', label: 'Watering ended', description: 'When an individual zone stops watering.' },
+    { field: 'error', label: 'Errors', description: 'When something goes wrong during a run.' },
+];
+
+/**
+ * Smart container for the Settings screen. Reads the notification toggles via
+ * `useNotificationSettings()` and PATCHes each flag back the moment its toggle
+ * flips (`useUpdateNotificationSettings()` applies the change optimistically,
+ * so the thumb moves instantly). Drop-in for any screen route — the caller
+ * wraps it in its own scroll container.
+ */
+export function NotificationSettingsView() {
+    const settings = useNotificationSettings();
+    const update = useUpdateNotificationSettings();
+
+    if (settings.isPending) {
+        return (
+            <View style={styles.container}>
+                <Text style={styles.eyebrow}>Preferences · loading</Text>
+                <Text style={styles.title}>Settings</Text>
+                <Text style={styles.placeholder}>Fetching notification settings…</Text>
+            </View>
+        );
+    }
+
+    if (settings.isError || settings.data === undefined) {
+        return (
+            <View style={styles.container}>
+                <Text style={styles.eyebrow}>Preferences · unavailable</Text>
+                <Text style={styles.title}>Settings</Text>
+                <Text style={styles.errorText}>Failed to load notification settings.</Text>
+            </View>
+        );
+    }
+
+    const values = settings.data;
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.eyebrow}>Preferences · notifications</Text>
+            <Text style={styles.title}>Settings</Text>
+
+            <Card>
+                <Text style={styles.cardHeading}>Notifications</Text>
+                {ROWS.map((row, index) => (
+                    <Fragment key={row.field}>
+                        {index > 0 && <View style={styles.divider} />}
+                        <View style={styles.row}>
+                            <View style={styles.rowText}>
+                                <Text style={styles.rowLabel}>{row.label}</Text>
+                                <Text style={styles.rowDescription}>{row.description}</Text>
+                            </View>
+                            <Toggle
+                                value={values[row.field]}
+                                onValueChange={next => update.mutate({ [row.field]: next })}
+                                accessibilityLabel={row.label}
+                            />
+                        </View>
+                    </Fragment>
+                ))}
+            </Card>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 18,
+        paddingHorizontal: 20,
+    },
+    eyebrow: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 11,
+        lineHeight: 13,
+        letterSpacing: 1.54,
+        color: colors['fg-muted'],
+        textTransform: 'uppercase',
+    },
+    title: {
+        fontFamily: FontFamily.displayBold,
+        fontSize: 28,
+        lineHeight: 28,
+        letterSpacing: -0.7,
+        color: colors.fg,
+    },
+    placeholder: {
+        fontFamily: FontFamily.sans,
+        fontSize: 14,
+        lineHeight: 20,
+        color: colors['fg-muted'],
+    },
+    errorText: {
+        fontFamily: FontFamily.sans,
+        fontSize: 14,
+        lineHeight: 20,
+        color: colors.warn,
+    },
+    cardHeading: {
+        fontFamily: FontFamily.sansSemibold,
+        fontSize: 11,
+        lineHeight: 11,
+        letterSpacing: 1.54,
+        color: colors.accent,
+        textTransform: 'uppercase',
+        marginBottom: 4,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 16,
+        paddingVertical: 12,
+    },
+    rowText: {
+        flex: 1,
+        gap: 2,
+    },
+    rowLabel: {
+        fontFamily: FontFamily.sansMedium,
+        fontSize: 15,
+        lineHeight: 18,
+        color: colors.fg,
+    },
+    rowDescription: {
+        fontFamily: FontFamily.sans,
+        fontSize: 12,
+        lineHeight: 16,
+        color: colors['fg-muted'],
+    },
+    divider: {
+        height: 1,
+        backgroundColor: colors.border,
+    },
+});

--- a/app/hooks/settings/.test.tsx
+++ b/app/hooks/settings/.test.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { buildApiWrapper, jsonResponse } from '@/api/test-utils';
+import { keys } from '@/api/query-keys';
+import type { NotificationSettingsDto } from '@/api/types/settings';
+import { useNotificationSettings, useUpdateNotificationSettings } from '.';
+
+const mockFetch = jest.fn();
+
+const DTO: NotificationSettingsDto = {
+    scheduleStart: true,
+    scheduleEnd: true,
+    wateringStart: false,
+    wateringEnd: false,
+    error: true,
+};
+
+beforeEach(() => {
+    (global as { fetch: typeof fetch }).fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'http://test.local:9753';
+});
+
+describe('useNotificationSettings', () => {
+    it('fetches and exposes the notification settings.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse(DTO));
+
+        const { result } = renderHook(() => useNotificationSettings(), { wrapper: buildApiWrapper().wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual(DTO);
+    });
+});
+
+describe('useUpdateNotificationSettings', () => {
+    it('PATCHes /settings/notifications with the partial body.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ...DTO, wateringStart: true }));
+
+        const { result } = renderHook(() => useUpdateNotificationSettings(), { wrapper: buildApiWrapper().wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ wateringStart: true });
+        });
+
+        const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://test.local:9753/settings/notifications');
+        expect(init.method).toBe('PATCH');
+        expect(JSON.parse(String(init.body))).toEqual({ wateringStart: true });
+    });
+
+    it('writes the optimistic flag into the cache synchronously on mutate.', async () => {
+        // Fetch never resolves so the mutation stays in-flight; the optimistic
+        // cache write should be observable immediately.
+        mockFetch.mockImplementation(() => new Promise(() => {}));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.settings.notifications(), DTO);
+
+        const { result } = renderHook(() => useUpdateNotificationSettings(), { wrapper });
+
+        act(() => {
+            result.current.mutate({ wateringStart: true });
+        });
+
+        await waitFor(() => {
+            const cached = client.getQueryData<NotificationSettingsDto>(keys.settings.notifications());
+            expect(cached?.wateringStart).toBe(true);
+            // Other flags untouched by the partial merge.
+            expect(cached?.scheduleStart).toBe(true);
+        });
+    });
+
+    it('rolls the cache back to the previous value when the mutation rejects.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.settings.notifications(), DTO);
+
+        const { result } = renderHook(() => useUpdateNotificationSettings(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ wateringStart: true }).catch(() => undefined);
+        });
+
+        expect(result.current.isError).toBe(true);
+        expect(client.getQueryData(keys.settings.notifications())).toEqual(DTO);
+    });
+
+    it('invalidates the notification-settings query after a successful PATCH.', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ ...DTO, error: false }));
+
+        const { wrapper, client } = buildApiWrapper();
+        client.setQueryData(keys.settings.notifications(), DTO);
+
+        const { result } = renderHook(() => useUpdateNotificationSettings(), { wrapper });
+
+        await act(async () => {
+            await result.current.mutateAsync({ error: false });
+        });
+
+        expect(client.getQueryState(keys.settings.notifications())?.isInvalidated).toBe(true);
+    });
+});

--- a/app/hooks/settings/index.ts
+++ b/app/hooks/settings/index.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient, type UseMutationResult, type UseQueryResult } from '@tanstack/react-query';
+import type { ApiError } from '@/api/client';
+import { getNotificationSettings, patchNotificationSettings } from '@/api/endpoints/settings';
+import { keys } from '@/api/query-keys';
+import type { NotificationSettingsDto, NotificationSettingsPatch } from '@/api/types/settings';
+
+/**
+ * Returns the five notification toggles for the Settings screen.
+ */
+export function useNotificationSettings(): UseQueryResult<NotificationSettingsDto, ApiError> {
+    return useQuery<NotificationSettingsDto, ApiError>({
+        queryKey: keys.settings.notifications(),
+        queryFn: getNotificationSettings,
+    });
+}
+
+type OptimisticContext = { previous: NotificationSettingsDto | undefined };
+
+/**
+ * PATCHes one or more notification flags. The cache update is optimistic:
+ * `onMutate` merges the requested partial into the cached DTO so the tapped
+ * toggle flips the moment the user taps. If the server rejects the PATCH,
+ * `onError` rolls the cache back to the snapshot. `onSettled` invalidates the
+ * notification-settings query for both success and failure paths so the cache
+ * reconciles with the authoritative server response.
+ */
+export function useUpdateNotificationSettings(): UseMutationResult<NotificationSettingsDto, ApiError, NotificationSettingsPatch, OptimisticContext> {
+    const queryClient = useQueryClient();
+    return useMutation<NotificationSettingsDto, ApiError, NotificationSettingsPatch, OptimisticContext>({
+        mutationFn: (patch: NotificationSettingsPatch) => patchNotificationSettings(patch),
+        onMutate: async patch => {
+            // Cancel any in-flight refetch so it can't resolve after the
+            // optimistic write and clobber it with stale server data.
+            await queryClient.cancelQueries({ queryKey: keys.settings.notifications() });
+            const previous = queryClient.getQueryData<NotificationSettingsDto>(keys.settings.notifications());
+            if (previous !== undefined) {
+                queryClient.setQueryData<NotificationSettingsDto>(keys.settings.notifications(), {
+                    ...previous,
+                    ...patch,
+                });
+            }
+            return { previous };
+        },
+        onError: (_err, _patch, context) => {
+            if (context?.previous !== undefined) {
+                queryClient.setQueryData(keys.settings.notifications(), context.previous);
+            }
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({ queryKey: keys.settings.all() });
+        },
+    });
+}


### PR DESCRIPTION
## Ticket

[APP-86](http://192.168.2.100:7123/home/browse/APP-86/) — Add notification settings screen.

Backed by [API-101](http://192.168.2.100:7123/home/browse/API-101/) (Done), which added `GET`/`PATCH /settings/notifications`.

## Summary

- **API layer** — new `NotificationSettingsDto` / `NotificationSettingsPatch` types, `getNotificationSettings` / `patchNotificationSettings` endpoint wrappers, `settings` query keys, and `useNotificationSettings` / `useUpdateNotificationSettings` hooks. The mutation applies each flag change optimistically (snapshot → optimistic write → rollback on error → invalidate on settle), mirroring `useSetSystemEnabled`.
- **Settings screen** — new `/settings` route wrapping a `NotificationSettingsView` (eyebrow + title + a Notifications card of five labelled `Toggle` rows). The screen reads the flags on mount and PATCHes the single tapped flag back immediately, flipping instantly via the optimistic cache write. Loading + error states mirror the schedules screen.
- **Entry point** — added a **Settings** item (new gear icon) to the nav drawer, wired to `/settings` in the layout's route map.

## Tests

- New suites for the endpoints, hooks, view, and route (16 new tests): GET/PATCH paths + body, optimistic write, rollback, invalidation; toggles render from data, optimistic flip on tap, loading/error; route mounts + fetches.
- Updated nav-drawer / icons / layout tests: four nav items, Settings renders + selects, `/settings` maps to the settings nav id and pushes the route.
- Full app suite green: 702 passed.