### PR TITLE
[APP-103] Handle lifecycle push notifications in the app

### DIFF
--- a/app/components/notifications-bridge/.test.tsx
+++ b/app/components/notifications-bridge/.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 
 jest.mock('expo-notifications', () => ({
     getPermissionsAsync: jest.fn(),
@@ -200,5 +200,151 @@ describe('NotificationsBridge', () => {
         });
 
         expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    // --- Lifecycle pushes (APP-103): data.category, no alertId. ---
+
+    /**
+     * Renders the bridge and returns a function that fires a background-tap
+     * response with the given `data` payload through the captured handler.
+     */
+    async function captureResponseHandler(): Promise<(data: Record<string, unknown>) => void> {
+        getPermissionsAsync.mockResolvedValueOnce(buildPermission({ granted: true, status: 'granted' }));
+        getExpoPushTokenAsync.mockResolvedValueOnce({ data: 'ExponentPushToken[xyz]', type: 'expo' });
+        mockFetch.mockResolvedValue(jsonResponse({ status: 'registered' }));
+
+        let handler: ((event: unknown) => void) | undefined;
+        addNotificationResponseReceivedListener.mockImplementation((h: (event: unknown) => void) => {
+            handler = h;
+            return { remove: jest.fn() };
+        });
+
+        render(<NotificationsBridge />, { wrapper: buildApiWrapper().wrapper });
+        await waitFor(() => expect(handler).toBeDefined());
+
+        return (data: Record<string, unknown>) => {
+            act(() => {
+                handler?.({ notification: { request: { content: { data } } } });
+            });
+        };
+    }
+
+    it('shows an informational banner for a lifecycle push.', async () => {
+        getPermissionsAsync.mockResolvedValueOnce(buildPermission({ granted: true, status: 'granted' }));
+        getExpoPushTokenAsync.mockResolvedValueOnce({ data: 'ExponentPushToken[xyz]', type: 'expo' });
+        mockFetch.mockResolvedValue(jsonResponse({ status: 'registered' }));
+
+        let receivedHandler: ((event: unknown) => void) | undefined;
+        addNotificationReceivedListener.mockImplementation((handler: (event: unknown) => void) => {
+            receivedHandler = handler;
+            return { remove: jest.fn() };
+        });
+
+        render(<NotificationsBridge />, { wrapper: buildApiWrapper().wrapper });
+        await waitFor(() => expect(receivedHandler).toBeDefined());
+
+        act(() => {
+            receivedHandler?.({
+                request: {
+                    content: {
+                        title: 'Irrigation started',
+                        body: 'Schedule started for the night of 2026-06-09.',
+                        data: { category: 'scheduleStart' },
+                    },
+                },
+            });
+        });
+
+        expect(screen.getByText('Irrigation started')).toBeOnTheScreen();
+        expect(screen.getByText('Schedule started for the night of 2026-06-09.')).toBeOnTheScreen();
+    });
+
+    it('routes a scheduleStart background tap to Home.', async () => {
+        const fire = await captureResponseHandler();
+        fire({ category: 'scheduleStart' });
+        expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('routes a scheduleEnd background tap to Home.', async () => {
+        const fire = await captureResponseHandler();
+        fire({ category: 'scheduleEnd' });
+        expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('routes a wateringStart background tap with a zoneId to that zone.', async () => {
+        const fire = await captureResponseHandler();
+        fire({ category: 'wateringStart', zoneId: 'zone-009' });
+        expect(mockPush).toHaveBeenCalledWith('/zone/zone-009');
+    });
+
+    it('routes a wateringEnd background tap without a zoneId to the Activity feed.', async () => {
+        const fire = await captureResponseHandler();
+        fire({ category: 'wateringEnd' });
+        expect(mockPush).toHaveBeenCalledWith('/activity');
+    });
+
+    it('routes when a lifecycle foreground banner is tapped, then dismisses it.', async () => {
+        getPermissionsAsync.mockResolvedValueOnce(buildPermission({ granted: true, status: 'granted' }));
+        getExpoPushTokenAsync.mockResolvedValueOnce({ data: 'ExponentPushToken[xyz]', type: 'expo' });
+        mockFetch.mockResolvedValue(jsonResponse({ status: 'registered' }));
+
+        let receivedHandler: ((event: unknown) => void) | undefined;
+        addNotificationReceivedListener.mockImplementation((handler: (event: unknown) => void) => {
+            receivedHandler = handler;
+            return { remove: jest.fn() };
+        });
+
+        render(<NotificationsBridge />, { wrapper: buildApiWrapper().wrapper });
+        await waitFor(() => expect(receivedHandler).toBeDefined());
+
+        act(() => {
+            receivedHandler?.({
+                request: {
+                    content: {
+                        title: 'Watering started',
+                        body: 'Front Lawn watering started (manual fire).',
+                        data: { category: 'wateringStart', zoneId: 'zone-009' },
+                    },
+                },
+            });
+        });
+
+        fireEvent.press(screen.getByLabelText('Notification: Watering started'));
+
+        expect(mockPush).toHaveBeenCalledWith('/zone/zone-009');
+        expect(screen.queryByText('Watering started')).toBeNull();
+    });
+
+    it('dismisses without navigating when a banner with no route is tapped.', async () => {
+        getPermissionsAsync.mockResolvedValueOnce(buildPermission({ granted: true, status: 'granted' }));
+        getExpoPushTokenAsync.mockResolvedValueOnce({ data: 'ExponentPushToken[xyz]', type: 'expo' });
+        mockFetch.mockResolvedValue(jsonResponse({ status: 'registered' }));
+
+        let receivedHandler: ((event: unknown) => void) | undefined;
+        addNotificationReceivedListener.mockImplementation((handler: (event: unknown) => void) => {
+            receivedHandler = handler;
+            return { remove: jest.fn() };
+        });
+
+        render(<NotificationsBridge />, { wrapper: buildApiWrapper().wrapper });
+        await waitFor(() => expect(receivedHandler).toBeDefined());
+
+        // An alert push with no zoneId resolves to a null route.
+        act(() => {
+            receivedHandler?.({
+                request: {
+                    content: {
+                        title: 'Weather data stale',
+                        body: 'Planner is using fallback ET.',
+                        data: { alertId: 'alert-9', tone: 'warn' },
+                    },
+                },
+            });
+        });
+
+        fireEvent.press(screen.getByLabelText('Notification: Weather data stale'));
+
+        expect(mockPush).not.toHaveBeenCalled();
+        expect(screen.queryByText('Weather data stale')).toBeNull();
     });
 });

--- a/app/components/notifications-bridge/index.tsx
+++ b/app/components/notifications-bridge/index.tsx
@@ -28,11 +28,25 @@ Notifications.setNotificationHandler({
     }),
 });
 
+/**
+ * The four lifecycle push categories emitted by the daemon + manual controller
+ * (API-104). Lifecycle pushes carry `data.category` (and a `zoneId` for the
+ * watering pair) but no `alertId` — that's how they're told apart from alert
+ * pushes, which carry `alertId` + an optional `zoneId`.
+ */
+const LIFECYCLE_CATEGORIES = ['scheduleStart', 'scheduleEnd', 'wateringStart', 'wateringEnd'] as const;
+type LifecyclePushCategory = (typeof LIFECYCLE_CATEGORIES)[number];
+
+function isLifecycleCategory(value: unknown): value is LifecyclePushCategory {
+    return typeof value === 'string' && (LIFECYCLE_CATEGORIES as readonly string[]).includes(value);
+}
+
 type BannerState = {
     tone: AlertRowTone;
     title: string;
     sub?: string;
-    zoneId?: string;
+    /** Deep-link target when the banner is tapped, or null for no navigation. */
+    route: string | null;
 };
 
 /**
@@ -75,10 +89,10 @@ export function NotificationsBridge() {
             const content = notification.request.content;
             const data = content.data ?? {};
             setBanner({
-                tone: toneFromData(data),
+                tone: toneForPush(data),
                 title: content.title ?? 'Irrigo alert',
                 ...(content.body ? { sub: content.body } : {}),
-                ...(typeof data.zoneId === 'string' ? { zoneId: data.zoneId } : {}),
+                route: routeForPush(data),
             });
         });
         return () => {
@@ -86,12 +100,13 @@ export function NotificationsBridge() {
         };
     }, []);
 
-    // Background tap → deep-link to the zone if the push carried a zoneId.
+    // Background tap → deep-link per the push's category / zone.
     useEffect(() => {
         const subscription = Notifications.addNotificationResponseReceivedListener(response => {
             const data = response.notification.request.content.data ?? {};
-            if (typeof data.zoneId === 'string') {
-                router.push(`/zone/${data.zoneId}` as never);
+            const route = routeForPush(data);
+            if (route !== null) {
+                router.push(route as never);
             }
         });
         return () => {
@@ -100,8 +115,8 @@ export function NotificationsBridge() {
     }, [router]);
 
     const handleBannerPress = useCallback(() => {
-        if (banner?.zoneId !== undefined) {
-            router.push(`/zone/${banner.zoneId}` as never);
+        if (banner?.route != null) {
+            router.push(banner.route as never);
         }
         setBanner(null);
     }, [banner, router]);
@@ -120,6 +135,33 @@ export function NotificationsBridge() {
             onDismiss={handleBannerDismiss}
         />
     );
+}
+
+/**
+ * Banner tone for a push. Lifecycle pushes (schedule / watering) are purely
+ * informational, so they paint `info`; alert pushes fall back to the
+ * failure-oriented `toneFromData` (default `danger`).
+ */
+function toneForPush(data: Record<string, unknown>): AlertRowTone {
+    if (isLifecycleCategory(data.category)) return 'info';
+    return toneFromData(data);
+}
+
+/**
+ * Resolves the deep-link a push routes to when tapped (foreground banner or
+ * background response), or null for no navigation:
+ *
+ * - lifecycle `scheduleStart` / `scheduleEnd` → Home (schedule state lives there);
+ * - lifecycle `wateringStart` / `wateringEnd` → the zone if one is attached, else the Activity feed;
+ * - alert pushes → the zone when a `zoneId` is present, else no navigation (matching pre-lifecycle behaviour).
+ */
+function routeForPush(data: Record<string, unknown>): string | null {
+    const zoneId = typeof data.zoneId === 'string' ? data.zoneId : undefined;
+    if (isLifecycleCategory(data.category)) {
+        if (data.category === 'scheduleStart' || data.category === 'scheduleEnd') return '/';
+        return zoneId !== undefined ? `/zone/${zoneId}` : '/activity';
+    }
+    return zoneId !== undefined ? `/zone/${zoneId}` : null;
 }
 
 /**


### PR DESCRIPTION
## Ticket

[APP-103](http://192.168.2.100:7123/home/browse/APP-103/) — Handle lifecycle push notifications in the app. Final step of epic [API-102](http://192.168.2.100:7123/home/browse/API-102/) (HA→Expo); pairs with [API-104](http://192.168.2.100:7123/home/browse/API-104/).

## Summary

API-104 introduced four lifecycle Expo pushes (`scheduleStart`/`scheduleEnd`/`wateringStart`/`wateringEnd`) whose `data` carries a `category` (and `zoneId` for watering) but **no** `alertId`. `NotificationsBridge` previously treated every push as a zone-or-nothing alert; this teaches it to handle lifecycle pushes without changing the alert path.

- **Unified routing** via a pure `routeForPush(data)` used by both the foreground-banner tap and the background-response handler:
  - lifecycle `scheduleStart`/`scheduleEnd` → Home;
  - lifecycle `wateringStart`/`wateringEnd` → the zone (if `zoneId`) else the Activity feed;
  - alert pushes → the zone when `zoneId` is present, else no navigation — **identical to today's behaviour**.
- **`toneForPush`** paints lifecycle banners with the informational `info` tone (the non-alert variant); alert banners keep their `toneFromData` (default `danger`).
- `BannerState` now carries the resolved `route` so the foreground tap and background tap share one decision.

No settings UI change (the five toggles already exist, APP-86); `PushBanner`/`AlertRow` already support the `info` tone; routes (`/`, `/activity`, `/zone/[slug]`) already exist.

## Tests

- Existing alert tests retained (zone deep-link, no-zone no-route, foreground banner).
- Added: lifecycle foreground banner; background taps for schedule→Home, watering+zoneId→zone, watering-no-zoneId→Activity; foreground lifecycle tap routes + dismisses; null-route tap dismisses without navigating.
- Full app suite green: 709 pass.