### PR TITLE
[API-104] Fire schedule + watering lifecycle notifications via Expo

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -916,6 +916,7 @@ if (import.meta.main) {
         openZone: effectiveOpenZone,
         closeZone: effectiveCloseZone,
         notifier,
+        pushNotify: sendCategoryPush,
         isAnyScheduledInFlight: () => daemon.getStatus().activeZones.length > 0,
         isIrrigationEnabled: async () => (await getSystemState()).irrigationEnabled,
     });

--- a/api/index.ts
+++ b/api/index.ts
@@ -47,6 +47,7 @@ import {
     bootPushTokensService,
     dispatchAlertPush,
     registerPushToken,
+    sendCategoryPush,
     unregisterPushToken,
 } from '@/service/push-tokens';
 import Expo from 'expo-server-sdk';
@@ -904,6 +905,7 @@ if (import.meta.main) {
     const alerter = createAlerter(alertsDb, notifier, dispatchAlertPush);
     const daemon = await daemonStart({
         notifier,
+        pushNotify: sendCategoryPush,
         alerter,
         openZone: effectiveOpenZone,
         closeZone: effectiveCloseZone,

--- a/api/models/manual.ts
+++ b/api/models/manual.ts
@@ -1,6 +1,7 @@
 import type { Clock } from '@/service/daemon/runtime';
 import type { Zone } from '@/models';
 import type { Notifier } from '@/notifications';
+import type { CategoryPushNotifier } from '@/service/push-tokens';
 
 /**
  * Snapshot of the active manual fire (if any). Drives the HTTP status the
@@ -25,6 +26,12 @@ export type ManualControllerDeps = {
     openZone: (zone: Zone) => Promise<void>;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    /**
+     * Gated Expo push for watering-lifecycle notifications. Defaults to a noop
+     * when unset. The HA `notifier` above still carries manual *error*
+     * notifications until API-50 retires it.
+     */
+    pushNotify?: CategoryPushNotifier;
 
     /**
      * Returns true if a scheduled cycle is currently in-flight. The controller

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -19,6 +19,7 @@ import type { ZoneJoinedRow, ZonesRepository } from '@/repositories/zones';
 import { joinedRowToZone } from '@/repositories/zones';
 import { planZoneSchedule } from '@/schedules/dynamic';
 import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
+import type { CategoryPushNotifier, NotificationCategory, PushMessageContent } from '@/service/push-tokens';
 import { bootSystemService } from '@/service/system';
 import { bootDaemonService, computeNextMorningAt, computeNextRePlanAt, start } from '.';
 import type { Clock, TimerHandle } from './runtime';
@@ -56,6 +57,16 @@ function recordingNotifier(): { notifier: Notifier; calls: RecordedNotification[
         calls.push({ event, context });
     };
     return { notifier, calls };
+}
+
+type RecordedPush = { category: NotificationCategory; content: PushMessageContent };
+
+function recordingPush(): { pushNotify: CategoryPushNotifier; calls: RecordedPush[] } {
+    const calls: RecordedPush[] = [];
+    const pushNotify: CategoryPushNotifier = async (category, content) => {
+        calls.push({ category, content });
+    };
+    return { pushNotify, calls };
 }
 
 function recordingAlerter(): { alerter: Alerter; calls: AlertEvent[] } {
@@ -1205,7 +1216,7 @@ describe('start', () => {
         expect(clearStaleToday!.value.format('YYYY-MM-DD')).toBe('2026-05-04');
     });
 
-    it('does not emit schedule-begun or schedule-ended for boot-armed cycles', async () => {
+    it('does not emit any lifecycle push for boot-armed cycles', async () => {
         const futureRow = buildFutureCycleRow({
             cycle: { id: 'cycle-boot', startTime: new Date('2026-05-04T11:00:00.000Z'), durationMin: 8 },
             zone: { id: 'zone-boot', name: 'Boot Zone' },
@@ -1213,13 +1224,13 @@ describe('start', () => {
         const stub = createDaemonReposStub({ futureCycles: [futureRow] });
         bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
         const { clock, advanceTo } = createFakeClock(NOW);
-        const { notifier, calls } = recordingNotifier();
+        const { pushNotify, calls } = recordingPush();
 
         await start({
             clock,
             rePlanHourLocal: 4,
             siteTimezone: 'UTC',
-            notifier,
+            pushNotify,
             runPlan: async () => ({ entries: [], projectedNextDepletionMm: 0 }),
             openZone: async () => {},
             closeZone: async () => {},
@@ -1227,18 +1238,16 @@ describe('start', () => {
 
         await advanceTo(new Date('2026-05-04T12:08:30.000Z'));
 
-        expect(calls.some(c => c.event === 'schedule-begun')).toBe(false);
-        expect(calls.some(c => c.event === 'schedule-ended')).toBe(false);
-        expect(calls.some(c => c.event === 'watering-started')).toBe(false);
-        expect(calls.some(c => c.event === 'watering-ended')).toBe(false);
+        // Boot-armed cycles carry no schedule markers, so no lifecycle push fires.
+        expect(calls).toHaveLength(0);
     });
 
-    it('rePlan tags the earliest cycle with schedule-begun and the latest with schedule-ended', async () => {
+    it('rePlan tags the earliest cycle with a scheduleStart push and the latest with scheduleEnd', async () => {
         const enabledRow = buildJoinedRow({ zone: { id: 'zone-rp', name: 'Replan Zone' } });
         const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
         bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
         const { clock, advanceTo } = createFakeClock(NOW);
-        const { notifier, calls } = recordingNotifier();
+        const { pushNotify, calls } = recordingPush();
         const planned = buildEntry('2026-05-04', [
             { startTime: '2026-05-04T13:00:00Z', durationMin: 6 },
             { startTime: '2026-05-04T14:00:00Z', durationMin: 6 },
@@ -1248,7 +1257,7 @@ describe('start', () => {
             clock,
             rePlanHourLocal: 4,
             siteTimezone: 'UTC',
-            notifier,
+            pushNotify,
             runPlan: async () => ({ entries: [planned], projectedNextDepletionMm: 0 }),
             openZone: async () => {},
             closeZone: async () => {},
@@ -1257,26 +1266,22 @@ describe('start', () => {
         await control.rePlan();
         await advanceTo(new Date('2026-05-04T14:06:30.000Z'));
 
-        const begunCalls = calls.filter(c => c.event === 'schedule-begun');
-        expect(begunCalls).toHaveLength(1);
-        expect(begunCalls[0]?.context).toEqual({ scheduleNight: '2026-05-04' });
+        const begun = calls.filter(c => c.category === 'scheduleStart');
+        expect(begun).toHaveLength(1);
+        expect(begun[0]?.content.body).toBe('Schedule started for the night of 2026-05-04.');
 
-        const endedCalls = calls.filter(c => c.event === 'schedule-ended');
-        expect(endedCalls).toHaveLength(1);
-        expect(endedCalls[0]?.context).toMatchObject({
-            scheduleNight: '2026-05-04',
-            perZoneRuntimeMin: { 'Replan Zone': 12 },
-            siteTimezone: 'UTC',
-        });
-        expect(endedCalls[0]?.context).not.toHaveProperty('nextIrrigation');
+        const ended = calls.filter(c => c.category === 'scheduleEnd');
+        expect(ended).toHaveLength(1);
+        // Two 6-min cycles on the one zone sum to 12 min; single night → no next-irrigation line.
+        expect(ended[0]?.content.body).toBe('Watered Replan Zone 12 min.');
     });
 
-    it('rePlan over a multi-night plan points each schedule-ended at the next night', async () => {
+    it('rePlan over a multi-night plan points each scheduleEnd push at the next night', async () => {
         const enabledRow = buildJoinedRow({ zone: { id: 'zone-multi', name: 'Multi Zone' } });
         const stub = createDaemonReposStub({ enabledZones: [enabledRow] });
         bootDaemonService({ repos: stub.repos, alertsDb: stub.alertsDb });
         const { clock, advanceTo } = createFakeClock(NOW);
-        const { notifier, calls } = recordingNotifier();
+        const { pushNotify, calls } = recordingPush();
         const tomorrowStart = new Date('2026-05-04T14:00:00Z');
         const tonight = buildEntry('2026-05-04', [{ startTime: '2026-05-04T13:00:00Z', durationMin: 4 }]);
         const tomorrow = buildEntry('2026-05-05', [{ startTime: tomorrowStart.toISOString(), durationMin: 4 }]);
@@ -1285,7 +1290,7 @@ describe('start', () => {
             clock,
             rePlanHourLocal: 4,
             siteTimezone: 'UTC',
-            notifier,
+            pushNotify,
             runPlan: async () => ({ entries: [tonight, tomorrow], projectedNextDepletionMm: 0 }),
             openZone: async () => {},
             closeZone: async () => {},
@@ -1294,15 +1299,15 @@ describe('start', () => {
         await control.rePlan();
         await advanceTo(new Date('2026-05-04T14:04:30.000Z'));
 
-        const begun = calls.filter(c => c.event === 'schedule-begun');
-        const ended = calls.filter(c => c.event === 'schedule-ended');
-        expect(begun.map(c => c.context?.scheduleNight)).toEqual(['2026-05-04', '2026-05-05']);
-        expect(ended[0]?.context).toMatchObject({
-            scheduleNight: '2026-05-04',
-            nextIrrigation: { zoneName: 'Multi Zone', startTime: tomorrowStart },
-        });
-        expect(ended[1]?.context).toMatchObject({ scheduleNight: '2026-05-05' });
-        expect(ended[1]?.context).not.toHaveProperty('nextIrrigation');
+        const begun = calls.filter(c => c.category === 'scheduleStart');
+        const ended = calls.filter(c => c.category === 'scheduleEnd');
+        expect(begun.map(c => c.content.body)).toEqual([
+            'Schedule started for the night of 2026-05-04.',
+            'Schedule started for the night of 2026-05-05.',
+        ]);
+        // First night points at the next; the last night has no next irrigation.
+        expect(ended[0]?.content.body).toContain('Next irrigation: Multi Zone on ');
+        expect(ended[1]?.content.body).not.toContain('Next irrigation');
     });
 
     describe('cross-zone deconfliction', () => {

--- a/api/service/daemon/boot/index.ts
+++ b/api/service/daemon/boot/index.ts
@@ -2,6 +2,7 @@ import type { Alerter } from '@/alerts';
 import type { ZoneRelayState } from '@/data/home-assistant';
 import type { WeatherData, Zone } from '@/models';
 import type { Notifier } from '@/notifications';
+import type { CategoryPushNotifier } from '@/service/push-tokens';
 import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
 import type { ZonesRepository } from '@/repositories/zones';
 import { getSystemState } from '@/service/system';
@@ -17,6 +18,8 @@ export type BootDeps = {
     clock: Clock;
     registry: TimerRegistry;
     notifier: Notifier;
+    /** Gated Expo push for lifecycle notifications, passed through to reconcile + armCycle. */
+    pushNotify?: CategoryPushNotifier;
     alerter: Alerter;
     openZone: (zone: Zone) => Promise<void>;
     closeZone: (zone: Zone) => Promise<void>;
@@ -55,13 +58,14 @@ export type RunBootSequenceResult = {
  */
 export async function runBootSequence(input: RunBootSequenceInput): Promise<RunBootSequenceResult> {
     const { morningTickMinutesAfterSunrise, deps } = input;
-    const { clock, registry, notifier, alerter, openZone, closeZone, getZoneState, getWeather, zonesRepo, scheduleEntriesRepo } = deps;
+    const { clock, registry, notifier, pushNotify, alerter, openZone, closeZone, getZoneState, getWeather, zonesRepo, scheduleEntriesRepo } = deps;
 
     const enabledZonesAtBoot = await zonesRepo.loadEnabled();
     const reconcileSummary = await reconcileCycleAndRelayState({
         clock,
         registry,
         notifier,
+        pushNotify,
         alerter,
         closeZone,
         getZoneState,
@@ -76,7 +80,7 @@ export async function runBootSequence(input: RunBootSequenceInput): Promise<RunB
         console.warn(`daemon: system irrigation is disabled (since ${systemAtBoot.since}); skipping arm of ${futureCycles.length} future cycle(s).`);
     } else {
         for (const { cycle, zone } of futureCycles) {
-            armCycle({ clock, registry, zone, cycle, openZone, closeZone, notifier, alerter });
+            armCycle({ clock, registry, zone, cycle, openZone, closeZone, notifier, pushNotify, alerter });
         }
     }
 

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -14,6 +14,7 @@ import { getWeatherData } from '@/data/weather';
 import type { WeatherData, Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import { noopNotifier, type Notifier } from '@/notifications';
+import { noopCategoryPush, type CategoryPushNotifier } from '@/service/push-tokens';
 import { runScheduleForZone, type RunScheduleForZoneOptions } from '@/schedules';
 import type { PlanZoneScheduleResult } from '@/schedules/dynamic';
 import { getSystemState } from '@/service/system';
@@ -97,6 +98,8 @@ export type DaemonOptions = {
     clock?: Clock;
     siteTimezone?: string;
     notifier?: Notifier;
+    /** Gated Expo push for lifecycle notifications. Defaults to a noop. Production wires `sendCategoryPush`. */
+    pushNotify?: CategoryPushNotifier;
     alerter?: Alerter;
 };
 
@@ -152,6 +155,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
 
     const registry = new TimerRegistry();
     const notifier = options?.notifier ?? noopNotifier;
+    const pushNotify = options?.pushNotify ?? noopCategoryPush;
     const alerter = options?.alerter ?? noopAlerter;
     let lastRePlanAt: Date | null = null;
     let started = false;
@@ -171,7 +175,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
     const { initialSunrise } = await runBootSequence({
         morningTickMinutesAfterSunrise,
         deps: {
-            clock, registry, notifier, alerter,
+            clock, registry, notifier, pushNotify, alerter,
             openZone, closeZone, getZoneState, getWeather,
             zonesRepo, scheduleEntriesRepo,
         },
@@ -260,7 +264,7 @@ export async function start(options?: DaemonOptions): Promise<DaemonControl> {
         }
 
         armCyclesWithScheduleMarkers(cyclesToArm, siteTimezone, ({ zone, cycle, scheduleStart, scheduleEnd }) => {
-            armCycle({ clock, registry, zone, cycle, openZone, closeZone, notifier, alerter, scheduleStart, scheduleEnd });
+            armCycle({ clock, registry, zone, cycle, openZone, closeZone, notifier, pushNotify, alerter, scheduleStart, scheduleEnd });
         });
 
         lastRePlanAt = clock.now();

--- a/api/service/daemon/reconcile.ts
+++ b/api/service/daemon/reconcile.ts
@@ -3,6 +3,7 @@ import type { ZoneRelayState } from '@/data/home-assistant';
 import type { Zone } from '@/models';
 import type { FutureCyclePair } from '@/models/cycle';
 import type { Notifier } from '@/notifications';
+import type { CategoryPushNotifier } from '@/service/push-tokens';
 import { armCloseOnly as defaultArmCloseOnly, type ArmCloseOnlyInputs, type Clock, type TimerRegistry } from './runtime';
 import { getScheduleEntriesRepo } from './state';
 
@@ -31,6 +32,8 @@ export type ReconcileDeps = {
     clock: Clock;
     registry: TimerRegistry;
     notifier: Notifier;
+    /** Gated Expo push for lifecycle notifications, passed through to `armCloseOnly`. */
+    pushNotify?: CategoryPushNotifier;
     alerter: Alerter;
     closeZone: (zone: Zone) => Promise<void>;
     getZoneState: (zone: Zone) => Promise<ZoneRelayState>;
@@ -55,7 +58,7 @@ export type ReconcileDeps = {
  */
 export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<ReconcileSummary> {
     const {
-        clock, registry, notifier, alerter, closeZone, getZoneState, managedZones,
+        clock, registry, notifier, pushNotify, alerter, closeZone, getZoneState, managedZones,
         loadInFlightCycles = () => getScheduleEntriesRepo().loadInFlightCycles(),
         armCloseOnly = defaultArmCloseOnly,
     } = deps;
@@ -93,7 +96,7 @@ export async function reconcileCycleAndRelayState(deps: ReconcileDeps): Promise<
         }
 
         if (state === 'on' && plannedCloseAt.getTime() > now.getTime()) {
-            armCloseOnly({ clock, registry, zone, cycle, closeZone, notifier, alerter, plannedCloseAt });
+            armCloseOnly({ clock, registry, zone, cycle, closeZone, notifier, pushNotify, alerter, plannedCloseAt });
             handledZoneIds.add(zone.id);
             summary.resumed += 1;
             console.log(`daemon: reconcile resumed cycle ${cycle.id} on zone ${zone.id} (closes at ${plannedCloseAt.toISOString()}).`);

--- a/api/service/daemon/runtime.test.ts
+++ b/api/service/daemon/runtime.test.ts
@@ -3,6 +3,7 @@ import type { AlertEvent, Alerter } from '@/alerts';
 import type { Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
+import type { CategoryPushNotifier, NotificationCategory, PushMessageContent } from '@/service/push-tokens';
 import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';
 import {
     armCloseOnly,
@@ -165,6 +166,16 @@ function recordingAlerter(): { alerter: Alerter; calls: AlertEvent[] } {
     return { alerter, calls };
 }
 
+type RecordedPush = { category: NotificationCategory; content: PushMessageContent };
+
+function recordingPush(): { pushNotify: CategoryPushNotifier; calls: RecordedPush[] } {
+    const calls: RecordedPush[] = [];
+    const pushNotify: CategoryPushNotifier = async (category, content) => {
+        calls.push({ category, content });
+    };
+    return { pushNotify, calls };
+}
+
 describe('armCycle', () => {
     let repo: ScheduleEntriesRepository;
     let updates: CycleUpdate[];
@@ -227,10 +238,11 @@ describe('armCycle', () => {
         expect(updates.filter(u => u.cycleId === 'cycle-B').some(u => u.closedAt instanceof Date)).toBe(true);
     });
 
-    it('emits schedule-begun on first cycle when scheduleStart marker is set', async () => {
+    it('emits a scheduleStart push on first cycle when scheduleStart marker is set', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
         const registry = new TimerRegistry();
-        const { notifier, calls } = recordingNotifier();
+        const { notifier } = recordingNotifier();
+        const { pushNotify, calls } = recordingPush();
         const { alerter } = recordingAlerter();
 
         armCycle({
@@ -241,13 +253,14 @@ describe('armCycle', () => {
             openZone: async () => {},
             closeZone: async () => {},
             notifier,
+            pushNotify,
             alerter,
             scheduleStart: { scheduleNight: '2026-05-04' },
         });
 
         await advanceTo(new Date('2026-05-04T13:00:01.000Z'));
 
-        expect(calls.some(c => c.event === 'schedule-begun')).toBe(true);
+        expect(calls.some(c => c.category === 'scheduleStart')).toBe(true);
     });
 
     it('calls advanceDepletion(zone.id, 0, closedAt) on the zones repo after the relay closes', async () => {

--- a/api/service/daemon/runtime.ts
+++ b/api/service/daemon/runtime.ts
@@ -2,6 +2,8 @@ import type { Alerter } from '@/alerts';
 import type { Zone } from '@/models';
 import type { PersistedCycle } from '@/models/cycle';
 import type { Notifier } from '@/notifications';
+import { noopCategoryPush, type CategoryPushNotifier } from '@/service/push-tokens';
+import { scheduleEndedMessage, scheduleStartedMessage } from '@/service/push-tokens/lifecycle-messages';
 import { getScheduleEntriesRepo, getZonesRepo } from './state';
 
 /**
@@ -116,6 +118,8 @@ export type ArmCycleInputs = {
     openZone: (zone: Zone) => Promise<void>;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    /** Gated Expo push for lifecycle notifications. Defaults to a noop when unset. */
+    pushNotify?: CategoryPushNotifier;
     alerter: Alerter;
     scheduleStart?: ScheduleStartMarker;
     scheduleEnd?: ScheduleEndMarker;
@@ -136,7 +140,7 @@ export function armCycle(inputs: ArmCycleInputs): void {
 }
 
 async function runOpen(inputs: ArmCycleInputs): Promise<void> {
-    const { clock, registry, zone, cycle, openZone, closeZone, notifier, alerter, scheduleStart, scheduleEnd } = inputs;
+    const { clock, registry, zone, cycle, openZone, closeZone, notifier, pushNotify, alerter, scheduleStart, scheduleEnd } = inputs;
 
     try {
         await openZone(zone);
@@ -160,13 +164,13 @@ async function runOpen(inputs: ArmCycleInputs): Promise<void> {
 
     if (scheduleStart) {
         console.log(`daemon: emitting schedule-begun for night ${scheduleStart.scheduleNight}.`);
-        await notifier('schedule-begun', { scheduleNight: scheduleStart.scheduleNight });
+        await (pushNotify ?? noopCategoryPush)('scheduleStart', scheduleStartedMessage(scheduleStart.scheduleNight));
     }
 
     const closeDelay = cycle.durationMin * 60_000;
     const endTime = new Date(firedAt.getTime() + closeDelay);
     const closeHandle = clock.setTimeout(() => {
-        runClose({ clock, registry, zone, cycle, closeZone, notifier, alerter, scheduleEnd }).catch(err => {
+        runClose({ clock, registry, zone, cycle, closeZone, notifier, pushNotify, alerter, scheduleEnd }).catch(err => {
             console.error(`daemon: unhandled error in cycle close path for ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -185,16 +189,18 @@ export type ArmCloseOnlyInputs = {
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    /** Gated Expo push for lifecycle notifications. Defaults to a noop when unset. */
+    pushNotify?: CategoryPushNotifier;
     alerter: Alerter;
     plannedCloseAt: Date;
 };
 
 export function armCloseOnly(inputs: ArmCloseOnlyInputs): void {
-    const { clock, registry, zone, cycle, closeZone, notifier, alerter, plannedCloseAt } = inputs;
+    const { clock, registry, zone, cycle, closeZone, notifier, pushNotify, alerter, plannedCloseAt } = inputs;
     const closeDelay = Math.max(0, plannedCloseAt.getTime() - clock.now().getTime());
 
     const closeHandle = clock.setTimeout(() => {
-        runClose({ clock, registry, zone, cycle, closeZone, notifier, alerter }).catch(err => {
+        runClose({ clock, registry, zone, cycle, closeZone, notifier, pushNotify, alerter }).catch(err => {
             console.error(`daemon: unhandled error in close-only path for cycle ${cycle.id}.`, err);
         });
     }, closeDelay);
@@ -208,12 +214,14 @@ type RunCloseInputs = {
     cycle: PersistedCycle;
     closeZone: (zone: Zone) => Promise<void>;
     notifier: Notifier;
+    /** Gated Expo push for lifecycle notifications. Defaults to a noop when unset. */
+    pushNotify?: CategoryPushNotifier;
     alerter: Alerter;
     scheduleEnd?: ScheduleEndMarker;
 };
 
 async function runClose(inputs: RunCloseInputs): Promise<void> {
-    const { clock, registry, zone, cycle, closeZone, notifier, alerter, scheduleEnd } = inputs;
+    const { clock, registry, zone, cycle, closeZone, notifier, pushNotify, alerter, scheduleEnd } = inputs;
 
     try {
         await closeZone(zone);
@@ -240,12 +248,11 @@ async function runClose(inputs: RunCloseInputs): Promise<void> {
 
     if (scheduleEnd) {
         console.log(`daemon: emitting schedule-ended for night ${scheduleEnd.scheduleNight}.`);
-        await notifier('schedule-ended', {
-            scheduleNight: scheduleEnd.scheduleNight,
+        await (pushNotify ?? noopCategoryPush)('scheduleEnd', scheduleEndedMessage({
             perZoneRuntimeMin: scheduleEnd.perZoneRuntimeMin,
             siteTimezone: scheduleEnd.siteTimezone,
             ...(scheduleEnd.nextIrrigation ? { nextIrrigation: scheduleEnd.nextIrrigation } : {}),
-        });
+        }));
     }
 }
 

--- a/api/service/manual/.test.ts
+++ b/api/service/manual/.test.ts
@@ -3,6 +3,7 @@ import type { Zone } from '@/models';
 import type { ManualRepository } from '@/repositories/manual';
 import type { Clock, TimerHandle } from '@/service/daemon/runtime';
 import type { NotificationContext, NotificationEvent, Notifier } from '@/notifications';
+import type { CategoryPushNotifier, NotificationCategory, PushMessageContent } from '@/service/push-tokens';
 import {
     BusyError,
     bootManualService,
@@ -19,6 +20,16 @@ function recordingNotifier(): { notifier: Notifier; calls: RecordedNotification[
         calls.push({ event, context });
     };
     return { notifier, calls };
+}
+
+type RecordedPush = { category: NotificationCategory; content: PushMessageContent };
+
+function recordingPush(): { pushNotify: CategoryPushNotifier; calls: RecordedPush[] } {
+    const calls: RecordedPush[] = [];
+    const pushNotify: CategoryPushNotifier = async (category, content) => {
+        calls.push({ category, content });
+    };
+    return { pushNotify, calls };
 }
 
 type ScheduledTimer = { handle: number; fireAt: number; cb: () => void };
@@ -123,12 +134,14 @@ describe('manual controller — open', () => {
     it('opens the relay, records active state, returns the open timestamp', async () => {
         const { clock } = createFakeClock(NOW);
         const opens: Zone[] = [];
-        const { notifier, calls } = recordingNotifier();
+        const { notifier } = recordingNotifier();
+        const { pushNotify, calls: pushCalls } = recordingPush();
         const controller = createManualController({
             clock,
             openZone: async (z) => { opens.push(z); },
             closeZone: async () => {},
             notifier,
+            pushNotify,
             isAnyScheduledInFlight: () => false,
             isIrrigationEnabled: async () => true,
         });
@@ -140,8 +153,9 @@ describe('manual controller — open', () => {
         expect(opens[0]?.id).toBe('zone-001');
         expect(result.since.getTime()).toBe(NOW.getTime());
         expect(controller.getActiveZone()).toEqual({ zoneId: 'zone-001', zoneName: 'Front Lawn', since: NOW, willCloseAt: null });
-        const started = calls.find(c => c.event === 'watering-started');
-        expect(started?.context).toEqual({ zoneName: 'Front Lawn', reason: 'manual' });
+        const started = pushCalls.find(c => c.category === 'wateringStart');
+        expect(started?.content.body).toBe('Front Lawn watering started (manual fire).');
+        expect(started?.content.data).toEqual({ category: 'wateringStart', zoneId: 'zone-001' });
         // `open` alone doesn't write — the write happens at close (or up-front in `run`).
         expect(writes).toHaveLength(0);
         expect(updates).toHaveLength(0);
@@ -211,12 +225,14 @@ describe('manual controller — close', () => {
     it('closes the active zone, calls writeManualRecord with elapsed duration, clears state', async () => {
         const { clock, advanceTo } = createFakeClock(NOW);
         const closes: Zone[] = [];
-        const { notifier, calls } = recordingNotifier();
+        const { notifier } = recordingNotifier();
+        const { pushNotify, calls: pushCalls } = recordingPush();
         const controller = createManualController({
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
             notifier,
+            pushNotify,
             isAnyScheduledInFlight: () => false,
             isIrrigationEnabled: async () => true,
         });
@@ -235,7 +251,7 @@ describe('manual controller — close', () => {
         // close on an `open`-then-`close` path uses writeManualRecord, not updateCycleClosedAt.
         expect(updates).toHaveLength(0);
         expect(controller.getActiveZone()).toBeNull();
-        expect(calls.some(c => c.event === 'watering-ended')).toBe(true);
+        expect(pushCalls.some(c => c.category === 'wateringEnd')).toBe(true);
     });
 
     it('records duration as elapsed time between open and close', async () => {
@@ -359,12 +375,14 @@ describe('manual controller — run', () => {
     it('opens, calls writeManualRecord upfront with the planned duration, and schedules the auto-close', async () => {
         const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
         const closes: Zone[] = [];
-        const { notifier, calls } = recordingNotifier();
+        const { notifier } = recordingNotifier();
+        const { pushNotify, calls: pushCalls } = recordingPush();
         const controller = createManualController({
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
             notifier,
+            pushNotify,
             isAnyScheduledInFlight: () => false,
             isIrrigationEnabled: async () => true,
         });
@@ -378,8 +396,8 @@ describe('manual controller — run', () => {
         expect(writes[0]?.durationMin).toBe(15);
         expect(writes[0]?.openedAt).toEqual(NOW);
         expect(writes[0]?.closedAt).toBeNull();
-        const started = calls.find(c => c.event === 'watering-started');
-        expect(started?.context).toEqual({ zoneName: 'Front Lawn', durationMin: 15, reason: 'manual' });
+        const started = pushCalls.find(c => c.category === 'wateringStart');
+        expect(started?.content.body).toBe('Front Lawn watering started (~15 min) (manual fire).');
         expect(getPendingCount()).toBe(1);
 
         await advanceTo(new Date('2026-05-04T15:15:30.000Z'));
@@ -390,7 +408,7 @@ describe('manual controller — run', () => {
         expect(updates[0]?.cycleId).toBe('cycle-1');
         expect(updates[0]?.closedAt).toEqual(new Date('2026-05-04T15:15:00.000Z'));
         expect(controller.getActiveZone()).toBeNull();
-        expect(calls.some(c => c.event === 'watering-ended')).toBe(true);
+        expect(pushCalls.some(c => c.category === 'wateringEnd')).toBe(true);
     });
 
     it('clears state and emits an error when the auto-close fires but closeZone rejects', async () => {
@@ -546,12 +564,14 @@ describe('manual controller — getActiveZone and shutdown', () => {
     it('shutdown closes any active manual zone and cancels the close timer', async () => {
         const { clock, advanceTo, getPendingCount } = createFakeClock(NOW);
         const closes: Zone[] = [];
-        const { notifier, calls } = recordingNotifier();
+        const { notifier } = recordingNotifier();
+        const { pushNotify, calls: pushCalls } = recordingPush();
         const controller = createManualController({
             clock,
             openZone: async () => {},
             closeZone: async (z) => { closes.push(z); },
             notifier,
+            pushNotify,
             isAnyScheduledInFlight: () => false,
             isIrrigationEnabled: async () => true,
         });
@@ -564,8 +584,8 @@ describe('manual controller — getActiveZone and shutdown', () => {
         expect(closes).toHaveLength(1);
         expect(getPendingCount()).toBe(0);
         expect(controller.getActiveZone()).toBeNull();
-        const ended = calls.find(c => c.event === 'watering-ended');
-        expect(ended?.context).toEqual({ zoneName: 'Front Lawn', reason: 'shutdown' });
+        const ended = pushCalls.find(c => c.category === 'wateringEnd');
+        expect(ended?.content.body).toBe('Front Lawn watering ended (closed during daemon shutdown).');
         // shutdown stamps closed_at via the repo.
         expect(updates).toHaveLength(1);
 

--- a/api/service/manual/index.ts
+++ b/api/service/manual/index.ts
@@ -3,6 +3,8 @@ import type { ActiveManualSnapshot, ManualController, ManualControllerDeps } fro
 import type { Zone } from '@/models';
 import { createManualRepository, type ManualRepository } from '@/repositories/manual';
 import type { TimerHandle } from '@/service/daemon/runtime';
+import { noopCategoryPush } from '@/service/push-tokens';
+import { wateringEndedMessage, wateringStartedMessage } from '@/service/push-tokens/lifecycle-messages';
 
 export type { ActiveManualSnapshot, ManualController, ManualControllerDeps } from '@/models/manual';
 
@@ -84,6 +86,7 @@ type ActiveManualFire = {
  */
 export function createManualController(deps: ManualControllerDeps): ManualController {
     const { clock, openZone, closeZone, notifier, isAnyScheduledInFlight, isIrrigationEnabled } = deps;
+    const pushNotify = deps.pushNotify ?? noopCategoryPush;
     let current: ActiveManualFire | null = null;
 
     const ensureSystemEnabled = async (action: string, zone: Zone): Promise<void> => {
@@ -117,7 +120,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         const openedAt = clock.now();
         current = { zone, openedAt, willCloseAt: null };
         console.log(`manual: opened zone ${zone.id} at ${openedAt.toISOString()}.`);
-        await notifier('watering-started', { zoneName: zone.name, reason: 'manual' });
+        await pushNotify('wateringStart', wateringStartedMessage({ zoneName: zone.name, zoneId: zone.id, reason: 'manual' }));
 
         return { since: openedAt };
     };
@@ -163,7 +166,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         }
 
         console.log(`manual: closed zone ${zone.id} at ${closedAt.toISOString()}.`);
-        await notifier('watering-ended', { zoneName: zone.name, reason: 'manual' });
+        await pushNotify('wateringEnd', wateringEndedMessage({ zoneName: zone.name, zoneId: zone.id, reason: 'manual' }));
         return { closed: true };
     };
 
@@ -186,7 +189,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
         }
 
         console.log(`manual: scheduled close for zone ${zone.id} at ${closedAt.toISOString()}.`);
-        await notifier('watering-ended', { zoneName: zone.name, reason: 'manual' });
+        await pushNotify('wateringEnd', wateringEndedMessage({ zoneName: zone.name, zoneId: zone.id, reason: 'manual' }));
     };
 
     const run: ManualController['run'] = async (zone, durationMin) => {
@@ -220,7 +223,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
 
         current = { zone, openedAt, willCloseAt, closeHandle, cycleId: cycleId ?? undefined, runDurationMin: durationMin };
         console.log(`manual: opened zone ${zone.id} at ${openedAt.toISOString()} for ${durationMin} min (auto-close).`);
-        await notifier('watering-started', { zoneName: zone.name, durationMin, reason: 'manual' });
+        await pushNotify('wateringStart', wateringStartedMessage({ zoneName: zone.name, zoneId: zone.id, durationMin, reason: 'manual' }));
 
         return { since: openedAt, willCloseAt };
     };
@@ -251,7 +254,7 @@ export function createManualController(deps: ManualControllerDeps): ManualContro
             if (active.cycleId !== undefined) {
                 await getRepo().updateCycleClosedAt(active.cycleId, closedAt);
             }
-            await notifier('watering-ended', { zoneName: active.zone.name, reason: 'shutdown' });
+            await pushNotify('wateringEnd', wateringEndedMessage({ zoneName: active.zone.name, zoneId: active.zone.id, reason: 'shutdown' }));
         } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             console.error(`manual: shutdown closeZone failed for zone ${active.zone.id}.`, err);

--- a/api/service/push-tokens/index.ts
+++ b/api/service/push-tokens/index.ts
@@ -126,6 +126,22 @@ export type PushMessageContent = {
 export type NotificationCategory = keyof NotificationSettingsDto;
 
 /**
+ * Injectable shape of `sendCategoryPush` — a gated push for one category. The
+ * daemon and manual controller take one of these so lifecycle producers can
+ * fire Expo pushes without importing the push singleton directly (and so tests
+ * can record the calls). `sendCategoryPush` satisfies it; production wires that
+ * in, tests pass a recorder, and `noopCategoryPush` is the safe default.
+ */
+export type CategoryPushNotifier = (category: NotificationCategory, content: PushMessageContent) => Promise<void>;
+
+/**
+ * No-op `CategoryPushNotifier`: resolves immediately, sends nothing. The
+ * default when no push channel is injected (tests, or a daemon booted without
+ * push wiring).
+ */
+export const noopCategoryPush: CategoryPushNotifier = async () => {};
+
+/**
  * Fires one Expo Push to every registered token, carrying the given content.
  * The general send primitive underlying both the gated `sendCategoryPush` and
  * the alert dispatcher.

--- a/api/service/push-tokens/lifecycle-messages.test.ts
+++ b/api/service/push-tokens/lifecycle-messages.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    scheduleEndedMessage,
+    scheduleStartedMessage,
+    wateringEndedMessage,
+    wateringStartedMessage,
+} from './lifecycle-messages';
+
+describe('scheduleStartedMessage', () => {
+    it('names the night when one is supplied', () => {
+        const m = scheduleStartedMessage('2026-06-09');
+        expect(m.title).toBe('Irrigation started');
+        expect(m.body).toBe('Schedule started for the night of 2026-06-09.');
+        expect(m.data).toEqual({ category: 'scheduleStart' });
+    });
+
+    it('omits the night when not supplied', () => {
+        expect(scheduleStartedMessage().body).toBe('Schedule started.');
+    });
+});
+
+describe('scheduleEndedMessage', () => {
+    it('renders the per-zone summary sorted by zone name', () => {
+        const m = scheduleEndedMessage({
+            perZoneRuntimeMin: { South: 8.5, North: 12 },
+            siteTimezone: 'America/Edmonton',
+        });
+        expect(m.title).toBe('Irrigation complete');
+        expect(m.body).toBe('Watered North 12 min, South 8.5 min.');
+        expect(m.data).toEqual({ category: 'scheduleEnd' });
+    });
+
+    it('falls back to a generic line when nothing was watered', () => {
+        const m = scheduleEndedMessage({ perZoneRuntimeMin: {}, siteTimezone: 'America/Edmonton' });
+        expect(m.body).toBe('All cycles complete.');
+    });
+
+    it('appends a tz-formatted next-irrigation sentence when one is known', () => {
+        const m = scheduleEndedMessage({
+            perZoneRuntimeMin: { North: 10 },
+            siteTimezone: 'America/Edmonton',
+            nextIrrigation: { zoneName: 'South Lawn', startTime: new Date('2026-06-10T03:30:00.000Z') },
+        });
+        expect(m.body).toMatch(/^Watered North 10 min\. Next irrigation: South Lawn on \w{3} \d{1,2} \w{3} at \d{1,2}:\d{2}(am|pm)\.$/);
+    });
+
+    it('omits the next-irrigation sentence when none is supplied', () => {
+        const m = scheduleEndedMessage({ perZoneRuntimeMin: { North: 10 }, siteTimezone: 'America/Edmonton' });
+        expect(m.body).not.toContain('Next irrigation');
+    });
+});
+
+describe('wateringStartedMessage', () => {
+    it('includes duration and the manual-fire qualifier', () => {
+        const m = wateringStartedMessage({ zoneName: 'Tomato', zoneId: 'z-1', durationMin: 15, reason: 'manual' });
+        expect(m.title).toBe('Watering started');
+        expect(m.body).toBe('Tomato watering started (~15 min) (manual fire).');
+        expect(m.data).toEqual({ category: 'wateringStart', zoneId: 'z-1' });
+    });
+
+    it('omits the duration when not supplied', () => {
+        const m = wateringStartedMessage({ zoneName: 'Tomato', zoneId: 'z-1', reason: 'manual' });
+        expect(m.body).toBe('Tomato watering started (manual fire).');
+    });
+
+    it('omits the manual qualifier when no reason is given', () => {
+        const m = wateringStartedMessage({ zoneName: 'Tomato', zoneId: 'z-1' });
+        expect(m.body).toBe('Tomato watering started.');
+    });
+});
+
+describe('wateringEndedMessage', () => {
+    it('uses the shutdown qualifier', () => {
+        const m = wateringEndedMessage({ zoneName: 'Tomato', zoneId: 'z-1', reason: 'shutdown' });
+        expect(m.body).toBe('Tomato watering ended (closed during daemon shutdown).');
+        expect(m.data).toEqual({ category: 'wateringEnd', zoneId: 'z-1' });
+    });
+
+    it('uses the manual qualifier', () => {
+        expect(wateringEndedMessage({ zoneName: 'Tomato', zoneId: 'z-1', reason: 'manual' }).body)
+            .toBe('Tomato watering ended (manual fire).');
+    });
+
+    it('omits the qualifier with no reason', () => {
+        expect(wateringEndedMessage({ zoneName: 'Tomato', zoneId: 'z-1' }).body)
+            .toBe('Tomato watering ended.');
+    });
+});

--- a/api/service/push-tokens/lifecycle-messages.ts
+++ b/api/service/push-tokens/lifecycle-messages.ts
@@ -1,0 +1,106 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+import type { PushMessageContent } from '.';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * Pure builders that turn a lifecycle event into the `title` / `body` / `data`
+ * of an Expo push. Copy is ported from the HA notifier's `buildMessage`
+ * (`api/notifications/index.ts`, removed in API-50) so message quality is
+ * preserved as notifications move to Expo. `data.category` lets the client
+ * route the push (APP-103); watering events also carry `zoneId`.
+ */
+
+/** Schedule run started — the night's first cycle opened. */
+export function scheduleStartedMessage(scheduleNight?: string): PushMessageContent {
+    return {
+        title: 'Irrigation started',
+        body: scheduleNight
+            ? `Schedule started for the night of ${scheduleNight}.`
+            : 'Schedule started.',
+        data: { category: 'scheduleStart' },
+    };
+}
+
+/** Schedule run finished — the night's last cycle closed. */
+export function scheduleEndedMessage(input: {
+    perZoneRuntimeMin: Record<string, number>;
+    siteTimezone: string;
+    nextIrrigation?: { zoneName: string; startTime: Date };
+}): PushMessageContent {
+    const summary = formatSummary(input.perZoneRuntimeMin);
+    const next = formatNextIrrigation(input.nextIrrigation, input.siteTimezone);
+    const head = summary === null ? 'All cycles complete.' : `Watered ${summary}.`;
+    return {
+        title: 'Irrigation complete',
+        body: next === null ? head : `${head} ${next}`,
+        data: { category: 'scheduleEnd' },
+    };
+}
+
+/** A zone started watering (manual fire, or a manual `run` with a duration). */
+export function wateringStartedMessage(input: {
+    zoneName: string;
+    zoneId: string;
+    durationMin?: number;
+    reason?: string;
+}): PushMessageContent {
+    const dur = input.durationMin !== undefined ? ` (~${input.durationMin} min)` : '';
+    const tail = input.reason === 'manual' ? ' (manual fire).' : '.';
+    return {
+        title: 'Watering started',
+        body: `${input.zoneName} watering started${dur}${tail}`,
+        data: { category: 'wateringStart', zoneId: input.zoneId },
+    };
+}
+
+/** A zone stopped watering. `reason` flips the copy for manual / shutdown closes. */
+export function wateringEndedMessage(input: {
+    zoneName: string;
+    zoneId: string;
+    reason?: string;
+}): PushMessageContent {
+    const tail = input.reason === 'shutdown'
+        ? ' (closed during daemon shutdown).'
+        : input.reason === 'manual'
+            ? ' (manual fire).'
+            : '.';
+    return {
+        title: 'Watering ended',
+        body: `${input.zoneName} watering ended${tail}`,
+        data: { category: 'wateringEnd', zoneId: input.zoneId },
+    };
+}
+
+/**
+ * Renders per-zone runtimes into `North 12 min, South 8.5 min`, sorted by zone
+ * name for stable output. Returns null when there's nothing watered.
+ */
+function formatSummary(perZone: Record<string, number>): string | null {
+    const entries = Object.entries(perZone);
+    if (entries.length === 0) return null;
+    entries.sort(([a], [b]) => a.localeCompare(b));
+    return entries.map(([zone, mins]) => `${zone} ${roundMin(mins)} min`).join(', ');
+}
+
+/**
+ * Renders the next scheduled irrigation into a `Next irrigation: <zone> on
+ * <date>.` sentence, formatted in the site's timezone. Returns null when none
+ * is known.
+ */
+function formatNextIrrigation(
+    next: { zoneName: string; startTime: Date } | undefined,
+    siteTimezone: string,
+): string | null {
+    if (!next) return null;
+    const formatted = dayjs(next.startTime).tz(siteTimezone).format('ddd D MMM [at] h:mma');
+    return `Next irrigation: ${next.zoneName} on ${formatted}.`;
+}
+
+function roundMin(value: number): number {
+    return Math.round(value * 10) / 10;
+}


### PR DESCRIPTION
## Ticket

[API-104](http://192.168.2.100:7123/home/browse/API-104/) — Fire schedule + watering lifecycle notifications via Expo. Step 2 of epic [API-102](http://192.168.2.100:7123/home/browse/API-102/) (HA→Expo). Builds on [API-103](http://192.168.2.100:7123/home/browse/API-103/) (`sendCategoryPush`).

## Summary

- **Lifecycle message builders** (`api/service/push-tokens/lifecycle-messages.ts`) — pure functions that turn each event into push `title`/`body`/`data`, porting the human-readable copy (per-zone summary, next-irrigation, manual/shutdown qualifiers) from the HA notifier's `buildMessage`. `data.category` (+ `zoneId` for watering) lets the client route the push (APP-103).
- **`CategoryPushNotifier` type + `noopCategoryPush`** added to the push-tokens service — the injectable shape lifecycle producers take (`sendCategoryPush` satisfies it).
- **Daemon** — `schedule-begun`/`schedule-ended` now fire `pushNotify('scheduleStart'|'scheduleEnd', …)` instead of the HA notifier. `pushNotify` is threaded (optional, noop default) through `runtime` / `reconcile` / `boot` / `daemon` and wired to `sendCategoryPush` in `api/index.ts`. The `markers` module is unchanged.
- **Manual** — the four `watering-started`/`watering-ended` emissions now fire `pushNotify('wateringStart'|'wateringEnd', …)`. Manual *error* notifications stay on the HA notifier for now (API-50 removes it).
- The HA `notifier` is left in place throughout — API-50 retires it wholesale.

## Tests

- New `lifecycle-messages.test.ts` (12) covering every builder branch.
- Daemon + manual suites migrated: lifecycle assertions now check the recording `pushNotify` (category + body); error/guard assertions stay on the notifier recorder. Reconcile/boot tests untouched (pushNotify optional).
- Full API suite green: 1015 pass.