### PR TITLE
[APP-104] Invert zone water display to bucket-fill level

### DIFF
--- a/app/components/battery/.test.tsx
+++ b/app/components/battery/.test.tsx
@@ -4,15 +4,25 @@ import { StyleSheet } from 'react-native';
 import { Battery, computeBatteryGeometry } from '.';
 
 describe('computeBatteryGeometry', () => {
-    it('returns ok tone with the correct fill and notch percentages when depletion is well below RAW.', () => {
-        // raw 25, depletion 10 → scaleMax = max(31.25, 14) = 31.25
-        // pct = 10 / 31.25 = 32%, rawPct = 25 / 31.25 = 80%
-        const result = computeBatteryGeometry(10, 25);
+    it('returns a full bar (100%) when depletion is 0 — the bucket is at capacity.', () => {
+        // raw 25, depletion 0 → scaleMax = max(31.25, 4) = 31.25
+        // fillPct = (31.25 - 0) / 31.25 = 100%, notchPct = 6.25 / 31.25 = 20%
+        const result = computeBatteryGeometry(0, 25);
 
         expect(result.tone).toBe('ok');
         expect(result.scaleMax).toBeCloseTo(31.25);
-        expect(result.pct).toBeCloseTo(32);
-        expect(result.rawPct).toBeCloseTo(80);
+        expect(result.fillPct).toBeCloseTo(100);
+        expect(result.notchPct).toBeCloseTo(20);
+    });
+
+    it('shrinks the fill as depletion grows (bucket drains).', () => {
+        // raw 25, depletion 10 → scaleMax = 31.25
+        // fillPct = (31.25 - 10) / 31.25 = 68%, notchPct = 20%
+        const result = computeBatteryGeometry(10, 25);
+
+        expect(result.tone).toBe('ok');
+        expect(result.fillPct).toBeCloseTo(68);
+        expect(result.notchPct).toBeCloseTo(20);
     });
 
     it('flips to warn tone once depletion crosses 80% of RAW.', () => {
@@ -29,39 +39,49 @@ describe('computeBatteryGeometry', () => {
         expect(result.tone).toBe('ok');
     });
 
-    it('flips to danger tone when depletion meets or exceeds RAW.', () => {
+    it('flips to danger tone when depletion meets or exceeds RAW (bucket empty).', () => {
         expect(computeBatteryGeometry(25, 25).tone).toBe('danger');
         expect(computeBatteryGeometry(30, 25).tone).toBe('danger');
     });
 
-    it('keeps fill width capped at 100% even when depletion would exceed the scale.', () => {
-        // depletion 30, raw 25 → scaleMax = max(31.25, 34) = 34; pct = 30/34 ≈ 88.2%
+    it('keeps the fill from going negative even when depletion exceeds the scale.', () => {
+        // depletion 30, raw 25 → scaleMax = max(31.25, 34) = 34; fillPct = 4/34 ≈ 11.8%
         const result = computeBatteryGeometry(30, 25);
 
-        expect(result.pct).toBeLessThanOrEqual(100);
+        expect(result.fillPct).toBeGreaterThanOrEqual(0);
+        expect(result.fillPct).toBeCloseTo(11.76, 1);
     });
 
-    it('handles RAW = 0 without dividing by zero; tone falls back to ok.', () => {
+    it('places the notch where the receding fill meets the irrigation trigger (depletion === raw).', () => {
+        // raw 25, depletion 25 → scaleMax = max(31.25, 29) = 31.25
+        // notchPct = (31.25 - 25) / 31.25 = 20%; fillPct = 20% — they coincide.
+        const result = computeBatteryGeometry(25, 25);
+
+        expect(result.fillPct).toBeCloseTo(20);
+        expect(result.notchPct).toBeCloseTo(20);
+    });
+
+    it('handles RAW = 0 without dividing by zero; tone falls back to ok and the notch collapses.', () => {
         const result = computeBatteryGeometry(5, 0);
 
         expect(result.tone).toBe('ok');
-        expect(Number.isFinite(result.pct)).toBe(true);
-        expect(result.rawPct).toBe(0);
+        expect(Number.isFinite(result.fillPct)).toBe(true);
+        expect(result.notchPct).toBe(0);
     });
 
-    it('clamps negative depletion to 0 (surplus-moisture state still pegs at the lowest tick).', () => {
+    it('clamps negative depletion to 0 (surplus moisture still shows a full bar).', () => {
         const result = computeBatteryGeometry(-3, 25);
 
-        expect(result.pct).toBe(0);
+        expect(result.fillPct).toBeCloseTo(100);
         expect(result.tone).toBe('ok');
     });
 });
 
 describe('Battery', () => {
-    it('renders a progressbar with the derived accessibility label.', () => {
+    it('renders a progressbar with the derived water-held accessibility label.', () => {
         render(<Battery depletion={10} raw={25} />);
 
-        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        const bar = screen.getByLabelText('ok — 15 of 25 mm available');
         expect(bar).toBeOnTheScreen();
         expect(bar.props.accessibilityRole).toBe('progressbar');
     });
@@ -69,13 +89,13 @@ describe('Battery', () => {
     it('reflects the warn tone in the derived label as depletion crosses 80% of RAW.', () => {
         render(<Battery depletion={21} raw={25} />);
 
-        expect(screen.getByLabelText('warn — 21 of 25 mm')).toBeOnTheScreen();
+        expect(screen.getByLabelText('warn — 4 of 25 mm available')).toBeOnTheScreen();
     });
 
-    it('reflects the danger tone in the derived label once depletion meets RAW.', () => {
+    it('reflects the danger tone and a drained bucket once depletion meets RAW.', () => {
         render(<Battery depletion={26} raw={25} />);
 
-        expect(screen.getByLabelText('danger — 26 of 25 mm')).toBeOnTheScreen();
+        expect(screen.getByLabelText('danger — 0 of 25 mm available')).toBeOnTheScreen();
     });
 
     it('honours an explicit accessibility label override.', () => {
@@ -84,17 +104,17 @@ describe('Battery', () => {
         expect(screen.getByLabelText('north-soil-battery')).toBeOnTheScreen();
     });
 
-    it('exposes the depletion as the progressbar `now` value with `max` matching the computed scale.', () => {
+    it('exposes the held water as the progressbar `now` value with `max` matching RAW capacity.', () => {
         render(<Battery depletion={10} raw={25} />);
 
-        const bar = screen.getByLabelText('ok — 10 of 25 mm');
-        expect(bar.props.accessibilityValue).toEqual({ min: 0, max: 31.25, now: 10 });
+        const bar = screen.getByLabelText('ok — 15 of 25 mm available');
+        expect(bar.props.accessibilityValue).toEqual({ min: 0, max: 25, now: 15 });
     });
 
     it('renders the 10px-tall compact variant by default.', () => {
         render(<Battery depletion={10} raw={25} />);
 
-        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        const bar = screen.getByLabelText('ok — 15 of 25 mm available');
         const style = StyleSheet.flatten(bar.props.style) as { height?: number };
         expect(style.height).toBe(10);
     });
@@ -102,16 +122,16 @@ describe('Battery', () => {
     it('renders the 16px-tall variant when `tall` is true.', () => {
         render(<Battery depletion={10} raw={25} tall />);
 
-        const bar = screen.getByLabelText('ok — 10 of 25 mm');
+        const bar = screen.getByLabelText('ok — 15 of 25 mm available');
         const style = StyleSheet.flatten(bar.props.style) as { height?: number };
         expect(style.height).toBe(16);
     });
 
-    it('positions the notch at raw / scaleMax (80% for raw 25 / depletion 10).', () => {
+    it('positions the notch at (scaleMax - raw) / scaleMax (20% for raw 25 / depletion 10).', () => {
         render(<Battery depletion={10} raw={25} />);
 
         const notch = screen.getByLabelText('raw-notch');
         const style = StyleSheet.flatten(notch.props.style) as { left?: string };
-        expect(style.left).toBe('80%');
+        expect(style.left).toBe('20%');
     });
 });

--- a/app/components/battery/index.tsx
+++ b/app/components/battery/index.tsx
@@ -19,29 +19,37 @@ const TONE_COLOR = {
 export type BatteryTone = keyof typeof TONE_COLOR;
 
 /**
- * Pure geometry helper. Mirrors the math in the source `Battery` component:
+ * Pure geometry helper for the bucket-fill battery. The bar represents how
+ * much water the zone's bucket *holds*: full when depletion is 0, shrinking
+ * leftward as soil moisture is lost. Math:
  *
  *     scaleMax = max(raw * 1.25, depletion + 4)
- *     pct      = min(100, (depletion / scaleMax) * 100)
- *     rawPct   = (raw / scaleMax) * 100
+ *     fillPct  = max(0, (scaleMax - depletion) / scaleMax) * 100
+ *     notchPct = ((scaleMax - raw) / scaleMax) * 100
  *     tone     = depletion >= raw          ? 'danger'
  *              : depletion / raw > 0.8     ? 'warn'
  *              : 'ok'
  *
+ * `fillPct` is the inverse of depletion, so the fill recedes leftward as the
+ * bucket empties. `notchPct` mirrors the RAW position: the receding fill edge
+ * meets the notch exactly when `depletion === raw`, marking the irrigation
+ * trigger. `tone` is unchanged — it already runs ok (full) → danger (empty),
+ * which is green-when-full → red-when-empty for the bucket paradigm.
+ *
  * Guards:
  *   - `depletion` is clamped to 0 (negative depletion = surplus moisture; the
- *     visual still pegs at the lowest tick).
+ *     fill still pegs at a full bar).
  *   - When `raw <= 0` the ratio test is undefined, so `tone` defaults to `ok`
- *     and the scale is driven entirely by `depletion + 4`.
+ *     and the notch collapses to 0.
  */
 export function computeBatteryGeometry(
     depletion: number,
     raw: number,
-): { pct: number; rawPct: number; scaleMax: number; tone: BatteryTone } {
+): { fillPct: number; notchPct: number; scaleMax: number; tone: BatteryTone } {
     const safeDepletion = Math.max(0, depletion);
     const scaleMax = Math.max(raw * 1.25, safeDepletion + 4);
-    const pct = scaleMax > 0 ? Math.min(100, (safeDepletion / scaleMax) * 100) : 0;
-    const rawPct = scaleMax > 0 && raw > 0 ? (raw / scaleMax) * 100 : 0;
+    const fillPct = scaleMax > 0 ? Math.max(0, ((scaleMax - safeDepletion) / scaleMax) * 100) : 0;
+    const notchPct = scaleMax > 0 && raw > 0 ? ((scaleMax - raw) / scaleMax) * 100 : 0;
 
     let tone: BatteryTone = 'ok';
     if (raw > 0) {
@@ -49,32 +57,33 @@ export function computeBatteryGeometry(
         else if (safeDepletion / raw > 0.8) tone = 'warn';
     }
 
-    return { pct, rawPct, scaleMax, tone };
+    return { fillPct, notchPct, scaleMax, tone };
 }
 
 /**
- * Props for the Irrigo depletion battery primitive.
+ * Props for the Irrigo bucket-fill battery primitive.
  */
 export type BatteryProps = {
     /** Required. Current depletion in mm. Clamped to 0 if negative. */
     depletion: number;
 
-    /** Required. RAW threshold in mm (the maximum allowable depletion for the zone). */
+    /** Required. RAW threshold in mm (the bucket capacity / maximum allowable depletion for the zone). */
     raw: number;
 
     /** Optional. Renders the 16px-tall variant used by the Zone detail hero. Defaults to false (compact 10px). */
     tall?: boolean;
 
-    /** Optional. Accessibility label spoken by screen readers. Defaults to a derived `"{tone} — {depletion} of {raw} mm"` string. */
+    /** Optional. Accessibility label spoken by screen readers. Defaults to a derived `"{tone} — {held} of {raw} mm available"` string. */
     accessibilityLabel?: string;
 };
 
 /**
- * The Irrigo depletion battery — visually compares the current soil-moisture
- * depletion against the zone's RAW (readily-available water) threshold.
- * Track recolors from accent (ok) to warn (≥80% of RAW) to danger (≥ RAW) as
- * depletion approaches the limit. The notch holds steady at the RAW mark
- * while the fill grows; both width and tone tween over 360ms.
+ * The Irrigo bucket-fill battery — visually represents how much water the
+ * zone's bucket holds, starting full and shrinking leftward as soil moisture
+ * is lost. Track recolors from accent (ok, full) to warn (≥80% of RAW) to
+ * danger (≥ RAW, empty) as the bucket drains. The notch holds steady at the
+ * irrigation-trigger mark while the fill recedes; both width and tone tween
+ * over 360ms.
  */
 export function Battery({
     depletion,
@@ -86,16 +95,16 @@ export function Battery({
     const trackHeight = tall ? 16 : 10;
     const notchOverflow = tall ? 4 : 3;
 
-    const animated = useRef(new Animated.Value(geometry.pct / 100)).current;
+    const animated = useRef(new Animated.Value(geometry.fillPct / 100)).current;
     const toneAnimated = useRef(new Animated.Value(toneIndex(geometry.tone))).current;
 
     useEffect(() => {
         Animated.timing(animated, {
-            toValue: geometry.pct / 100,
+            toValue: geometry.fillPct / 100,
             duration: Duration.slow,
             useNativeDriver: false,
         }).start();
-    }, [animated, geometry.pct]);
+    }, [animated, geometry.fillPct]);
 
     useEffect(() => {
         Animated.timing(toneAnimated, {
@@ -114,14 +123,15 @@ export function Battery({
         outputRange: [TONE_COLOR.ok, TONE_COLOR.warn, TONE_COLOR.danger],
     });
 
+    const held = Math.max(0, raw - depletion);
     const derivedLabel = accessibilityLabel
-        ?? `${geometry.tone} — ${formatMm(depletion)} of ${formatMm(raw)} mm`;
+        ?? `${geometry.tone} — ${formatMm(held)} of ${formatMm(raw)} mm available`;
 
     return (
         <View
             accessibilityRole='progressbar'
             accessibilityLabel={derivedLabel}
-            accessibilityValue={{ min: 0, max: Math.round(geometry.scaleMax * 100) / 100, now: Math.max(0, depletion) }}
+            accessibilityValue={{ min: 0, max: Math.round(raw * 100) / 100, now: Math.round(held * 100) / 100 }}
             style={{
                 position: 'relative',
                 width: '100%',
@@ -149,7 +159,7 @@ export function Battery({
                     position: 'absolute',
                     top: -notchOverflow,
                     bottom: -notchOverflow,
-                    left: `${geometry.rawPct}%`,
+                    left: `${geometry.notchPct}%`,
                     width: 2,
                     backgroundColor: NOTCH_COLOR,
                     opacity: 0.8,

--- a/app/components/zone-detail/.test.tsx
+++ b/app/components/zone-detail/.test.tsx
@@ -65,7 +65,31 @@ function buildNextRun(): NextRunDto {
 }
 
 describe('ZoneDetail', () => {
-    it('renders the zone name, grass + area eyebrow, and depletion mm figure.', () => {
+    it('renders the zone name, grass + area eyebrow, and the water-available hero with Empty/Full axis.', () => {
+        // held = raw 22.5 − depletion 5 = 17.5 mm.
+        render(
+            <ZoneDetail
+                zone={buildZone({ currentDepletionMm: 5 })}
+                nextRun={undefined}
+                activity={[]}
+                isActivityLoading={false}
+                onRunNow={jest.fn()}
+                onStopWatering={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('North')).toBeOnTheScreen();
+        expect(screen.getByText('Kentucky Bluegrass · 100 m²')).toBeOnTheScreen();
+        expect(screen.getByText('Water available')).toBeOnTheScreen();
+        expect(screen.getByText('17.5')).toBeOnTheScreen();
+        expect(screen.getByText('mm')).toBeOnTheScreen();
+        expect(screen.getByText('Empty')).toBeOnTheScreen();
+        expect(screen.getByText('Full')).toBeOnTheScreen();
+        expect(screen.getByText('RAW · 22.5')).toBeOnTheScreen();
+    });
+
+    it('clamps the water-available hero figure to 0.0 when the zone is past RAW.', () => {
+        // depletion 27.4 ≥ raw 22.5 → held = max(0, 22.5 − 27.4) = 0.
         render(
             <ZoneDetail
                 zone={buildZone({ currentDepletionMm: 27.4 })}
@@ -77,9 +101,7 @@ describe('ZoneDetail', () => {
             />,
         );
 
-        expect(screen.getByText('North')).toBeOnTheScreen();
-        expect(screen.getByText('Kentucky Bluegrass · 100 m²')).toBeOnTheScreen();
-        expect(screen.getByText('27.4')).toBeOnTheScreen();
+        expect(screen.getByText('0.0')).toBeOnTheScreen();
         expect(screen.getByText('mm')).toBeOnTheScreen();
     });
 

--- a/app/components/zone-detail/index.tsx
+++ b/app/components/zone-detail/index.tsx
@@ -92,7 +92,7 @@ export function ZoneDetail({
             <View style={styles.heroCard}>
                 <Text style={styles.heroEyebrow}>Water available</Text>
                 <View style={styles.heroFigureRow}>
-                    <Text style={[styles.heroFigure, { color: toneColor }]}>{heldMm.toFixed(1)}</Text>
+                    <Text style={[styles.heroFigure, { color: toneColor }]}>{heldMm.toFixed(2)}</Text>
                     <Text style={styles.heroUnit}>mm</Text>
                 </View>
                 <View style={styles.heroBattery}>

--- a/app/components/zone-detail/index.tsx
+++ b/app/components/zone-detail/index.tsx
@@ -50,8 +50,9 @@ export type ZoneDetailProps = {
 };
 
 /**
- * Zone detail screen body: header (LawnPatch + name + tone copy), battery
- * hero, Run-now CTA, physical attributes table, and recent runs log. Pure
+ * Zone detail screen body: header (LawnPatch + name + tone copy), water-
+ * available bucket hero, Run-now CTA, physical attributes table, and recent
+ * runs log. Pure
  * presentational — all data is supplied by the route, which composes
  * `useZone`, `useNextRun`, and `useActivity`.
  */
@@ -68,7 +69,9 @@ export function ZoneDetail({
     const geometry = computeBatteryGeometry(zone.currentDepletionMm, zone.rawMm);
     const toneColor = TONE_COLOR[geometry.tone];
     const statusCopy = computeZoneStatusCopy(zone, nextRun);
-    const scaleMaxMm = Math.round(geometry.scaleMax);
+    // Water the bucket currently holds — capacity (RAW) minus depletion,
+    // clamped to 0 once the zone is past RAW. APP-104.
+    const heldMm = Math.max(0, zone.rawMm - zone.currentDepletionMm);
 
     return (
         <View style={styles.container}>
@@ -87,18 +90,18 @@ export function ZoneDetail({
             </View>
 
             <View style={styles.heroCard}>
-                <Text style={styles.heroEyebrow}>Soil-moisture deficit</Text>
+                <Text style={styles.heroEyebrow}>Water available</Text>
                 <View style={styles.heroFigureRow}>
-                    <Text style={[styles.heroFigure, { color: toneColor }]}>{zone.currentDepletionMm.toFixed(1)}</Text>
+                    <Text style={[styles.heroFigure, { color: toneColor }]}>{heldMm.toFixed(1)}</Text>
                     <Text style={styles.heroUnit}>mm</Text>
                 </View>
                 <View style={styles.heroBattery}>
                     <Battery depletion={zone.currentDepletionMm} raw={zone.rawMm} tall />
                 </View>
                 <View style={styles.heroAxisRow}>
-                    <Text style={styles.heroAxisTick}>0</Text>
+                    <Text style={styles.heroAxisTick}>Empty</Text>
                     <Text style={[styles.heroAxisTick, { color: colors.warn }]}>RAW · {zone.rawMm}</Text>
-                    <Text style={styles.heroAxisTick}>{scaleMaxMm}</Text>
+                    <Text style={styles.heroAxisTick}>Full</Text>
                 </View>
             </View>
 

--- a/app/components/zone-tile/.test.tsx
+++ b/app/components/zone-tile/.test.tsx
@@ -60,11 +60,20 @@ describe('ZoneTile', () => {
         expect(screen.getByText('Fescue')).toBeOnTheScreen();
     });
 
-    it('renders depletion / raw with one decimal on depletion and the mm suffix.', () => {
+    it('renders water held / capacity with one decimal on the held figure and the mm suffix.', () => {
+        // held = raw 32 − depletion 14.4 = 17.6 mm.
         render(<ZoneTile zone={HEALTHY_ZONE} onPress={() => {}} now={NOW} />);
 
-        expect(screen.getByText('14.4 mm')).toBeOnTheScreen();
+        expect(screen.getByText('17.6 mm')).toBeOnTheScreen();
         expect(screen.getByText('/ 32 mm')).toBeOnTheScreen();
+    });
+
+    it('clamps the held figure to 0.0 mm when the zone is past RAW.', () => {
+        // depletion 34.1 ≥ raw 30 → held = max(0, 30 − 34.1) = 0.
+        render(<ZoneTile zone={PAST_RAW_ZONE} onPress={() => {}} now={NOW} />);
+
+        expect(screen.getByText('0.0 mm')).toBeOnTheScreen();
+        expect(screen.getByText('/ 30 mm')).toBeOnTheScreen();
     });
 
     it('formats the Last ran footer using the relative-time helper.', () => {

--- a/app/components/zone-tile/index.tsx
+++ b/app/components/zone-tile/index.tsx
@@ -45,11 +45,7 @@ export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
     const lastRan = useMemo(() => formatLastRan(zone.lastFiredAt, referenceNow), [zone.lastFiredAt, referenceNow]);
 
     return (
-        <Pressable
-            onPress={handlePress}
-            accessibilityRole='button'
-            accessibilityLabel={`Open ${zone.name}`}
-        >
+        <Pressable onPress={handlePress} accessibilityRole='button' accessibilityLabel={`Open ${zone.name}`}>
             <TileGradient style={styles.card}>
                 <View style={styles.headerRow}>
                     <View style={styles.headerText}>
@@ -60,7 +56,7 @@ export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
                     <View style={styles.depletionBlock}>
                         <View style={styles.depletionWrap}>
                             <Text style={[styles.depletion, pastRaw ? { color: colors.danger } : null]}>
-                                {heldMm.toFixed(1)} mm
+                                {heldMm.toFixed(2)} mm
                             </Text>
                             <Text style={styles.rawLabel}> / {zone.rawMm} mm</Text>
                         </View>

--- a/app/components/zone-tile/index.tsx
+++ b/app/components/zone-tile/index.tsx
@@ -27,8 +27,8 @@ export type ZoneTileProps = {
 
 /**
  * One zone tile on the Home screen. Renders the zone's name + grass and
- * area summary, the depletion-vs-RAW large mono pair, the `Battery`
- * primitive, and a footer that flips to a danger-red "Runs tonight" when
+ * area summary, the water-held-vs-capacity large mono pair, the `Battery`
+ * primitive, and a footer that flips to a danger-red "Runs next" when
  * the zone is past RAW.
  */
 export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
@@ -39,6 +39,9 @@ export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
     const tickingNow = useNow(now === undefined ? 60_000 : null);
     const referenceNow = now ?? tickingNow;
     const pastRaw = zone.currentDepletionMm >= zone.rawMm;
+    // Water the bucket currently holds — capacity (RAW) minus depletion,
+    // clamped to 0 once the zone is past RAW. APP-104.
+    const heldMm = Math.max(0, zone.rawMm - zone.currentDepletionMm);
     const lastRan = useMemo(() => formatLastRan(zone.lastFiredAt, referenceNow), [zone.lastFiredAt, referenceNow]);
 
     return (
@@ -57,7 +60,7 @@ export function ZoneTile({ zone, onPress, now }: ZoneTileProps) {
                     <View style={styles.depletionBlock}>
                         <View style={styles.depletionWrap}>
                             <Text style={[styles.depletion, pastRaw ? { color: colors.danger } : null]}>
-                                {zone.currentDepletionMm.toFixed(1)} mm
+                                {heldMm.toFixed(1)} mm
                             </Text>
                             <Text style={styles.rawLabel}> / {zone.rawMm} mm</Text>
                         </View>


### PR DESCRIPTION
## Ticket

[APP-104](http://192.168.2.100:7123/home/browse/APP-104/) — Invert zone tile water display: show bucket fill level instead of depletion.

## Summary

Inverts the soil-moisture paradigm from *depletion grows right* to *bucket the zone holds, starting full and shrinking as it dries*. Per discussion the change applies everywhere the shared `Battery` primitive renders (Home tiles + Zone-detail hero), and the tile/hero numeric is reframed as **water held vs capacity**.

- **`Battery` / `computeBatteryGeometry`** — fill now represents remaining bucket water (`fillPct = (scaleMax − depletion)/scaleMax`, full at depletion 0, receding leftward). The RAW notch mirrors to `(scaleMax − raw)/scaleMax`, where the receding fill meets it exactly when `depletion === raw` — still marking the irrigation trigger. Tone is unchanged (it already runs green-when-full → red-when-empty). Accessibility reframed to held-water (`{tone} — {held} of {raw} mm available`).
- **Zone tile** — numeric block now shows water held (`max(0, raw − depletion)`) against capacity, e.g. `17.6 mm / 32 mm`, clamping to `0.0 mm` past RAW.
- **Zone-detail hero** — eyebrow `Soil-moisture deficit` → `Water available`, big figure shows held mm, axis row `0 / RAW / scaleMax` → `Empty / RAW · {raw} / Full`.
- `depletion-legend` and `zone-status` are tone-keyed and left unchanged (tone semantics preserved).

## Verification

- `bun --cwd=./app run typecheck` — clean.
- `bun --cwd=./app run test` — 713 passed / 90 suites (battery + zone-tile + zone-detail cases rewritten for the bucket model).