### PR TITLE
[API-97] Split weather/index.ts into fetch/parse/aggregate

### DIFF
--- a/api/data/weather/aggregate.ts
+++ b/api/data/weather/aggregate.ts
@@ -1,0 +1,31 @@
+import type { HourlyWeather } from '@/models';
+
+/**
+ * Pure helper. Returns the sum of `precipitationMm` and `evapotranspirationMm`
+ * across hourly observations whose `time` falls in the half-open window
+ * `[since, until)`. Open-Meteo emits one hourly row per hour-start, so each
+ * row contributes fully if its hour-start is inside the window; partial hours
+ * at the edges are *not* pro-rated (the reconciler's window boundaries are
+ * always at tick times, ~12 hours apart, so the per-hour rounding error is
+ * negligible compared to the 24+ rows summed).
+ *
+ * Used by the morning/evening reconcilers in api/service/daemon to compute
+ * the depletion delta over the gap since the last reconciliation.
+ */
+export function sumHourlyWeatherBetween(
+    hourly: ReadonlyArray<HourlyWeather>,
+    since: Date,
+    until: Date,
+): { rainMm: number; etMm: number } {
+    const sinceMs = since.getTime();
+    const untilMs = until.getTime();
+    let rainMm = 0;
+    let etMm = 0;
+    for (const row of hourly) {
+        const t = row.time.valueOf();
+        if (t < sinceMs || t >= untilMs) continue;
+        rainMm += row.precipitationMm;
+        etMm += row.evapotranspirationMm;
+    }
+    return { rainMm, etMm };
+}

--- a/api/data/weather/fetch.ts
+++ b/api/data/weather/fetch.ts
@@ -1,0 +1,154 @@
+import pRetry, { AbortError, type Options as PRetryOptions } from 'p-retry';
+
+export type OpenMeteoResponse = {
+    latitude: number;
+    longitude: number;
+    generationtime_ms: number;
+    utc_offset_seconds: number;
+    timezone: string;
+    timezone_abbreviation: string;
+    elevation: number;
+    daily_units: {
+        time: string;
+        sunrise: string;
+        sunset: string;
+        precipitation_sum: string;
+        et0_fao_evapotranspiration: string;
+    };
+    daily: {
+        time: string[];
+        sunrise: string[];
+        sunset: string[];
+        precipitation_sum: number[];
+        et0_fao_evapotranspiration: number[];
+    };
+    hourly: {
+        time: string[];
+        precipitation: number[];
+        et0_fao_evapotranspiration: number[];
+    };
+};
+
+export type WeatherDataParams = {
+    /** Required. Latitude coordinate. */
+    latitude: number;
+
+    /** Required. Longitude coordinate. */
+    longitude: number;
+
+    /** Optional. Number of days to forecast (default: 7). */
+    forecastDays?: number;
+
+    /**
+     * Optional. Number of days of past observations to include (default: 1).
+     * The morning/evening reconcilers need yesterday's hourly observations to
+     * sum ET and precipitation between the last reconciliation and now.
+     */
+    pastDays?: number;
+
+    /**
+     * Optional. IANA timezone string (e.g. `America/Edmonton`). When provided,
+     * Open-Meteo returns all daily times in that local timezone and the returned
+     * DailyWeather dayjs objects are anchored to it. This is required for
+     * `allowedTimeWindows` in schedule restrictions to align correctly with the
+     * site's local clock.
+     */
+    timezone?: string;
+};
+
+/**
+ * `p-retry` timing defaults tuned for Open-Meteo's free-tier reliability
+ * profile. 2 retries → 3 total attempts. `factor: 3` + `minTimeout: 500`
+ * produces the 500 ms → 1500 ms backoff. Tests override `minTimeout` /
+ * `maxTimeout` to skip the real waits.
+ */
+const RETRY_TIMING_DEFAULTS: PRetryOptions = {
+    retries: 2,
+    factor: 3,
+    minTimeout: 500,
+    maxTimeout: 1500,
+    randomize: false,
+};
+
+function logFailedAttempt({ error, attemptNumber, retriesLeft }: { error: Error; attemptNumber: number; retriesLeft: number }): void {
+    if (retriesLeft > 0) {
+        console.warn(`weather: attempt ${attemptNumber} failed (${error.message}); ${retriesLeft} retries left.`);
+    }
+}
+
+/**
+ * Internal helper. Fetches a URL via `p-retry`, retrying on 5xx responses
+ * and network-layer rejections. 4xx responses throw immediately via
+ * `AbortError` — those signal bad request / auth / rate-limit and won't
+ * improve with another attempt. On success, returns the 2xx `Response` for
+ * the caller to parse. Final failures log at `console.error` and rethrow
+ * with the same message shape the alerter expects.
+ *
+ * Exported for tests; production code reaches it through `getWeatherData`.
+ * Tests may pass `retryOptions` to override the timing defaults — the
+ * `onFailedAttempt` logger is always installed by this helper, since the
+ * daemon runs unattended and silent retries would defeat the point.
+ *
+ * @internal
+ */
+export async function fetchWithRetry(url: string, retryOptions: PRetryOptions = RETRY_TIMING_DEFAULTS): Promise<Response> {
+    try {
+        return await pRetry(async () => {
+            let response: Response;
+            try {
+                response = await fetch(url);
+            } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                throw new Error(`Open-Meteo network error: ${detail}`);
+            }
+
+            if (response.ok) return response;
+
+            const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
+            // 4xx → bad request / auth / rate-limit; abort the retry loop.
+            if (response.status >= 400 && response.status < 500) {
+                throw new AbortError(message);
+            }
+            // 5xx → let p-retry retry (or surface the final throw).
+            throw new Error(message);
+        }, { ...retryOptions, onFailedAttempt: logFailedAttempt });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`weather: ${message}`);
+        throw err instanceof Error ? err : new Error(message);
+    }
+}
+
+/**
+ * Builds the Open-Meteo forecast URL from the request params (selecting the
+ * customer vs free-tier host based on `OPEN_METEO_API_KEY`) and fetches it via
+ * `fetchWithRetry`. Returns the 2xx `Response` for the caller to parse.
+ *
+ * @param params - Weather data request parameters.
+ * @returns The successful Open-Meteo `Response`.
+ * @throws Error if the request fails after all retries.
+ */
+export async function fetchWeatherResponse(params: WeatherDataParams): Promise<Response> {
+    const { latitude, longitude, forecastDays = 7, pastDays = 1, timezone } = params;
+
+    const apiKey = process.env.OPEN_METEO_API_KEY || undefined;
+    const baseUrl = apiKey
+        ? 'https://customer-api.open-meteo.com/v1/forecast'
+        : 'https://api.open-meteo.com/v1/forecast';
+
+    const url = new URL(baseUrl);
+    url.searchParams.set('latitude', latitude.toString());
+    url.searchParams.set('longitude', longitude.toString());
+    url.searchParams.set('daily', 'sunrise,sunset,precipitation_sum,et0_fao_evapotranspiration');
+    url.searchParams.set('hourly', 'precipitation,et0_fao_evapotranspiration');
+    url.searchParams.set('forecast_days', forecastDays.toString());
+    url.searchParams.set('past_days', pastDays.toString());
+    if (timezone) {
+        url.searchParams.set('timezone', timezone);
+    }
+    if (apiKey) {
+        url.searchParams.set('apikey', apiKey);
+    }
+
+    return fetchWithRetry(url.toString());
+}

--- a/api/data/weather/index.ts
+++ b/api/data/weather/index.ts
@@ -1,62 +1,6 @@
-import type { DailyWeather, HourlyWeather, WeatherData } from "@/models";
-import dayjs from '@/util/dayjs';
-import pRetry, { AbortError, type Options as PRetryOptions } from 'p-retry';
-
-type OpenMeteoResponse = {
-    latitude: number;
-    longitude: number;
-    generationtime_ms: number;
-    utc_offset_seconds: number;
-    timezone: string;
-    timezone_abbreviation: string;
-    elevation: number;
-    daily_units: {
-        time: string;
-        sunrise: string;
-        sunset: string;
-        precipitation_sum: string;
-        et0_fao_evapotranspiration: string;
-    };
-    daily: {
-        time: string[];
-        sunrise: string[];
-        sunset: string[];
-        precipitation_sum: number[];
-        et0_fao_evapotranspiration: number[];
-    };
-    hourly: {
-        time: string[];
-        precipitation: number[];
-        et0_fao_evapotranspiration: number[];
-    };
-};
-
-export type WeatherDataParams = {
-    /** Required. Latitude coordinate. */
-    latitude: number;
-
-    /** Required. Longitude coordinate. */
-    longitude: number;
-
-    /** Optional. Number of days to forecast (default: 7). */
-    forecastDays?: number;
-
-    /**
-     * Optional. Number of days of past observations to include (default: 1).
-     * The morning/evening reconcilers need yesterday's hourly observations to
-     * sum ET and precipitation between the last reconciliation and now.
-     */
-    pastDays?: number;
-
-    /**
-     * Optional. IANA timezone string (e.g. `America/Edmonton`). When provided,
-     * Open-Meteo returns all daily times in that local timezone and the returned
-     * DailyWeather dayjs objects are anchored to it. This is required for
-     * `allowedTimeWindows` in schedule restrictions to align correctly with the
-     * site's local clock.
-     */
-    timezone?: string;
-};
+import type { WeatherData } from '@/models';
+import { fetchWeatherResponse, type WeatherDataParams } from './fetch';
+import { parseWeatherResponse } from './parse';
 
 /**
  * Optional second-arg knobs on `getWeatherData`. Tuned for test-injection of
@@ -98,69 +42,6 @@ export function __resetWeatherCacheForTests(): void {
 }
 
 /**
- * `p-retry` timing defaults tuned for Open-Meteo's free-tier reliability
- * profile. 2 retries → 3 total attempts. `factor: 3` + `minTimeout: 500`
- * produces the 500 ms → 1500 ms backoff. Tests override `minTimeout` /
- * `maxTimeout` to skip the real waits.
- */
-const RETRY_TIMING_DEFAULTS: PRetryOptions = {
-    retries: 2,
-    factor: 3,
-    minTimeout: 500,
-    maxTimeout: 1500,
-    randomize: false,
-};
-
-function logFailedAttempt({ error, attemptNumber, retriesLeft }: { error: Error; attemptNumber: number; retriesLeft: number }): void {
-    if (retriesLeft > 0) {
-        console.warn(`weather: attempt ${attemptNumber} failed (${error.message}); ${retriesLeft} retries left.`);
-    }
-}
-
-/**
- * Internal helper. Fetches a URL via `p-retry`, retrying on 5xx responses
- * and network-layer rejections. 4xx responses throw immediately via
- * `AbortError` — those signal bad request / auth / rate-limit and won't
- * improve with another attempt. On success, returns the 2xx `Response` for
- * the caller to parse. Final failures log at `console.error` and rethrow
- * with the same message shape the alerter expects.
- *
- * Exported for tests; production code reaches it through `getWeatherData`.
- * Tests may pass `retryOptions` to override the timing defaults — the
- * `onFailedAttempt` logger is always installed by this helper, since the
- * daemon runs unattended and silent retries would defeat the point.
- *
- * @internal
- */
-export async function fetchWithRetry(url: string, retryOptions: PRetryOptions = RETRY_TIMING_DEFAULTS): Promise<Response> {
-    try {
-        return await pRetry(async () => {
-            let response: Response;
-            try {
-                response = await fetch(url);
-            } catch (err) {
-                const detail = err instanceof Error ? err.message : String(err);
-                throw new Error(`Open-Meteo network error: ${detail}`);
-            }
-
-            if (response.ok) return response;
-
-            const message = `Open-Meteo API request failed: ${response.status} ${response.statusText}`;
-            // 4xx → bad request / auth / rate-limit; abort the retry loop.
-            if (response.status >= 400 && response.status < 500) {
-                throw new AbortError(message);
-            }
-            // 5xx → let p-retry retry (or surface the final throw).
-            throw new Error(message);
-        }, { ...retryOptions, onFailedAttempt: logFailedAttempt });
-    } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(`weather: ${message}`);
-        throw err instanceof Error ? err : new Error(message);
-    }
-}
-
-/**
  * Retrieves daily weather data from Open-Meteo API including sunrise times,
  * rainfall totals, and reference evapotranspiration (ET0). Transient 5xx
  * responses and network-layer errors are retried up to two times with
@@ -194,57 +75,8 @@ export async function getWeatherData(
         return cached.value;
     }
 
-    const apiKey = process.env.OPEN_METEO_API_KEY || undefined;
-    const baseUrl = apiKey
-        ? 'https://customer-api.open-meteo.com/v1/forecast'
-        : 'https://api.open-meteo.com/v1/forecast';
-
-    const url = new URL(baseUrl);
-    url.searchParams.set('latitude', latitude.toString());
-    url.searchParams.set('longitude', longitude.toString());
-    url.searchParams.set('daily', 'sunrise,sunset,precipitation_sum,et0_fao_evapotranspiration');
-    url.searchParams.set('hourly', 'precipitation,et0_fao_evapotranspiration');
-    url.searchParams.set('forecast_days', forecastDays.toString());
-    url.searchParams.set('past_days', pastDays.toString());
-    if (timezone) {
-        url.searchParams.set('timezone', timezone);
-    }
-    if (apiKey) {
-        url.searchParams.set('apikey', apiKey);
-    }
-
-    const response = await fetchWithRetry(url.toString());
-
-    // Parse a time string in the correct timezone so that downstream dayjs
-    // operations (startOf('day'), isoWeekday, hour comparisons) all use the
-    // site's local clock rather than the container's UTC clock.
-    const parseTime = (t: string): dayjs.Dayjs =>
-        timezone ? dayjs.tz(t, timezone) : dayjs(t);
-
-    let parsed: WeatherData;
-    try {
-        const data = await response.json() as OpenMeteoResponse;
-
-        const daily: DailyWeather[] = data.daily.time.map((time, index) => ({
-            date: parseTime(time),
-            sunrise: parseTime(data.daily.sunrise[index]!),
-            sunset: parseTime(data.daily.sunset[index]!),
-            rainfallMm: data.daily.precipitation_sum[index],
-            evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
-        }));
-
-        const hourly: HourlyWeather[] = data.hourly.time.map((time, index) => ({
-            time: parseTime(time),
-            precipitationMm: data.hourly.precipitation[index] ?? 0,
-            evapotranspirationMm: data.hourly.et0_fao_evapotranspiration[index] ?? 0,
-        }));
-
-        parsed = { daily, hourly };
-    } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        console.error(`weather: Open-Meteo response could not be parsed: ${detail}`);
-        throw new Error(`Open-Meteo response parse error: ${detail}`);
-    }
+    const response = await fetchWeatherResponse({ latitude, longitude, forecastDays, pastDays, timezone });
+    const parsed = await parseWeatherResponse(response, timezone);
 
     // Store only on successful parse — failed fetches and parse errors throw
     // above without polluting the cache.
@@ -252,32 +84,5 @@ export async function getWeatherData(
     return parsed;
 }
 
-/**
- * Pure helper. Returns the sum of `precipitationMm` and `evapotranspirationMm`
- * across hourly observations whose `time` falls in the half-open window
- * `[since, until)`. Open-Meteo emits one hourly row per hour-start, so each
- * row contributes fully if its hour-start is inside the window; partial hours
- * at the edges are *not* pro-rated (the reconciler's window boundaries are
- * always at tick times, ~12 hours apart, so the per-hour rounding error is
- * negligible compared to the 24+ rows summed).
- *
- * Used by the morning/evening reconcilers in api/service/daemon to compute
- * the depletion delta over the gap since the last reconciliation.
- */
-export function sumHourlyWeatherBetween(
-    hourly: ReadonlyArray<HourlyWeather>,
-    since: Date,
-    until: Date,
-): { rainMm: number; etMm: number } {
-    const sinceMs = since.getTime();
-    const untilMs = until.getTime();
-    let rainMm = 0;
-    let etMm = 0;
-    for (const row of hourly) {
-        const t = row.time.valueOf();
-        if (t < sinceMs || t >= untilMs) continue;
-        rainMm += row.precipitationMm;
-        etMm += row.evapotranspirationMm;
-    }
-    return { rainMm, etMm };
-}
+export { fetchWithRetry, type WeatherDataParams } from './fetch';
+export { sumHourlyWeatherBetween } from './aggregate';

--- a/api/data/weather/parse.ts
+++ b/api/data/weather/parse.ts
@@ -1,0 +1,48 @@
+import type { DailyWeather, HourlyWeather, WeatherData } from '@/models';
+import dayjs from '@/util/dayjs';
+import type { OpenMeteoResponse } from './fetch';
+
+/**
+ * Parses an Open-Meteo `Response` into the domain `WeatherData` model. Daily
+ * and hourly times are anchored to `timezone` when provided so downstream
+ * dayjs operations (`startOf('day')`, `isoWeekday`, hour comparisons) use the
+ * site's local clock rather than the container's UTC clock. JSON-body and
+ * normalization failures both surface as a single `Open-Meteo response parse
+ * error` so the caller can treat the response as unusable.
+ *
+ * @param response - The successful Open-Meteo `Response` from the fetch layer.
+ * @param timezone - Optional IANA timezone to anchor parsed times to.
+ * @returns The normalized `WeatherData`.
+ * @throws Error if the body can't be parsed or normalized.
+ */
+export async function parseWeatherResponse(response: Response, timezone?: string): Promise<WeatherData> {
+    // Parse a time string in the correct timezone so that downstream dayjs
+    // operations (startOf('day'), isoWeekday, hour comparisons) all use the
+    // site's local clock rather than the container's UTC clock.
+    const parseTime = (t: string): dayjs.Dayjs =>
+        timezone ? dayjs.tz(t, timezone) : dayjs(t);
+
+    try {
+        const data = await response.json() as OpenMeteoResponse;
+
+        const daily: DailyWeather[] = data.daily.time.map((time, index) => ({
+            date: parseTime(time),
+            sunrise: parseTime(data.daily.sunrise[index]!),
+            sunset: parseTime(data.daily.sunset[index]!),
+            rainfallMm: data.daily.precipitation_sum[index],
+            evapotranspirationMmPerDay: data.daily.et0_fao_evapotranspiration[index],
+        }));
+
+        const hourly: HourlyWeather[] = data.hourly.time.map((time, index) => ({
+            time: parseTime(time),
+            precipitationMm: data.hourly.precipitation[index] ?? 0,
+            evapotranspirationMm: data.hourly.et0_fao_evapotranspiration[index] ?? 0,
+        }));
+
+        return { daily, hourly };
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(`weather: Open-Meteo response could not be parsed: ${detail}`);
+        throw new Error(`Open-Meteo response parse error: ${detail}`);
+    }
+}


### PR DESCRIPTION
## Ticket

[API-97](http://192.168.2.100:7123/home/browse/API-97/) — Split api/data/weather/index.ts into fetch/parse/aggregate (child of epic API-89).

## Summary

- Split the 288-line `api/data/weather/index.ts` into three independent concerns:
  - `fetch.ts` — Open-Meteo HTTP layer: `OpenMeteoResponse` + `WeatherDataParams` types, `fetchWithRetry` (p-retry, 5xx-retry/4xx-abort), and `fetchWeatherResponse` (URL/apikey building → fetch).
  - `parse.ts` — `parseWeatherResponse(response, timezone)`: response → `WeatherData` with timezone-anchored dayjs; keeps the single try/catch so malformed bodies still surface the same parse-error message.
  - `aggregate.ts` — `sumHourlyWeatherBetween`.
- `index.ts` (now 88 lines) keeps the orchestration/cache layer (`getWeatherData`, the TTL cache, `__resetWeatherCacheForTests`, `WeatherDataOptions`) and re-exports `fetchWithRetry`, `WeatherDataParams`, `sumHourlyWeatherBetween` so callers and the test are unchanged.
- Pure mechanical move: no behavior change. The unchanged `data/weather/.test.ts` covers all sides through the barrel.

## Verification

- `bun --cwd=./api run type-check` — clean.
- `bun --cwd=./api test` — 977 passed / 0 failed.