### PR TITLE
[API-95] Centralize dayjs plugin extension into shared util

### DIFF
--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -1,11 +1,6 @@
 import type { DailyWeather, HourlyWeather, WeatherData } from "@/models";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import tzPlugin from "dayjs/plugin/timezone";
+import dayjs from '@/util/dayjs';
 import pRetry, { AbortError, type Options as PRetryOptions } from 'p-retry';
-
-dayjs.extend(utc);
-dayjs.extend(tzPlugin);
 
 type OpenMeteoResponse = {
     latitude: number;

--- a/api/schedules/dynamic/.test.ts
+++ b/api/schedules/dynamic/.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import dayjs from 'dayjs';
+import dayjs from '@/util/dayjs';
 import { createTestZone, GRASS_TYPES, SOIL_TYPES } from '@/mock/zone';
 import {
     createWeatherDays,

--- a/api/schedules/dynamic/multi-zone.test.ts
+++ b/api/schedules/dynamic/multi-zone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import dayjs, { type Dayjs } from 'dayjs';
+import dayjs, { type Dayjs } from '@/util/dayjs';
 
 import { createTestZone, GRASS_TYPES, SOIL_TYPES } from '@/mock/zone';
 import { createDryPeriod } from '@/mock/weather';

--- a/api/schedules/dynamic/restrictions.ts
+++ b/api/schedules/dynamic/restrictions.ts
@@ -1,7 +1,4 @@
-import dayjs from 'dayjs';
-import isoWeek from 'dayjs/plugin/isoWeek';
-
-dayjs.extend(isoWeek);
+import dayjs from '@/util/dayjs';
 
 /**
  * One allowed irrigation window within a day. `start` and `end` are

--- a/api/scripts/next-runs.ts
+++ b/api/scripts/next-runs.ts
@@ -1,12 +1,7 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import { and, eq, gte, isNull } from 'drizzle-orm';
 import { irrigationCycles, scheduleEntries, sites, zones } from '@/db/schema';
 import type { db as DbType } from '@/db';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 const ZONE_COL_WIDTH = 30;
 const TIME_COL_WIDTH = 26;

--- a/api/service/daemon/.test.ts
+++ b/api/service/daemon/.test.ts
@@ -1,13 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { AlertEvent, Alerter, AlertsDb } from '@/alerts';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import { grassTypes, irrigationCycles, scheduleEntries, schedules, sites, soilTypes, weatherState, zones } from '@/db/schema';
 import { __resetWeatherCacheForTests } from '@/data/weather';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 import type { DailyWeather, IrrigationScheduleEntry, Zone } from '@/models';
 import type { FutureCyclePair, PersistedCycle } from '@/models/cycle';
 import type { ScheduleEntriesRepository } from '@/repositories/schedule-entries';

--- a/api/service/daemon/index.ts
+++ b/api/service/daemon/index.ts
@@ -1,6 +1,4 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import { noopAlerter, type Alerter } from '@/alerts';
 import {
     closeZone as defaultCloseZone,
@@ -43,9 +41,6 @@ import {
     type DaemonServiceRepos,
     type SetDaemonReposInput,
 } from './state';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 /**
  * Default hour-of-day (site-local) for the daily re-plan. 20:00 is chosen

--- a/api/service/daemon/scheduling/.test.ts
+++ b/api/service/daemon/scheduling/.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import { computeNextMorningAt, computeNextRePlanAt, pickNextTick, pickUpcomingSunrise } from '.';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 describe('computeNextRePlanAt', () => {
     it('UTC: returns todays hour when the current time is before that hour', () => {

--- a/api/service/daemon/scheduling/index.ts
+++ b/api/service/daemon/scheduling/index.ts
@@ -1,9 +1,4 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import dayjs from '@/util/dayjs';
 
 /**
  * Distinguishes the daemon's two scheduled ticks. The morning tick

--- a/api/service/daemon/tick/.test.ts
+++ b/api/service/daemon/tick/.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import dayjs from 'dayjs';
+import dayjs from '@/util/dayjs';
 import type { AlertEvent, Alerter, AlertsDb } from '@/alerts';
 import type { ZoneActuationInterval } from '@/data/home-assistant';
 import { createTestZone } from '@/mock/zone';

--- a/api/service/push-tokens/lifecycle-messages.ts
+++ b/api/service/push-tokens/lifecycle-messages.ts
@@ -1,11 +1,6 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 
 import type { PushMessageContent } from '.';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 /**
  * Pure builders that turn a lifecycle event into the `title` / `body` / `data`

--- a/api/service/schedules-list/.test.ts
+++ b/api/service/schedules-list/.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import { irrigationCycles, scheduleEntries } from '@/db/schema';
 import type { NextRunJoinedRow, ScheduleEntriesRepository } from '@/repositories/schedule-entries';
 import type { Schedule, SchedulesRepository } from '@/repositories/schedules';
@@ -12,9 +10,6 @@ import {
     formatWhenLabel,
     listSchedules,
 } from '.';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 type EntryRow = typeof scheduleEntries.$inferSelect;
 type CycleRow = typeof irrigationCycles.$inferSelect;

--- a/api/service/schedules-list/index.ts
+++ b/api/service/schedules-list/index.ts
@@ -1,6 +1,4 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import type { Database } from '@/db';
 import type {
     ScheduleAllowedTimeWindow,
@@ -14,9 +12,6 @@ import {
 } from '@/repositories/schedule-entries';
 import { createSchedulesRepository, type Schedule, type SchedulesRepository } from '@/repositories/schedules';
 import { getSiteTimezone } from '@/service/sites';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 export type { ScheduleAllowedTimeWindow, ScheduleListItem, ScheduleNextRun } from '@/models/schedules-list';
 

--- a/api/service/tonight/.test.ts
+++ b/api/service/tonight/.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import { irrigationCycles, scheduleEntries, zones } from '@/db/schema';
 import type { Schedule, SchedulesRepository } from '@/repositories/schedules';
 import type { TonightJoinedRow, TonightRepository } from '@/repositories/tonight';
@@ -9,9 +7,6 @@ import { bootSchedulesService } from '@/service/schedules';
 import { bootSitesService } from '@/service/sites';
 import { bootSystemService } from '@/service/system';
 import { bootTonightService, getTonightSummary } from '.';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 type EntryRow = typeof scheduleEntries.$inferSelect;
 type CycleRow = typeof irrigationCycles.$inferSelect;

--- a/api/service/tonight/index.ts
+++ b/api/service/tonight/index.ts
@@ -1,6 +1,4 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '@/util/dayjs';
 import type { Database } from '@/db';
 import type { TonightCycle, TonightDto, TonightState, TonightZone } from '@/models/tonight';
 import {
@@ -11,9 +9,6 @@ import {
 import { loadActiveSchedulesBySite } from '@/service/schedules';
 import { getSiteTimezone } from '@/service/sites';
 import { getSystemState } from '@/service/system';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 /**
  * Input to `bootTonightService`. Production passes `{ db }`; tests pass

--- a/api/util/dayjs.test.ts
+++ b/api/util/dayjs.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'bun:test';
+import dayjs from '@/util/dayjs';
+
+describe('@/util/dayjs', () => {
+    it('has the utc plugin extended', () => {
+        const instant = dayjs.utc('2026-06-01T12:00:00Z');
+        expect(instant.isValid()).toBe(true);
+        expect(instant.toISOString()).toBe('2026-06-01T12:00:00.000Z');
+    });
+
+    it('has the timezone plugin extended', () => {
+        // 12:00 UTC is 06:00 in America/Edmonton (MDT, UTC-6) in June.
+        const local = dayjs.utc('2026-06-01T12:00:00Z').tz('America/Edmonton');
+        expect(local.hour()).toBe(6);
+        expect(local.format('YYYY-MM-DD')).toBe('2026-06-01');
+    });
+
+    it('has the isoWeek plugin extended', () => {
+        // 2026-06-01 is a Monday → isoWeekday 1.
+        const isoWeekday = dayjs('2026-06-01').isoWeekday();
+        expect(isoWeekday).toBe(1);
+    });
+});

--- a/api/util/dayjs.ts
+++ b/api/util/dayjs.ts
@@ -1,0 +1,16 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import isoWeek from 'dayjs/plugin/isoWeek';
+
+// Extend the timezone-aware plugins once, here, as a side effect of importing
+// this module. Every file that needs `.utc()`, `.tz()`, or iso-week helpers
+// should `import dayjs from '@/util/dayjs'` rather than re-running these extend
+// calls. The calls are idempotent and order-insensitive, so importing this
+// module from many places is safe.
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(isoWeek);
+
+export type { Dayjs } from 'dayjs';
+export default dayjs;


### PR DESCRIPTION
## Ticket

[API-95](http://192.168.2.100:7123/home/browse/API-95/) — Centralize dayjs plugin extension into a shared util (child of epic API-89).

## Summary

- Added `api/util/dayjs.ts`, which extends the `utc`, `timezone`, and `isoWeek` plugins once as a side effect and re-exports the `dayjs` singleton + `Dayjs` type.
- Replaced the duplicated `import dayjs from 'dayjs'` + `dayjs.extend(...)` incantation in 15 consumers with `import dayjs from '@/util/dayjs'`. Also migrated three naked-`'dayjs'` test imports that called `.tz()/.utc()` and were silently relying on transitive plugin extension.
- `dayjs.extend(...)` and `dayjs/plugin/*` imports now live **only** in `api/util/dayjs.ts` (verified via grep). Files using plain date math and the type-only `import type dayjs` sites were intentionally left untouched.
- Added `api/util/dayjs.test.ts` asserting all three plugins are active when imported from the util.
- Pure mechanical refactor: the extend calls are idempotent and order-insensitive, so behavior is unchanged.

## Verification

- `bun --cwd=./api run type-check` — clean.
- `bun --cwd=./api test` — 977 passed / 0 failed.