### PR TITLE
[API-103] General Expo push channel + per-category gating

### DIFF
--- a/api/service/push-tokens/.test.ts
+++ b/api/service/push-tokens/.test.ts
@@ -5,17 +5,35 @@ import type {
     ExpoPushReceiptId,
     ExpoPushTicket,
 } from 'expo-server-sdk';
+import { NOTIFICATION_SETTINGS_DEFAULTS, type NotificationSettingsDto } from '@/models/notification-settings';
 import type { PushAlertEvent } from '@/models/push-token';
 import type { PushToken, PushTokensRepository } from '@/repositories/push-tokens';
+import { bootNotificationSettingsService } from '@/service/notification-settings';
 import {
     bootPushTokensService,
     dispatchAlertPush,
     pollReceipts,
     registerPushToken,
+    sendCategoryPush,
+    sendPushToAll,
     unregisterPushToken,
     type ExpoPushClient,
+    type NotificationCategory,
     type SchedulePoll,
 } from '.';
+
+/**
+ * Boots the notification-settings service with a fake singleton row so the
+ * gated push paths (`sendCategoryPush`, `dispatchAlertPush`) can read flags.
+ * Defaults to {@link NOTIFICATION_SETTINGS_DEFAULTS} (error on), so existing
+ * dispatch assertions hold unless a test overrides a flag.
+ */
+function bootSettings(overrides?: Partial<NotificationSettingsDto>): void {
+    const row: NotificationSettingsDto = { ...NOTIFICATION_SETTINGS_DEFAULTS, ...overrides };
+    bootNotificationSettingsService({
+        repo: { findSingleton: async () => row, upsertSingleton: async () => {} },
+    });
+}
 
 const NOW = new Date('2026-05-22T12:00:00.000Z');
 const CHUNK_LIMIT = 100;
@@ -205,6 +223,9 @@ describe('dispatchAlertPush', () => {
 
     beforeEach(() => {
         warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        // dispatchAlertPush now reads flags.error before sending; default the
+        // singleton to error-on so the existing send assertions below hold.
+        bootSettings();
     });
 
     afterEach(() => {
@@ -407,6 +428,162 @@ describe('dispatchAlertPush', () => {
         expect(repoState.deletes).toEqual(['tok-100']);
         expect(captured).toHaveLength(1);
     });
+
+    it('does not send (or poll) when the error toggle is off', async () => {
+        bootSettings({ error: false });
+        const { repo } = fakeRepo([buildToken()]);
+        const { expo, state: expoState } = fakeExpoClient();
+        const { schedulePoll, captured } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await dispatchAlertPush(buildAlertEvent());
+
+        expect(expoState.sendChunks).toEqual([]);
+        expect(captured).toEqual([]);
+    });
+
+    it('sends when the error toggle is on', async () => {
+        bootSettings({ error: true });
+        const { repo } = fakeRepo([buildToken()]);
+        const { expo, state: expoState } = fakeExpoClient();
+        const { schedulePoll } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await dispatchAlertPush(buildAlertEvent());
+
+        expect(expoState.sendChunks).toHaveLength(1);
+    });
+});
+
+describe('sendPushToAll', () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('does nothing and calls no SDK methods when no tokens are registered', async () => {
+        const { repo } = fakeRepo([]);
+        const { expo, state: expoState } = fakeExpoClient();
+        const { schedulePoll, captured } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await sendPushToAll({ title: 'T', body: 'B' });
+
+        expect(expoState.sendChunks).toEqual([]);
+        expect(captured).toEqual([]);
+    });
+
+    it('builds one message per token with the given title, body, data, and priority', async () => {
+        const { repo } = fakeRepo([
+            buildToken({ token: 'tok-1' }),
+            buildToken({ id: 'pt-2', token: 'tok-2' }),
+        ]);
+        const { expo, state: expoState } = fakeExpoClient();
+        const { schedulePoll } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await sendPushToAll({
+            title: 'Schedule started',
+            body: 'Tonight run began',
+            data: { category: 'scheduleStart' },
+            priority: 'high',
+        });
+
+        expect(expoState.sendChunks).toHaveLength(1);
+        const sent = expoState.sendChunks[0]!;
+        expect(sent.map(m => m.to)).toEqual(['tok-1', 'tok-2']);
+        expect(sent[0]!.title).toBe('Schedule started');
+        expect(sent[0]!.body).toBe('Tonight run began');
+        expect(sent[0]!.data).toEqual({ category: 'scheduleStart' });
+        expect(sent[0]!.priority).toBe('high');
+    });
+
+    it(`defaults priority to 'default' and omits data when not supplied`, async () => {
+        const { repo } = fakeRepo([buildToken()]);
+        const { expo, state: expoState } = fakeExpoClient();
+        const { schedulePoll } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await sendPushToAll({ title: 'T', body: 'B' });
+
+        const msg = expoState.sendChunks[0]![0]!;
+        expect(msg.priority).toBe('default');
+        expect('data' in msg).toBe(false);
+    });
+
+    it('chunks 150 tokens into a 100-token send and a 50-token send', async () => {
+        const rows = Array.from({ length: 150 }, (_, i) => buildToken({ id: `pt-${i}`, token: `tok-${i}` }));
+        const { repo } = fakeRepo(rows);
+        const { expo, state: expoState } = fakeExpoClient();
+        const { schedulePoll } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await sendPushToAll({ title: 'T', body: 'B' });
+
+        expect(expoState.sendChunks).toHaveLength(2);
+        expect(expoState.sendChunks[0]!).toHaveLength(100);
+        expect(expoState.sendChunks[1]!).toHaveLength(50);
+    });
+
+    it('prunes tokens flagged DeviceNotRegistered and schedules a poll for ok tickets', async () => {
+        const { repo, state: repoState } = fakeRepo([
+            buildToken({ id: 'pt-A', token: 'tok-A' }),
+            buildToken({ id: 'pt-B', token: 'tok-B' }),
+        ]);
+        const { expo, state: expoState } = fakeExpoClient();
+        expoState.sendResults = [[
+            { status: 'ok', id: 'ticket-A' },
+            { status: 'error', message: 'gone', details: { error: 'DeviceNotRegistered' } },
+        ]];
+        const { schedulePoll, captured } = recordSchedulePoll();
+        bootPushTokensService({ repo, expo, schedulePoll });
+
+        await sendPushToAll({ title: 'T', body: 'B' });
+
+        expect(repoState.deletes).toEqual(['tok-B']);
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.delayMs).toBe(15_000);
+    });
+});
+
+describe('sendCategoryPush', () => {
+    const CATEGORIES: NotificationCategory[] = ['scheduleStart', 'scheduleEnd', 'wateringStart', 'wateringEnd', 'error'];
+
+    for (const category of CATEGORIES) {
+        it(`sends to all tokens when the ${category} toggle is on`, async () => {
+            const overrides: Partial<NotificationSettingsDto> = {};
+            overrides[category] = true;
+            bootSettings(overrides);
+            const { repo } = fakeRepo([buildToken()]);
+            const { expo, state: expoState } = fakeExpoClient();
+            const { schedulePoll } = recordSchedulePoll();
+            bootPushTokensService({ repo, expo, schedulePoll });
+
+            await sendCategoryPush(category, { title: 'T', body: 'B' });
+
+            expect(expoState.sendChunks).toHaveLength(1);
+        });
+
+        it(`suppresses the send (no SDK call, no poll) when the ${category} toggle is off`, async () => {
+            const overrides: Partial<NotificationSettingsDto> = {};
+            overrides[category] = false;
+            bootSettings(overrides);
+            const { repo } = fakeRepo([buildToken()]);
+            const { expo, state: expoState } = fakeExpoClient();
+            const { schedulePoll, captured } = recordSchedulePoll();
+            bootPushTokensService({ repo, expo, schedulePoll });
+
+            await sendCategoryPush(category, { title: 'T', body: 'B' });
+
+            expect(expoState.sendChunks).toEqual([]);
+            expect(captured).toEqual([]);
+        });
+    }
 });
 
 describe('pollReceipts', () => {

--- a/api/service/push-tokens/index.ts
+++ b/api/service/push-tokens/index.ts
@@ -5,11 +5,13 @@ import Expo, {
     type ExpoPushTicket,
 } from 'expo-server-sdk';
 import type { Database } from '@/db';
+import type { NotificationSettingsDto } from '@/models/notification-settings';
 import type { PushAlertEvent, PushRegistration } from '@/models/push-token';
 import {
     createPushTokensRepository,
     type PushTokensRepository,
 } from '@/repositories/push-tokens';
+import { getNotificationSettings } from '@/service/notification-settings';
 
 const RECEIPT_POLL_DELAY_MS = 15_000;
 
@@ -104,9 +106,29 @@ export async function unregisterPushToken(token: string): Promise<void> {
 }
 
 /**
- * Fires an Expo Push to every registered token for a single alert. Called by
- * the alerter on insert (a brand-new alert) — dedup-updates suppress it,
- * matching the existing "loud once, quiet until acked" semantics.
+ * Self-contained content of a single push notification, fanned out unchanged
+ * to every registered device by `sendPushToAll`. `data` rides along as the
+ * Expo `data` payload (the client routes on it); `priority` maps to Expo's
+ * delivery priority and defaults to `'default'`.
+ */
+export type PushMessageContent = {
+    title: string;
+    body: string;
+    data?: Record<string, unknown>;
+    priority?: 'default' | 'high';
+};
+
+/**
+ * The notification categories the operator can toggle. Each is exactly a key
+ * of `NotificationSettingsDto`, so gating is a single flag lookup — see
+ * `sendCategoryPush`.
+ */
+export type NotificationCategory = keyof NotificationSettingsDto;
+
+/**
+ * Fires one Expo Push to every registered token, carrying the given content.
+ * The general send primitive underlying both the gated `sendCategoryPush` and
+ * the alert dispatcher.
  *
  * Best-effort throughout: chunk-level send failures are logged at `warn` and
  * the remaining chunks still attempt to deliver. Tickets are scanned for
@@ -115,24 +137,18 @@ export async function unregisterPushToken(token: string): Promise<void> {
  * receipt poll — Expo surfaces most `DeviceNotRegistered` outcomes there, not
  * in the immediate ticket response.
  */
-export async function dispatchAlertPush(event: PushAlertEvent): Promise<void> {
+export async function sendPushToAll(content: PushMessageContent): Promise<void> {
     const tokens = await getRepo().listAll();
     if (tokens.length === 0) return;
 
     const client = getExpo();
 
-    const data: Record<string, unknown> = {
-        alertId: event.alertId,
-        class: event.class,
-    };
-    if (event.zoneId !== null) data['zoneId'] = event.zoneId;
-
     const messages: ExpoPushMessage[] = tokens.map(t => ({
         to: t.token,
-        title: event.title,
-        body: event.sub ?? event.title,
-        data,
-        priority: event.tone === 'danger' ? 'high' : 'default',
+        title: content.title,
+        body: content.body,
+        ...(content.data !== undefined ? { data: content.data } : {}),
+        priority: content.priority ?? 'default',
     }));
 
     const chunks = client.chunkPushNotifications(messages);
@@ -184,6 +200,44 @@ export async function dispatchAlertPush(event: PushAlertEvent): Promise<void> {
             console.warn('push: unhandled receipt poll failure; swallowing.', err);
         });
     }, RECEIPT_POLL_DELAY_MS);
+}
+
+/**
+ * Sends a push for `category`, gated on the live `notification_settings` flag
+ * of the same name (API-101). When the toggle is off the push is suppressed —
+ * logged, never sent. The single entry point producers should use so the
+ * operator's per-event toggles take effect on the very next event without a
+ * restart. Requires `bootNotificationSettingsService` to have run.
+ */
+export async function sendCategoryPush(category: NotificationCategory, content: PushMessageContent): Promise<void> {
+    const flags = await getNotificationSettings();
+    if (!flags[category]) {
+        console.log(`push: ${category} notification suppressed by settings toggle.`);
+        return;
+    }
+    await sendPushToAll(content);
+}
+
+/**
+ * Fires an Expo Push to every registered token for a single alert. Called by
+ * the alerter on insert (a brand-new alert) — dedup-updates suppress it,
+ * matching the existing "loud once, quiet until acked" semantics. Gated on the
+ * `error` toggle via `sendCategoryPush`, so disabling Errors in the app
+ * silences failure pushes.
+ */
+export async function dispatchAlertPush(event: PushAlertEvent): Promise<void> {
+    const data: Record<string, unknown> = {
+        alertId: event.alertId,
+        class: event.class,
+    };
+    if (event.zoneId !== null) data['zoneId'] = event.zoneId;
+
+    await sendCategoryPush('error', {
+        title: event.title,
+        body: event.sub ?? event.title,
+        data,
+        priority: event.tone === 'danger' ? 'high' : 'default',
+    });
 }
 
 /**


### PR DESCRIPTION
## Ticket

[API-103](http://192.168.2.100:7123/home/browse/API-103/) — Expo push: general send-to-all channel + per-category gating. First step of epic [API-102](http://192.168.2.100:7123/home/browse/API-102/) (move all notifications from Home Assistant to Expo push).

## Summary

- **`sendPushToAll({ title, body, data?, priority? })`** — extracted the chunk / send / `DeviceNotRegistered`-prune / deferred receipt-poll core out of `dispatchAlertPush` into a general, non-alert-shaped primitive that fans one message out to every registered token.
- **`sendCategoryPush(category, content)`** — gated wrapper. A `NotificationCategory` is exactly a `keyof NotificationSettingsDto`, so gating is one live `getNotificationSettings()` flag lookup; when the toggle is off the push is suppressed (logged, never sent). This is the entry point lifecycle producers (API-104) will use.
- **`dispatchAlertPush`** is now a thin adapter over `sendCategoryPush('error', …)` — same `PushDispatcher` signature and message shape as before (so `createAlerter` / `api/index.ts` wiring is untouched), but now **gated on `flags.error`**. Closes a latent gap: the Errors toggle previously gated only the HA notifier, so turning it off did nothing on the Expo path.

## Tests

- New `sendPushToAll` suite (message build, default priority, data-omitted, chunking, prune + poll) and `sendCategoryPush` suite (all five categories: on → send, off → suppress).
- `dispatchAlertPush` tests now boot the notification-settings service and add error-gating on/off cases; existing message-shape/prune/poll assertions retained.
- Full API suite green: 1003 pass.